### PR TITLE
New improvements and features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 attrs
 pytest
 hypothesis
+deprecation

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,13 @@ import os
 import setuptools
 
 
-requirements = ["numpy>=1.13", "setuptools>=40.1.0", "zhinst>=20.01", "attrs"]
+requirements = [
+    "numpy>=1.13",
+    "setuptools>=40.1.0",
+    "zhinst>=20.01",
+    "attrs",
+    "deprecation>=2.1.0",
+]
 
 
 with open("README.md", "r") as fh:

--- a/src/zhinst/toolkit/control/drivers/base/base.py
+++ b/src/zhinst/toolkit/control/drivers/base/base.py
@@ -5,11 +5,14 @@
 
 import numpy as np
 from typing import List, Dict
+import logging
 
 import zhinst.ziPython as zi
 from zhinst.toolkit.control.connection import DeviceConnection, ZIConnection
 from zhinst.toolkit.control.node_tree import NodeTree
 from zhinst.toolkit.interface import InstrumentConfiguration, DeviceTypes
+
+_logger = logging.getLogger(__name__)
 
 
 class ToolkitError(Exception):
@@ -121,6 +124,11 @@ class BaseInstrument:
             self._nodetree = NodeTree(self)
         self._options = self._get("/features/options").split("\n")
         self._init_settings()
+
+    def factory_reset(self) -> None:
+        """Loads the factory default settings."""
+        self._set(f"/system/preset/load", 1)
+        _logger.info(f"Factory preset is loaded to device {self.serial.upper()}.")
 
     def _init_settings(self):
         """Initial device settings.

--- a/src/zhinst/toolkit/control/drivers/hdawg.py
+++ b/src/zhinst/toolkit/control/drivers/hdawg.py
@@ -304,7 +304,10 @@ class AWG(AWGCore):
                     f"Sequence type {t} must be one of {allowed_sequences}!"
                 )
         if "trigger_mode" in kwargs.keys():
-            if TriggerMode(kwargs["trigger_mode"]) == TriggerMode.EXTERNAL_TRIGGER:
+            if TriggerMode(kwargs["trigger_mode"]) in [
+                TriggerMode.EXTERNAL_TRIGGER,
+                TriggerMode.RECEIVE_TRIGGER,
+            ]:
                 self._apply_trigger_settings()
 
     def _apply_trigger_settings(self):

--- a/src/zhinst/toolkit/control/drivers/hdawg.py
+++ b/src/zhinst/toolkit/control/drivers/hdawg.py
@@ -72,6 +72,10 @@ class HDAWG(BaseInstrument):
         super().connect_device(nodetree=nodetree)
         [awg._setup() for awg in self.awgs]
 
+    def factory_reset(self) -> None:
+        """Loads the factory default settings."""
+        super().factory_reset()
+
     def _init_settings(self):
         """Sets initial device settings on startup."""
         settings = [

--- a/src/zhinst/toolkit/control/drivers/mfli.py
+++ b/src/zhinst/toolkit/control/drivers/mfli.py
@@ -77,6 +77,10 @@ class MFLI(BaseInstrument):
         self._sweeper_module = SweeperModule(self)
         self._sweeper_module._setup()
 
+    def factory_reset(self) -> None:
+        """Loads the factory default settings."""
+        super().factory_reset()
+
     def _init_settings(self):
         pass
 

--- a/src/zhinst/toolkit/control/drivers/pqsc.py
+++ b/src/zhinst/toolkit/control/drivers/pqsc.py
@@ -28,3 +28,7 @@ class PQSC(BaseInstrument):
 
     def __init__(self, name: str, serial: str, discovery=None, **kwargs) -> None:
         super().__init__(name, DeviceTypes.PQSC, serial, discovery, **kwargs)
+
+    def factory_reset(self) -> None:
+        """Loads the factory default settings."""
+        super().factory_reset()

--- a/src/zhinst/toolkit/control/drivers/uhfli.py
+++ b/src/zhinst/toolkit/control/drivers/uhfli.py
@@ -78,6 +78,10 @@ class UHFLI(BaseInstrument):
         self._sweeper = SweeperModule(self)
         self._sweeper._setup()
 
+    def factory_reset(self) -> None:
+        """Loads the factory default settings."""
+        super().factory_reset()
+
     def _init_settings(self):
         if "AWG" in self.options:
             settings = [

--- a/src/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/src/zhinst/toolkit/control/drivers/uhfqa.py
@@ -164,6 +164,10 @@ class UHFQA(BaseInstrument):
         super().connect_device(nodetree=nodetree)
         self.awg._setup()
 
+    def factory_reset(self) -> None:
+        """Loads the factory default settings."""
+        super().factory_reset()
+
     def crosstalk_matrix(self, matrix=None):
         """Sets or gets the crosstalk matrix of the UHFQA as a 2D array.
 

