### PR TITLE
feat(ZIConnection): Add `daq.setVector(...)` wrapper set_vector

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ zhinst
 numpy
 attrs
 pytest
+pytest-mock
 hypothesis

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -27,13 +27,15 @@ class Device:
     interface = "usb"
     device_type = DeviceTypes.HDAWG
 
+
 class DiscoveryMock:
     def find(self, serial):
         return serial.upper()
-    
+
     def get(self, serial):
-        assert(serial == serial.upper())
-        return { "deviceid": serial }
+        assert serial == serial.upper()
+        return {"deviceid": serial}
+
 
 def test_init_zi_connection():
     c = ZIConnection(Details())
@@ -52,6 +54,8 @@ def test_check_connection():
         c.get_sample("tests/test")
     with pytest.raises(ToolkitConnectionError):
         c.set("tests/test", 1)
+    with pytest.raises(ToolkitConnectionError):
+        c.set_vector("tests/test", [0])
     with pytest.raises(ToolkitConnectionError):
         c.connect()
 
@@ -77,6 +81,7 @@ def test_device_connection_connect():
         c.set("tests/test", 1)
     with pytest.raises(ToolkitConnectionError):
         c.get_nodetree("*")
+
 
 def test_device_normalized_serial():
     c = DeviceConnection(Device(), DiscoveryMock())

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,13 +1,18 @@
 import pytest
-from hypothesis import given, assume, strategies as st
-from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
-import numpy as np
+import zhinst.ziPython as zi
+
 
 from .context import (
     ZIConnection,
     DeviceConnection,
     ToolkitConnectionError,
     DeviceTypes,
+)
+
+from zhinst.toolkit.control.connection import (
+    AWGModuleConnection,
+    DAQModuleConnection,
+    SweeperModuleConnection,
 )
 
 
@@ -60,10 +65,191 @@ def test_check_connection():
         c.connect()
 
 
