### PR TITLE
Implement basic improvements

### DIFF
--- a/zhinst/toolkit/control/drivers/base/base.py
+++ b/zhinst/toolkit/control/drivers/base/base.py
@@ -121,6 +121,13 @@ class BaseInstrument:
             self._nodetree = NodeTree(self)
         self._options = self._get("/features/options").split("\n")
         self._init_settings()
+        
+    def factory_reset(self) -> None:
+        """Loads the factory default settings."""
+        self._set(f"/system/preset/load", 1)
+        print(
+        f"Factory preset is loaded to device {self.serial.upper()}."
+        )
 
     def _init_settings(self):
         """Initial device settings. 

--- a/zhinst/toolkit/control/drivers/hdawg.py
+++ b/zhinst/toolkit/control/drivers/hdawg.py
@@ -72,6 +72,10 @@ class HDAWG(BaseInstrument):
         super().connect_device(nodetree=nodetree)
         [awg._setup() for awg in self.awgs]
 
+    def factory_reset(self) -> None:
+        """Loads the factory default settings."""
+        super().factory_reset()
+        
     def _init_settings(self):
         """Sets initial device settings on startup."""
         settings = [

--- a/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/zhinst/toolkit/control/drivers/uhfqa.py
@@ -160,6 +160,10 @@ class UHFQA(BaseInstrument):
         """
         super().connect_device(nodetree=nodetree)
         self.awg._setup()
+        
+    def factory_reset(self) -> None:
+        """Loads the factory default settings."""
+        super().factory_reset()
 
     def crosstalk_matrix(self, matrix=None):
         """Sets or gets the crosstalk matrix of the UHFQA as a 2D array.

--- a/zhinst/toolkit/helpers/sequence_commands.py
+++ b/zhinst/toolkit/helpers/sequence_commands.py
@@ -6,6 +6,7 @@
 from datetime import datetime
 import numpy as np
 
+from zhinst.toolkit.interface import DeviceTypes
 
 class SequenceCommand(object):
     """A collection of sequence commands used for an AWG program."""
@@ -44,6 +45,30 @@ class SequenceCommand(object):
             return ""
         else:
             return f"wait({int(i)});\n"
+        
+    @staticmethod
+    def play_zero(i, target=DeviceTypes.HDAWG):
+        """Inserts playZero(...) command to the sequencer.
+
+        The granularity of the device will be automatically matched.
+
+        Arguments:
+            i (int): length in number of samples to play zero.
+            target (str): type of the target device which
+                determines the granularity to be matched.
+                (default: DeviceTypes.HDAWG)
+
+        """
+        if i < 0:
+            raise ValueError("Number of samples cannot be negative!")
+        elif target in [DeviceTypes.HDAWG]:
+            if i < 32:
+                raise ValueError("Number of samples cannot be lower than 32 samples!")
+            return f"playZero({int(round(i / 16) * 16)});\n"
+        elif target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI]:
+            if i < 16:
+                raise ValueError("Number of samples cannot be lower than 16 samples!")
+            return f"playZero({int(round(i / 8) * 8)});\n"
 
     @staticmethod
     def wait_wave():
@@ -86,14 +111,34 @@ class SequenceCommand(object):
         return f"playWave({amp1}*w{i+1}_1, {amp2}*w{i+2}_2);\n"
 
     @staticmethod
-    def init_buffer_indexed(length, i):
-        if length < 16 or i < 0:
+    def init_buffer_indexed(length, i, target=DeviceTypes.HDAWG):
+        """Initialize placeholders (`placeholder(...)`) of specified length.
+
+        The granularity of the device should be matched.
+
+        Arguments:
+            length (int): length of the placeholders in number of samples.
+            i (int): index for the waveform label.
+            target (str): type of the target device which
+                determines the granularity to be matched.
+                (default: DeviceTypes.HDAWG)
+
+        """
+        if i < 0:
             raise ValueError("Invalid Values for waveform buffer!")
-        if length % 16:
-            raise ValueError("Buffer Length has to be multiple of 16!")
+        elif target in [DeviceTypes.HDAWG]:
+            if length < 32:
+                raise ValueError("Buffer Length cannot be lower than 32 samples!")
+            elif length % 16:
+                raise ValueError("Buffer Length has to be multiple of 16!")
+        elif target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI]:
+            if length < 16:
+                raise ValueError("Buffer Length cannot be lower than 16 samples!")
+            elif length % 8:
+                raise ValueError("Buffer Length has to be multiple of 8!")
         return (
-            f"wave w{i + 1}_1 = randomUniform({length});\n"
-            f"wave w{i + 1}_2 = randomUniform({length});\n"
+            f"wave w{i + 1}_1 = placeholder({length});\n"
+            f"wave w{i + 1}_2 = placeholder({length});\n"
         )
 
     @staticmethod

--- a/zhinst/toolkit/helpers/sequences.py
+++ b/zhinst/toolkit/helpers/sequences.py
@@ -106,6 +106,12 @@ class Sequence(object):
 
     def update_params(self):
         """Update interrelated parameters."""
+        # Set the correct clock rate depending on the device type
+        if self.target in [DeviceTypes.HDAWG]:
+            self.clock_rate = 2.4e9
+        elif self.target in [DeviceTypes.UHFLI, DeviceTypes.UHFQA]:
+            self.clock_rate = 1.8e9
+        # Set the trigger commands depending on the trigger mode
         if self.trigger_mode == TriggerMode.NONE:
             self.trigger_cmd_1 = SequenceCommand.comment_line()
             self.trigger_cmd_2 = SequenceCommand.comment_line()
@@ -170,7 +176,7 @@ class Sequence(object):
 class SimpleSequence(Sequence):
     """Sequence for *simple* playback of waveform arrays.
 