--- a/src/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/src/zhinst/toolkit/control/drivers/uhfqa.py
@@ -362,7 +362,10 @@ class AWG(AWGCore):
                 self._apply_base_settings()
         # apply settings dependent on trigger type
         if "trigger_mode" in kwargs.keys():
-            if TriggerMode(kwargs["trigger_mode"]) == TriggerMode.EXTERNAL_TRIGGER:
+            if TriggerMode(kwargs["trigger_mode"]) in [
+                TriggerMode.EXTERNAL_TRIGGER,
+                TriggerMode.RECEIVE_TRIGGER,
+            ]:
                 self._apply_trigger_settings()
 
     def _apply_base_settings(self):

--- a/src/zhinst/toolkit/helpers/sequence_commands.py
+++ b/src/zhinst/toolkit/helpers/sequence_commands.py
@@ -48,6 +48,30 @@ class SequenceCommand(object):
             return f"wait({int(i)});\n"
 
     @staticmethod
+    def play_zero(i, target=DeviceTypes.HDAWG):
+        """Inserts playZero(...) command to the sequencer.
+
+        The granularity of the device will be automatically matched.
+
+        Arguments:
+            i (int): length in number of samples to play zero.
+            target (str): type of the target device which
+                determines the granularity to be matched.
+                (default: DeviceTypes.HDAWG)
+
+        """
+        if i < 0:
+            raise ValueError("Number of samples cannot be negative!")
+        elif target in [DeviceTypes.HDAWG]:
+            if i < 32:
+                raise ValueError("Number of samples cannot be lower than 32 samples!")
+            return f"playZero({int(round(i / 16) * 16)});\n"
+        elif target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI]:
+            if i < 16:
+                raise ValueError("Number of samples cannot be lower than 16 samples!")
+            return f"playZero({int(round(i / 8) * 8)});\n"
+
+    @staticmethod
     def wait_wave():
         return "waitWave();\n"
 

--- a/src/zhinst/toolkit/helpers/sequences.py
+++ b/src/zhinst/toolkit/helpers/sequences.py
@@ -7,10 +7,12 @@ import textwrap
 import attr
 import numpy as np
 from pathlib import Path
+import deprecation
 
 from .sequence_commands import SequenceCommand
 from .utils import SequenceType, TriggerMode, Alignment
 from zhinst.toolkit.interface import DeviceTypes
+from zhinst.toolkit._version import version as __version__
 
 
 def is_positive(self, attribute, value):
@@ -127,12 +129,21 @@ class Sequence(object):
             self.trigger_cmd_2 = SequenceCommand.comment_line()
             self.dead_cycles = 0
 
+    @deprecation.deprecated(
+        deprecated_in="0.2.0",
+        current_version=__version__,
+        details="Use the time_to_samples function instead",
+    )
     def time_to_cycles(self, time, wait_time=True):
         """Helper method to convert time to FPGA clock cycles."""
         if wait_time:
             return int(time * self.clock_rate / 8)
         else:
             return int(time * self.clock_rate)
+
+    def time_to_samples(self, time):
+        """Helper method to convert time to number of samples."""
+        return round(time * self.clock_rate)
 
     def get_gauss_params(self, width, truncation):
         """Calculates the attribute `gauss_params` from width and truncation.

--- a/src/zhinst/toolkit/helpers/sequences.py
+++ b/src/zhinst/toolkit/helpers/sequences.py
@@ -170,7 +170,7 @@ class Sequence(object):
 class SimpleSequence(Sequence):
     """Sequence for *simple* playback of waveform arrays.
 
-    Initializes placeholders (`randomUniform(...)`) of the correct length for
+    Initializes placeholders (`placeholder(...)`) of the correct length for
     the waveforms in the queue of the AWG Core. The data of the waveform
     placeholders is then replaced in memory when uploading the waveform using
     `upload_waveforms()`. The waveforms are played sequentially within the main
@@ -197,8 +197,9 @@ class SimpleSequence(Sequence):
     def write_sequence(self):
         self.sequence = SequenceCommand.header_comment(sequence_type="Simple")
         for i in range(self.n_HW_loop):
+            # Loop over the waveforms and initialize placeholders
             self.sequence += SequenceCommand.init_buffer_indexed(
-                self.buffer_lengths[i], i
+                self.buffer_lengths[i], i, self.target
             )
         self.sequence += SequenceCommand.trigger(0)
         self.sequence += SequenceCommand.repeat(self.repetitions)