+def test_ZIConnection_daq_api(mocker):
+    daq_mock = mocker.Mock(spec=zi.ziDAQServer)
+    mocker.patch("zhinst.ziPython.ziDAQServer", return_value=daq_mock)
+    c = ZIConnection(Details())
+    c.connect()
+
+    c.set("tests/test", [0])
+    daq_mock.set.assert_called_with("tests/test", [0])
+
+    c.get("tests/test", [0])
+    daq_mock.get.assert_called_with("tests/test", [0])
+
+    c.list_nodes("tests/test", [0])
+    daq_mock.listNodesJSON.assert_called_with("tests/test", [0])
+
+    c.get_sample("tests/test", [0])
+    daq_mock.getSample.assert_called_with("tests/test", [0])
+
+    c.set_vector("tests/test", [0])
+    daq_mock.setVector.assert_called_with("tests/test", [0])
+
+
+def test_ZIConnection_properties(mocker):
+    daq_mock = mocker.Mock(spec=zi.ziDAQServer)
+    mocker.patch("zhinst.ziPython.ziDAQServer", return_value=daq_mock)
+    c = ZIConnection(Details())
+    c.connect()
+
+    assert type(c.awg_module) == AWGModuleConnection
+    assert type(c.daq_module) == DAQModuleConnection
+    assert type(c.sweeper_module) == SweeperModuleConnection
+
+
+def test_AWGModuleConnection(mocker):
+    awg_module_mock = mocker.Mock()
+    attrs = {"awgModule.return_value": awg_module_mock}
+    daq_mock = mocker.Mock(spec=zi.ziDAQServer, **attrs)
+
+    awg_module = AWGModuleConnection(daq_mock)
+
+    awg_module.set("tests/test", [0])
+    awg_module_mock.set.assert_called_with("tests/test", [0])
+
+    awg_module.get("tests/test", [0])
+    awg_module_mock.get.assert_called_with("tests/test", [0], flat=True)
+
+    awg_module.get_int("tests/test", [0])
+    awg_module_mock.getInt.assert_called_with("tests/test", [0])
+
+    awg_module.get_double("tests/test", [0])
+    awg_module_mock.getDouble.assert_called_with("tests/test", [0])
+
+    awg_module.get_string("tests/test", [0])
+    awg_module_mock.getString.assert_called_with("tests/test", [0])
+
+
+@pytest.mark.parametrize("with_device", [True, False])
+def test_DAQModuleConnection(mocker, with_device: bool):
+    daq_module_mock = mocker.Mock()
+    attrs = {"dataAcquisitionModule.return_value": daq_module_mock}
+    daq_mock = mocker.Mock(spec=zi.ziDAQServer, **attrs)
+    device = mocker.Mock() if with_device is True else None
+
+    daq_module = DAQModuleConnection(daq_mock)
+
+    daq_module.execute(device)
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.execute.assert_called()
+    daq_module_mock.reset_mock()
+
+    daq_module.finish(device)
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.finish.assert_called()
+    daq_module_mock.reset_mock()
+
+    daq_module.finished(device)
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.finished.assert_called()
+    daq_module_mock.reset_mock()
+
+    daq_module.progress(device)
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.progress.assert_called()
+    daq_module_mock.reset_mock()
+
+    daq_module.trigger(device)
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.trigger.assert_called()
+    daq_module_mock.reset_mock()
+
+    daq_module.read(device, foo=True)
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.read.assert_called_with(foo=True)
+    daq_module_mock.reset_mock()
+
+    daq_module.subscribe(True, device=device)
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.subscribe.assert_called_with(True)
+    daq_module_mock.reset_mock()
+
+    daq_module.unsubscribe(True, device=device)
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.unsubscribe.assert_called_with(True)
+    daq_module_mock.reset_mock()
+
+    daq_module.save(True, device=device)
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.save.assert_called_with(True)
+    daq_module_mock.reset_mock()
+
+    daq_module.clear(device=device)
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.clear.assert_called()
+    daq_module_mock.reset_mock()
+
+    daq_module.set(True, device=device)
+    if with_device:
+        assert daq_module_mock.set.call_count == 2
+        daq_module.update_device(None)
+    else:
+        daq_module_mock.set.assert_called_with(True)
+
+    daq_module_mock.reset_mock()
+
+    daq_module.get(True, device=device)
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.get.assert_called_with(True, flat=True)
+    daq_module_mock.reset_mock()
+
+    daq_module.get_int(True, device=device)
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.getInt.assert_called_with(True)
+    daq_module_mock.reset_mock()
+
+    daq_module.get_double(True, device=device)
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.getDouble.assert_called_with(True)
+    daq_module_mock.reset_mock()
+
+    daq_module.get_string(True, device=device)
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.getString.assert_called_with(True)
+    daq_module_mock.reset_mock()
+
+    daq_module_mock.listNodesJSON.return_value = '{"foo": true}'
+    daq_module.get_nodetree("tests/test", device=device, **{"foo": True})
+    if with_device:
+        daq_module_mock.set.assert_called_with("/device", device)
+        daq_module.update_device(None)
+    daq_module_mock.listNodesJSON.assert_called_with("tests/test", foo=True)
+    daq_module_mock.reset_mock()
+
+
 def test_init_device_connection():
     dev = Device()
     c = DeviceConnection(dev, DiscoveryMock())
-    assert c._connection == None
+    assert c._connection is None
     assert c._device == dev
 
 

--- a/zhinst/toolkit/control/connection.py
+++ b/zhinst/toolkit/control/connection.py
@@ -8,7 +8,6 @@ from typing import List, Union
 import json
 import zhinst.ziPython as zi
 from zhinst.toolkit.interface import DeviceTypes
-import zhinst.ziPython as zi
 
 
 class ToolkitConnectionError(Exception):
@@ -42,7 +41,7 @@ class ZIConnection:
 
     def __init__(self, connection_details):
         self._connection_details = connection_details
-        self._daq: "zi.ziDAQServer" = None
+        self._daq: zi.ziDAQServer = None
         self._awg = None
 
     def connect(self):

--- a/zhinst/toolkit/control/connection.py
+++ b/zhinst/toolkit/control/connection.py
@@ -2,11 +2,14 @@
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.
+from __future__ import annotations
+from typing import List, Union
 
 import json
 import zhinst.ziPython as zi
 from zhinst.toolkit.interface import DeviceTypes
 import zhinst.ziPython as zi