-    Initializes placeholders (`randomUniform(...)`) of the correct length for 
+    Initializes placeholders (`placeholder(...)`) of the correct length for 
     the waveforms in the queue of the AWG Core. The data of the waveform 
     placeholders is then replaced in memory when uploading the waveform using 
     `upload_waveforms()`. The waveforms are played sequentially within the main 
@@ -197,8 +203,9 @@ class SimpleSequence(Sequence):
     def write_sequence(self):
         self.sequence = SequenceCommand.header_comment(sequence_type="Simple")
         for i in range(self.n_HW_loop):
+            # Loop over the waveforms and initialize placeholders
             self.sequence += SequenceCommand.init_buffer_indexed(
-                self.buffer_lengths[i], i
+                self.buffer_lengths[i], i, self.target
             )
         self.sequence += SequenceCommand.trigger(0)
         self.sequence += SequenceCommand.repeat(self.repetitions)
@@ -250,8 +257,6 @@ class SimpleSequence(Sequence):
         if len(self.buffer_lengths) > len(self.delay_times):
             n = len(self.buffer_lengths) - len(self.delay_times)
             self.delay_times = np.append(self.delay_times, np.zeros(n))
-        if self.target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI]:
-            self.clock_rate = 1.8e9
 
     def check_attributes(self):
         super().check_attributes()
@@ -623,8 +628,6 @@ class ReadoutSequence(Sequence):
             self.wait_cycles = self.time_to_cycles(
                 temp - self.latency + self.trigger_delay
             )
-        if self.target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI]:
-            self.clock_rate = 1.8e9
         len_f = len(self.readout_frequencies)
         len_a = len(self.readout_amplitudes)
         len_p = len(self.phase_shifts)
@@ -703,8 +706,6 @@ class PulsedSpectroscopySequence(Sequence):
             self.wait_cycles = self.time_to_cycles(
                 temp - self.latency + self.trigger_delay
             )
-        if self.target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI]:
-            self.clock_rate = 1.8e9
 
 
 @attr.s


### PR DESCRIPTION
1) Replace ´randomUniform´ with ´placeholder´.
It should reduce the initial compilation and uploading time for very long waveforms.

2) Add ´factory_reset´ method.
It loads the factory preset to the device.
The method is added to the BaseInstrument class because this method is common to multiples devices: UHFQA, HDAWG.
HDAWG and UHFQA classes call the ´factory_reset´ method from the parent class BaseInsturment.
Update clock rate in ´update_params´ method of parent class ´Sequence´
To me, it makes more sense to update the clock rate in the parent class because clock rate is common to multiple children classes for different sequence types. 

3) Add sequencer command ´play_zero´