--- a/src/zhinst/toolkit/helpers/sequences.py
+++ b/src/zhinst/toolkit/helpers/sequences.py
@@ -106,6 +106,12 @@ class Sequence(object):
 
     def update_params(self):
         """Update interrelated parameters."""
+        # Set the correct clock rate depending on the device type
+        if self.target in [DeviceTypes.HDAWG]:
+            self.clock_rate = 2.4e9
+        elif self.target in [DeviceTypes.UHFLI, DeviceTypes.UHFQA]:
+            self.clock_rate = 1.8e9
+        # Set the trigger commands depending on the trigger mode
         if self.trigger_mode == TriggerMode.NONE:
             self.trigger_cmd_1 = SequenceCommand.comment_line()
             self.trigger_cmd_2 = SequenceCommand.comment_line()
@@ -251,8 +257,6 @@ class SimpleSequence(Sequence):
         if len(self.buffer_lengths) > len(self.delay_times):
             n = len(self.buffer_lengths) - len(self.delay_times)
             self.delay_times = np.append(self.delay_times, np.zeros(n))
-        if self.target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI]:
-            self.clock_rate = 1.8e9
 
     def check_attributes(self):
         super().check_attributes()
@@ -624,8 +628,6 @@ class ReadoutSequence(Sequence):
             self.wait_cycles = self.time_to_cycles(
                 temp - self.latency + self.trigger_delay
             )
-        if self.target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI]:
-            self.clock_rate = 1.8e9
         len_f = len(self.readout_frequencies)
         len_a = len(self.readout_amplitudes)
         len_p = len(self.phase_shifts)
@@ -704,8 +706,6 @@ class PulsedSpectroscopySequence(Sequence):
             self.wait_cycles = self.time_to_cycles(
                 temp - self.latency + self.trigger_delay
             )
-        if self.target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI]:
-            self.clock_rate = 1.8e9
 
 
 @attr.s

--- a/src/zhinst/toolkit/helpers/sequences.py
+++ b/src/zhinst/toolkit/helpers/sequences.py
@@ -33,9 +33,11 @@ class Sequence(object):
         period (double): Period in seconds at which the experiment is repeated.
         trigger_mode (str or :class:`TriggerMode` enum): The trigger mode of the
             sequence, i.e if the AWG Core is used to send out the triger signal
-            (*'Send Triger'* or :class:`TriggerMode.SEND_TRIGGER`) or to wait
-            for an external trigger signal (*'External Triger'* or
-            :class:`TriggerMode.EXTERNAL_TRIGGER`). (default:
+            (*'Send Triger'* or :class:`TriggerMode.SEND_TRIGGER`), to wait
+            for an external trigger signal (*'Receive Triger'* or
+            :class:`TriggerMode.RECEIVE_TRIGGER`) or to wait for an external
+            signal to send out the triger signal (*'Send and Receive Triger'* or
+            :class:`TriggerMode.SEND_AND_RECEIVE_TRIGGER`). (default:
             :class:`TriggerMode.NONE`)
         repetitions (int): The number of repetitions of the experiment.
         alignment (str): The alignment of the played waveform with the trigger
@@ -122,7 +124,10 @@ class Sequence(object):
             self.trigger_cmd_1 = SequenceCommand.trigger(1)
             self.trigger_cmd_2 = SequenceCommand.trigger(0)
             self.dead_cycles = self.time_to_cycles(self.dead_time)
-        elif self.trigger_mode == TriggerMode.EXTERNAL_TRIGGER:
+        elif self.trigger_mode in [
+            TriggerMode.EXTERNAL_TRIGGER,
+            TriggerMode.RECEIVE_TRIGGER,
+        ]:
             self.trigger_cmd_1 = SequenceCommand.wait_dig_trigger(
                 index=int(self.target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI])
             )
@@ -256,7 +261,10 @@ class SimpleSequence(Sequence):
             self.wait_cycles = self.time_to_cycles(self.period)
         elif self.trigger_mode == TriggerMode.SEND_TRIGGER:
             self.wait_cycles = self.time_to_cycles(self.period - self.dead_time)
-        elif self.trigger_mode == TriggerMode.EXTERNAL_TRIGGER:
+        elif self.trigger_mode in [
+            TriggerMode.EXTERNAL_TRIGGER,
+            TriggerMode.RECEIVE_TRIGGER,
+        ]:
             self.wait_cycles = self.time_to_cycles(
                 self.period - self.dead_time - self.latency + self.trigger_delay
             )