+
 
 class ToolkitConnectionError(Exception):
     """Exception specific to the zhinst.toolkit ZIConnection class."""
@@ -14,186 +17,13 @@ class ToolkitConnectionError(Exception):
     pass
 
 
-class ZIConnection:
-    """Connection to a Zurich Instruments data server object. 
-    
-    Wraps around the basic functionality of connecting to the dataserver, 
-    connecting a device to the server, and setting and getting node values. It 
-    also holds an awg module object that implements the `daq.awgModule` module 
-    as well as DAQ module and Sweeper Module connections.
-    
-    Arguments:
-        connection_details: Part of the instrument config.
-    
-    Attributes:
-        connection_details (ZIAPI)
-        daq (zi.ziDAQServer): data server object from zhinst.ziPython
-    
-    Properties:
-        established (bool): A flag showing if a connection has been established.
-        awg_module (AWGModuleConnection)
-        daq_module (DAQModuleConnection)
-        sweeper_module (SweeperModuleConnection)
-
-    """
-
-    def __init__(self, connection_details):
-        self._connection_details = connection_details
-        self._daq = None
-        self._awg = None
-
-    def connect(self):
-        """Established a connection to the data server. 
-        
-        Uses the connection details (host, port, api level) specified in the 
-        'connection_details' to open a `zi.ziDAQServer` data server object that
-        is used for all communication to the data server.
-
-        Raises:
-            ToolkitConnectionError: if connection to the Data Server could not 
-                be established
-
-        """
-        try:
-            self._daq = zi.ziDAQServer(
-                self._connection_details.host,
-                self._connection_details.port,
-                self._connection_details.api,
-            )
-        except RuntimeError:
-            raise ToolkitConnectionError(
-                f"No connection could be established with the connection details:"
-                f"{self._connection_details}"
-            )
-        if self._daq is not None:
-            print(
-                f"Successfully connected to data server at "
-                f"{self._connection_details.host}:"
-                f"{self._connection_details.port} "
-                f"api version: {self._connection_details.api}"
-            )
-            self._awg_module = AWGModuleConnection(self._daq)
-            self._daq_module = DAQModuleConnection(self._daq)
-            self._sweeper_module = SweeperModuleConnection(self._daq)
-        else:
-            raise ToolkitConnectionError(
-                f"No connection could be established with the connection details:"
-                f"{self._connection_details}"
-            )
-
-    @property
-    def established(self):
-        return self._daq is not None
-
-    def connect_device(self, serial=None, interface=None):
-        """Connects a device to the data server. 
-
-        Arguments:
-            serial (str): the serial number of the device, e.g. 'dev8030'
-            interface (str): the type of interface, must be either '1gbe' or 
-                'usb'
-
-        Raises:
-            ToolkitConnectionError if the could not be established. 
-
-        """        
-        if self._daq is None:
-            raise ToolkitConnectionError("No existing connection to data server")
-        if any(k is None for k in [serial, interface]):
-            raise ToolkitConnectionError(
-                "To connect a Zurich Instruments' device, youd need a serial and an interface [1gbe or usb]"
-            )
-        self._daq.connectDevice(serial, interface)
-        print(
-            f"Successfully connected to device {serial.upper()} on interface {interface.upper()}"
-        )
-        self._awg_module.update(device=serial, index=0)
-
-    def set(self, *args):
-        """Wrapper around the `zi.ziDAQServer.set()` method of the API.
-        
-        Passes all arguments to the undelying method.
-        
-        Raises:
-            ToolkitConnectionError: is the connection is not yet established
-        
-        Returns:
-            the value returned from `daq.set(...)`
-        
-        """
-        if not self.established:
-            raise ToolkitConnectionError("The connection is not yet established.")
-        return self._daq.set(*args)
-
-    def get(self, *args, **kwargs):
-        """Wrapper around the `zi.ziDAQServer.get(...)` method of the API.
-        
-        Passes all arguments and keyword arguments to the underlying method.
-        
-        Raises:
-            ToolkitConnectionError: is the connection is not yet established
-        
-        Returns:
-            the value returned from `daq.get(...)`
-        
-        """
-        if not self.established:
-            raise ToolkitConnectionError("The connection is not yet established.")
-        return self._daq.get(*args, **kwargs)
-
-    def get_sample(self, *args, **kwargs):
-        """Wrapper around the `daq.getSample(...)` method of the API. 
-        
-        Passes all arguments and keyword arguments to the underlying method. 
-        Used only for certain streaming nodes on the UHFLI or MFLI devices.
-
-        Raises:
-            ToolkitConnectionError: is the connection is not yet established
-        
-        Returns:
-            the value returned from `daq.getSample(...)`
-        
-        """
-        if not self.established:
-            raise ToolkitConnectionError("The connection is not yet established.")
-        return self._daq.getSample(*args, **kwargs)
-
-    def list_nodes(self, *args, **kwargs):
-        """Wrapper around the `daq.listNodesJSON(...)` method of the API. 
-        
-        Passes all arguments and keyword arguemnts to the undelying method.
-
-        Raises:
-            ToolkitConnectionError: is the connection is not yet established
-        
-        Returns:
-            the value returned from `daq.listNodesJSON(...)`
-        
-        """
-        if not self.established:
-            raise ToolkitConnectionError("The connection is not yet established.")
-        return self._daq.listNodesJSON(*args, **kwargs)
-
-    @property
-    def awg_module(self):
-        return self._awg_module
-
-    @property
-    def daq_module(self):
-        return self._daq_module
-
-    @property
-    def sweeper_module(self):
-        return self._sweeper_module
-
-
 class AWGModuleConnection:
     """Connection to an AWG Module.
 
-    Implements an awg module as `daq.awgModule(...)` of the API with 
-    get and set methods of the module. Allows to address different awgs on 
-    different devices with the same awg module using the `update(...)` method. 
-    Also wraps around all other methods from the API. 
+    Implements an awg module as `daq.awgModule(...)` of the API with
+    get and set methods of the module. Allows to address different awgs on
+    different devices with the same awg module using the `update(...)` method.
+    Also wraps around all other methods from the API.
 
     Arguments:
         daq (zi.ziDAQServer)
@@ -259,8 +89,8 @@ class AWGModuleConnection:
 class DAQModuleConnection:
     """Connection to a DAQ Module.
 