@@ -378,7 +386,10 @@ class RabiSequence(Sequence):
                 self.wait_cycles -= self.gauss_params[0] / 8
             elif self.alignment == Alignment.START_WITH_TRIGGER:
                 self.dead_cycles -= self.gauss_params[0] / 8
-        elif self.trigger_mode == TriggerMode.EXTERNAL_TRIGGER:
+        elif self.trigger_mode in [
+            TriggerMode.EXTERNAL_TRIGGER,
+            TriggerMode.RECEIVE_TRIGGER,
+        ]:
             self.wait_cycles = self.time_to_cycles(
                 self.period - self.dead_time - self.latency + self.trigger_delay
             )
@@ -458,7 +469,10 @@ class T1Sequence(Sequence):
         self.get_gauss_params(self.pulse_width, self.pulse_truncation)
         if self.trigger_mode in [TriggerMode.NONE, TriggerMode.SEND_TRIGGER]:
             self.wait_cycles = self.time_to_cycles(self.period - self.dead_time)
-        elif self.trigger_mode == TriggerMode.EXTERNAL_TRIGGER:
+        elif self.trigger_mode in [
+            TriggerMode.EXTERNAL_TRIGGER,
+            TriggerMode.RECEIVE_TRIGGER,
+        ]:
             self.wait_cycles = self.time_to_cycles(
                 self.period - self.dead_time - self.latency + self.trigger_delay
             )
@@ -635,7 +649,10 @@ class ReadoutSequence(Sequence):
             self.wait_cycles = self.time_to_cycles(temp)
         elif self.trigger_mode == TriggerMode.SEND_TRIGGER:
             self.wait_cycles = self.time_to_cycles(temp)
-        elif self.trigger_mode == TriggerMode.EXTERNAL_TRIGGER:
+        elif self.trigger_mode in [
+            TriggerMode.EXTERNAL_TRIGGER,
+            TriggerMode.RECEIVE_TRIGGER,
+        ]:
             self.wait_cycles = self.time_to_cycles(
                 temp - self.latency + self.trigger_delay
             )
@@ -713,7 +730,10 @@ class PulsedSpectroscopySequence(Sequence):
             self.wait_cycles = self.time_to_cycles(temp)
         elif self.trigger_mode == TriggerMode.SEND_TRIGGER:
             self.wait_cycles = self.time_to_cycles(temp)
-        elif self.trigger_mode == TriggerMode.EXTERNAL_TRIGGER:
+        elif self.trigger_mode in [
+            TriggerMode.EXTERNAL_TRIGGER,
+            TriggerMode.RECEIVE_TRIGGER,
+        ]:
             self.wait_cycles = self.time_to_cycles(
                 temp - self.latency + self.trigger_delay
             )
@@ -745,7 +765,10 @@ class CWSpectroscopySequence(Sequence):
             self.wait_cycles = self.time_to_cycles(self.period - self.dead_time)
         elif self.trigger_mode == TriggerMode.SEND_TRIGGER:
             self.wait_cycles = self.time_to_cycles(self.period - self.dead_time)
-        elif self.trigger_mode == TriggerMode.EXTERNAL_TRIGGER:
+        elif self.trigger_mode in [
+            TriggerMode.EXTERNAL_TRIGGER,
+            TriggerMode.RECEIVE_TRIGGER,
+        ]:
             self.wait_cycles = self.time_to_cycles(
                 self.period - self.dead_time - self.latency + self.trigger_delay
             )

--- a/src/zhinst/toolkit/helpers/utils.py
+++ b/src/zhinst/toolkit/helpers/utils.py
@@ -50,7 +50,9 @@ class TriggerMode(Enum):
 
     NONE = None
     SEND_TRIGGER = "Send Trigger"
-    EXTERNAL_TRIGGER = "External Trigger"
+    EXTERNAL_TRIGGER = "External Trigger"  # deprecated
+    RECEIVE_TRIGGER = "Receive Trigger"
+    SEND_AND_RECEIVE_TRIGGER = "Send and Receive Trigger"
 
 
 class Alignment(Enum):

--- a/tests/test_sequenceCommands.py
+++ b/tests/test_sequenceCommands.py
@@ -42,6 +42,26 @@ def test_wait_positive(i):
         assert str(i) in SequenceCommand.wait(i)
 
 
+@given(
+    i=st.integers(-10, 100),
+    target=st.sampled_from(
+        [getattr(DeviceTypes, x) for x in ["HDAWG", "UHFQA", "UHFLI"]]
+    ),
+)
+def test_play_zero(i, target):
+    if i < 0:
+        with pytest.raises(ValueError):
+            SequenceCommand.play_zero(i, target)
+    elif target in [DeviceTypes.HDAWG] and i < 32:
+        with pytest.raises(ValueError):
+            SequenceCommand.play_zero(i, target)
+    elif target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI] and i < 16:
+        with pytest.raises(ValueError):
+            SequenceCommand.play_zero(i, target)
+    else:
+        SequenceCommand.play_zero(i, target)
+
+
 @given(value=st.integers(-1, 2), index=st.integers(0, 3))
 def test_trigger(value, index):
     if value not in [0, 1] or index not in [1, 2]:

--- a/tests/test_sequenceProgram.py
+++ b/tests/test_sequenceProgram.py
@@ -54,12 +54,14 @@ class SequenceProgramMachine(RuleBasedStateMachine):
         else:
             assert self.sequenceProgram.sequence_type.value == types[t]
 
-    @rule(t=st.integers(0, 2))
+    @rule(t=st.integers(0, 4))
     def change_trigger_by_enum(self, t):
         types = {
             0: TriggerMode.NONE,
             1: TriggerMode.SEND_TRIGGER,
             2: TriggerMode.EXTERNAL_TRIGGER,
+            3: TriggerMode.RECEIVE_TRIGGER,
+            4: TriggerMode.SEND_AND_RECEIVE_TRIGGER,
         }
         self.sequenceProgram.set_params(trigger_mode=types[t])
         params = self.sequenceProgram.list_params()
@@ -67,13 +69,15 @@ class SequenceProgramMachine(RuleBasedStateMachine):
             params = params["sequence_parameters"]
             assert params["trigger_mode"] == types[t]
 
-    @rule(t=st.integers(-1, 2))
+    @rule(t=st.integers(-1, 4))
     def change_trigger_by_string(self, t):
         types = {
             -1: "None",
             0: None,
             1: "Send Trigger",
             2: "External Trigger",
+            3: "Receive Trigger",
+            4: "Send and Receive Trigger",
         }
         self.sequenceProgram.set_params(trigger_mode=types[t])
         params = self.sequenceProgram.list_params()


### PR DESCRIPTION
#### **The following changes are made in the update**:
##### **1) Update `init_buffer_indexed` helper function:**
* Replaced `randomUniform` with `placeholder`. It should reduce the
initial compilation and uploading time for very long waveforms.
* The target device type is also added to the arguments so that the
granularity and minimum waveform can be checked depending on the device
type. UHFQA and HDAWG have different granularities and minimum waveform
lengths.
* A docstring is also added to the method to improve documentation.
* The related test is also updated according to the changes made to the
method.
##### **2) Add `factory_reset` method:**
* It loads the factory preset to the device. The method is added to the
`BaseInstrument` class because this method is common to multiple
devices: UHFQA, HDAWG, UHFLI, MFLI and PQSC. The instrument classes call
the `factory_reset` method from the parent class `BaseInsturment`.
* Logging facility is also used to allow the user to track the factory
reset event.
##### **3) Update clock rate in parent class `Sequence`:**
Clock rate can be updated in `update_params` method of parent class
`Sequence`. It makes more sense to update the clock rate in the parent
class because clock rate only depends on the device type and it is
common to multiple children classes for different sequence types.
##### **4) Add sequencer command `play_zero`:**
* This command will be used to implement more precise waiting time
compared to `wait` command.
* A test function is also added for this sequence command.
##### **5) Add deprecation module to requirements:**
This module is necessary to deprecate outdated features. The requirement
is added to `setup.py` and `requirements.txt`
##### **6) Add helper function `time_to_samples`:**
This does the some thing as the helper function `time_to_cycles` with
the option `wait_time=False` but it is simpler and has a more clear
naming. Also, we do not need the `wait_time=True` option of
`time_to_cycles` anymore, therefore it is deprecated now.
##### **7) Update the enumeration for `TriggerMode`:**
* A new trigger mode is added: `SEND_AND_RECEIVE_TRIGGER`. This trigger
mode will be used when the Master HDAWG is sending out trigger signals
to slave devices, but before that, it waits to receive an external
trigger, which is usually the same 10 MHz clock signal it uses as
external clock. This is necessary to make sure the Master HDAWG
generates the trigger signal always with the same latency with respect
to the external clock it runs from.
* We also replace `EXTERNAL_TRIGGER` with `RECEIVE_TRIGGER` because this
enumeration is more consistent the other enumerations used:
`SEND_TRIGGER` and `SEND_AND_RECEIVE_TRIGGER`. The old enumeration
`EXTERNAL_TRIGGER` is not completely removed but just deprecated for the
moment.
* Also updated the docstring of `Sequence` class according to the new
trigger enumeration.
* The related test is also updated according to the changes made
to the enumeration.