-    Implements a daq module as `daq.DataAcquisitionModule(...)` of the API with 
-    get and set methods of the module. Also wraps around all other methods from 
+    Implements a daq module as `daq.DataAcquisitionModule(...)` of the API with
+    get and set methods of the module. Also wraps around all other methods from
     the API.
 
     Arguments:
@@ -368,9 +198,9 @@ class DAQModuleConnection:
 
 class SweeperModuleConnection(DAQModuleConnection):
     """Connection to a Sweeper Module.
-    
+
     Inherits from `DAQModuleConnection` but uses the `daq.seep()` module instead.
-    
+
     """
 
     def __init__(self, daq):
@@ -379,24 +209,24 @@ class SweeperModuleConnection(DAQModuleConnection):
 
 
 class DeviceConnection(object):
-    """Implements a connection to the data server for a single device. 
-    
-    Wraps around the data server connection (ZIConnection) for a single device 
-    with a specified serial number and type. This class allows it to call 
-    get(...) and set(...) for any node in the nodetree without having to specify 
-    the device address. In contrast to zhinst.ziPython the get(...) method 
+    """Implements a connection to the data server for a single device.
+
+    Wraps around the data server connection (ZIConnection) for a single device
+    with a specified serial number and type. This class allows it to call
+    get(...) and set(...) for any node in the nodetree without having to specify
+    the device address. In contrast to zhinst.ziPython the get(...) method
     returns only the value of the node as a scalar or numpy array.
-    
+
     Arguments:
-        device (BaseInstrument): Associated device that the device connection 
+        device (BaseInstrument): Associated device that the device connection
             is used for.
         discovery: an instance of ziDiscovery
 
     Attributes:
-        connection (ZIConnection): Data server connection (common for more 
+        connection (ZIConnection): Data server connection (common for more
             than one instrument).
         device (BaseInstrument): Associated instrument that is addressed.
-    
+
     """
 
     def __init__(self, device, discovery):
@@ -407,9 +237,9 @@ class DeviceConnection(object):
 
     def setup(self, connection: ZIConnection = None):
         """Establishes the connection to the data server.
-        
+
         Keyword Arguments:
-            connection (ZIConnection): An existing connection can be passed as 
+            connection (ZIConnection): An existing connection can be passed as
                 an argument. (default: None)
 
         """
@@ -420,14 +250,16 @@ class DeviceConnection(object):
             self._connection = connection
         if not self._connection.established:
             self._connection.connect()
-    
+
     def _normalize_serial(self, serial):
-        try:            
+        try:
             device_props = self.discovery.get(self.discovery.find(serial))
             discovered_serial = device_props["deviceid"]
             return discovered_serial.lower()
         except RuntimeError:
-            raise ToolkitConnectionError(f"Failed to discover a device with serial {serial}")
+            raise ToolkitConnectionError(
+                f"Failed to discover a device with serial {serial}"
+            )
 
     def connect_device(self):
         """Connects the device to the data server."""
@@ -436,16 +268,17 @@ class DeviceConnection(object):
             self.normalized_serial = self._normalize_serial(self._device.serial)
         else:
             self.normalized_serial = self._device.serial
-            
+
         self._connection.connect_device(
-            serial=self.normalized_serial, interface=self._device.interface,
+            serial=self.normalized_serial,
+            interface=self._device.interface,
         )
 
     def set(self, *args):
-        """Sets the value of the node for the connected device. 
-        
-        Parses the input arguments to either set a single node/value pair or a 
-        list of node/value tuples. Eventually wraps around the daq.set(...) of 
+        """Sets the value of the node for the connected device.
+
+        Parses the input arguments to either set a single node/value pair or a
+        list of node/value tuples. Eventually wraps around the daq.set(...) of
         the API.
 
         Raises:
@@ -465,17 +298,17 @@ class DeviceConnection(object):
         return self._connection.set(settings)
 
     def get(self, command, valueonly=True):
-        """Gets the value of the node for the connected device. 
-        
-        Parses the returned dictionary from the data server to output only the 
+        """Gets the value of the node for the connected device.
+
+        Parses the returned dictionary from the data server to output only the
         actual value in a nice format. Wraps around the daq.get(...) of the API.
 
         Arguments:
             command (str): node string of the value to get
-            
+
         Keyword Arguments:
-            valueonly (bool): a flag specifying if the entire dict should be 
-                returned as from the API or only the actual value 
+            valueonly (bool): a flag specifying if the entire dict should be
+                returned as from the API or only the actual value
                 (default: True)
 
         Raises:
@@ -515,13 +348,13 @@ class DeviceConnection(object):
             raise ToolkitConnectionError("No device connected!")
 
     def get_nodetree(self, prefix: str, **kwargs):
-        """Gets the entire nodetree of the connected device. 
-        
+        """Gets the entire nodetree of the connected device.
+
         Wraps around the `daq.listNodesJSON(...)` method in zhinst.ziPython.
 
         Arguments:
-            prefix (str): a partial node string that is passed to 
-                'listNodesJSON(...)' to specify which part of the nodetree 
+            prefix (str): a partial node string that is passed to
+                'listNodesJSON(...)' to specify which part of the nodetree
                 to return
 
         Returns:
@@ -532,18 +365,18 @@ class DeviceConnection(object):
 
     def _get_value_from_dict(self, data):
         """Retrieves the parameter value from the returned dict of the API.
-        
-        Parses the dict returned from the Python API into a nicer format. 
-        Removes the device serial from the node string to be used as a key in 
-        the returned dict. The corresponding value is the returned value from 
+
+        Parses the dict returned from the Python API into a nicer format.
+        Removes the device serial from the node string to be used as a key in
+        the returned dict. The corresponding value is the returned value from
         the Python API, can be a scalar or vector.
-        
+
         Arguments:
             data (dict): A dictionary as returned from the Python API.
-        
+
         Raises:
             ToolkitConnectionError: if no data is returned from the API
-        
+
         Returns:
             A dictionary with node/value as key and value.
 
@@ -565,13 +398,13 @@ class DeviceConnection(object):
 
     def _get_value_from_streamingnode(self, data):
         """Gets the (complex) data only for specific demod sample nodes.
-        
+
         Arguments:
             data (dict): A dictionary as returned from the Python API.
-        
+
         Raises:
             ToolkitConnectionError: if no data is returned from the API
-        
+
         Returns:
             The complex demod sample value.
 
@@ -586,18 +419,18 @@ class DeviceConnection(object):
 
     def _commands_to_node(self, settings):
         """Converts a list of command strings to a list of node paths.
-        
-        Parses a list of command and value pairs into a a list of node value 
-        pairs that can be passed to 'ziDAQServer.set(...)'. E.g. adds the 
+
+        Parses a list of command and value pairs into a a list of node value
+        pairs that can be passed to 'ziDAQServer.set(...)'. E.g. adds the
         device serial in front of every command.
-        
+
         Arguments:
             settings (list): list of command/value pairs
-        
+
         Raises:
-            ToolkitConnectionError: if the command/value pairs are not 
+            ToolkitConnectionError: if the command/value pairs are not
                 specified as pairs/tuples
-        
+
         Returns:
             The parsed list.
 
@@ -617,17 +450,17 @@ class DeviceConnection(object):
     def _command_to_node(self, command):
         """Converts a command string to a node path.
 
-        Parses a single command into a node string that can be passed 
-        to `ziDAQServer.set(...)`. Checks if the command starts with a '/' and 
-        adds the right device serial if the command 
+        Parses a single command into a node string that can be passed
+        to `ziDAQServer.set(...)`. Checks if the command starts with a '/' and
+        adds the right device serial if the command
         does not start with '/zi/'.
-        
+
         Arguments:
             command (str): command to be parsed
-        
+
         Returns:
             The parsed command.
-            
+
         """
         command = command.lower()
         if command[0] != "/":
@@ -636,3 +469,197 @@ class DeviceConnection(object):
             if self.normalized_serial not in command:
                 command = f"/{self.normalized_serial}" + command
         return command
+
+
+class ZIConnection:
+    """Connection to a Zurich Instruments data server object.
+
+    Wraps around the basic functionality of connecting to the dataserver,
+    connecting a device to the server, and setting and getting node values. It
+    also holds an awg module object that implements the `daq.awgModule` module
+    as well as DAQ module and Sweeper Module connections.
+
+    Arguments:
+        connection_details: Part of the instrument config.
+
+    Attributes:
+        connection_details (ZIAPI)
+        daq (zi.ziDAQServer): data server object from zhinst.ziPython
+
+    Properties:
+        established (bool): A flag showing if a connection has been established.
+        awg_module (AWGModuleConnection)
+        daq_module (DAQModuleConnection)
+        sweeper_module (SweeperModuleConnection)
+
+    """
+
+    def __init__(self, connection_details):
+        self._connection_details = connection_details
+        self._daq: "zi.ziDAQServer" = None
+        self._awg = None
+
+    def connect(self):
+        """Established a connection to the data server.
+
+        Uses the connection details (host, port, api level) specified in the
+        'connection_details' to open a `zi.ziDAQServer` data server object that
+        is used for all communication to the data server.
+
+        Raises:
+            ToolkitConnectionError: if connection to the Data Server could not
+                be established
+
+        """
+        try:
+            self._daq = zi.ziDAQServer(
+                self._connection_details.host,
+                self._connection_details.port,
+                self._connection_details.api,
+            )
+        except RuntimeError:
+            raise ToolkitConnectionError(
+                f"No connection could be established with the connection details:"
+                f"{self._connection_details}"
+            )
+        if self._daq is not None:
+            print(
+                f"Successfully connected to data server at "
+                f"{self._connection_details.host}:"
+                f"{self._connection_details.port} "
+                f"api version: {self._connection_details.api}"
+            )
+            self._awg_module = AWGModuleConnection(self._daq)
+            self._daq_module = DAQModuleConnection(self._daq)
+            self._sweeper_module = SweeperModuleConnection(self._daq)
+        else:
+            raise ToolkitConnectionError(
+                f"No connection could be established with the connection details:"
+                f"{self._connection_details}"
+            )
+
+    @property
+    def established(self):
+        return self._daq is not None
+
+    def connect_device(self, serial=None, interface=None):
+        """Connects a device to the data server.
+
+        Arguments:
+            serial (str): the serial number of the device, e.g. 'dev8030'
+            interface (str): the type of interface, must be either '1gbe' or
+                'usb'
+
+        Raises:
+            ToolkitConnectionError if the could not be established.
+
+        """
+        if self._daq is None:
+            raise ToolkitConnectionError("No existing connection to data server")
+        if any(k is None for k in [serial, interface]):
+            raise ToolkitConnectionError(
+                "To connect a Zurich Instruments' device, youd need a serial and an interface [1gbe or usb]"
+            )
+        self._daq.connectDevice(serial, interface)
+        print(
+            f"Successfully connected to device {serial.upper()} on interface {interface.upper()}"
+        )
+        self._awg_module.update(device=serial, index=0)
+
+    def set(self, *args):
+        """Wrapper around the `zi.ziDAQServer.set()` method of the API.
+
+        Passes all arguments to the undelying method.
+
+        Raises:
+            ToolkitConnectionError: is the connection is not yet established
+
+        Returns:
+            the value returned from `daq.set(...)`
+
+        """
+        if not self.established:
+            raise ToolkitConnectionError("The connection is not yet established.")
+        return self._daq.set(*args)
+
+    def get(self, *args, **kwargs):
+        """Wrapper around the `zi.ziDAQServer.get(...)` method of the API.
+
+        Passes all arguments and keyword arguments to the underlying method.
+
+        Raises:
+            ToolkitConnectionError: is the connection is not yet established
+
+        Returns:
+            the value returned from `daq.get(...)`
+
+        """
+        if not self.established:
+            raise ToolkitConnectionError("The connection is not yet established.")
+        return self._daq.get(*args, **kwargs)
+
+    def get_sample(self, *args, **kwargs):
+        """Wrapper around the `daq.getSample(...)` method of the API.
+
+        Passes all arguments and keyword arguments to the underlying method.
+        Used only for certain streaming nodes on the UHFLI or MFLI devices.
+
+        Raises:
+            ToolkitConnectionError: is the connection is not yet established
+
+        Returns:
+            the value returned from `daq.getSample(...)`
+
+        """
+        if not self.established:
+            raise ToolkitConnectionError("The connection is not yet established.")
+        return self._daq.getSample(*args, **kwargs)
+
+    def list_nodes(self, *args, **kwargs):
+        """Wrapper around the `daq.listNodesJSON(...)` method of the API.
+
+        Passes all arguments and keyword arguemnts to the undelying method.
+
+        Raises:
+            ToolkitConnectionError: is the connection is not yet established
+
+        Returns:
+            the value returned from `daq.listNodesJSON(...)`
+
+        """
+        if not self.established:
+            raise ToolkitConnectionError("The connection is not yet established.")
+        return self._daq.listNodesJSON(*args, **kwargs)
+
+    def set_vector(self, path: str, vector: Union[List, str]):
+        """Wrapper around the `daq.setVector(...)` method of the API.
+
+        Sets the Command Table vector to the specified node path.
+
+        Raises:
+            ToolkitConnectionError: is the connection is not yet established
+
+        Args:
+            path (str): The node path.
+            vector (Union[List, str]): The Vector ((u)int8, (u)int16, (u)int32,
+                (u)int64, float, double) or string to write.
+
+        Raises:
+            ToolkitConnectionError: [description]
+        """
+        if not self.established:
+            raise ToolkitConnectionError("The connection is not yet established.")
+
+        self._daq.setVector(path, vector)
+
+    @property
+    def awg_module(self) -> AWGModuleConnection:
+        return self._awg_module
+
+    @property
+    def daq_module(self) -> DAQModuleConnection:
+        return self._daq_module
+
+    @property
+    def sweeper_module(self) -> SweeperModuleConnection:
+        return self._sweeper_module


### PR DESCRIPTION
* Added missing wrapper function `setVector` on DAQ interface.
* Moved `ZIConnection` to the bottom of the `connection.py` because it references AWGModuleConnection, DAQModuleConnection and SweeperModuleConnection. Switching order makes it able to let the IDE find the reference (F12)
* Added return type to `ZIConnection` attributes
* Formatted touched files.