### PR TITLE
Update trigger functions

### DIFF
--- a/src/zhinst/toolkit/helpers/sequence_commands.py
+++ b/src/zhinst/toolkit/helpers/sequence_commands.py
@@ -239,12 +239,25 @@ class SequenceCommand(object):
         return "\n}"
 
     @staticmethod
-    def wait_dig_trigger(index=0):
-        if index not in [0, 1, 2]:
+    def wait_dig_trigger(index=1, target=DeviceTypes.HDAWG):
+        """Insert waitDigTrigger(...) command to the sequencer.
+
+        The arguments of waitDigTrigger(...) function are different
+        for HDAWG and UHFQA/UHFLI.
+
+        Arguments:
+            index (int): index of the digital trigger input;
+                can be either 1 or 2. (default: 1)
+            target (str): type of the target device which
+                determines the arguments to pass to the
+                function. (default: DeviceTypes.HDAWG)
+        """
+
+        if index not in [1, 2]:
             raise ValueError("Invalid Trigger Index!")
-        if index == 0:
-            return "waitDigTrigger(1);\n"
-        else:
+        if target in [DeviceTypes.HDAWG]:
+            return f"waitDigTrigger({index});\n"
+        elif target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI]:
             return f"waitDigTrigger({index}, 1);\n"
 
     @staticmethod

--- a/src/zhinst/toolkit/helpers/sequence_commands.py
+++ b/src/zhinst/toolkit/helpers/sequence_commands.py
@@ -5,8 +5,10 @@
 
 from datetime import datetime
 import numpy as np
+import deprecation
 
 from zhinst.toolkit.interface import DeviceTypes
+from zhinst.toolkit._version import version as __version__
 
 
 class SequenceCommand(object):
@@ -76,12 +78,37 @@ class SequenceCommand(object):
         return "waitWave();\n"
 
     @staticmethod
+    @deprecation.deprecated(
+        deprecated_in="0.2.0",
+        current_version=__version__,
+        details="Use the define_trigger and play_trigger functions instead",
+    )
     def trigger(value, index=1):
         if value not in [0, 1]:
             raise ValueError("Invalid Trigger Value!")
         if index not in [1, 2]:
             raise ValueError("Invalid Trigger Index!")
         return f"setTrigger({value << (index - 1)});\n"
+
+    @staticmethod
+    def define_trigger(length=32):
+        """Define a marker waveform to be used to send out trigger signals.
+
+        The analog part of the waveform is zero.
+
+        Arguments:
+            length (int): length of marker waveform in number of samples. (default: 32)
+        """
+        if length < 32:
+            raise ValueError("Trigger cannot be shorter than 32 samples!")
+        if length % 16:
+            raise ValueError("Trigger Length has to be multiple of 16!")
+        return f"wave start_trigger = marker({length},1);\n"
+
+    @staticmethod
+    def play_trigger():
+        """Play the marker waveform which is used as trigger."""
+        return "playWave(1, start_trigger);\n"
 
     @staticmethod
     def count_waveform(i, n):

--- a/src/zhinst/toolkit/helpers/sequences.py
+++ b/src/zhinst/toolkit/helpers/sequences.py
@@ -128,9 +128,7 @@ class Sequence(object):
             TriggerMode.EXTERNAL_TRIGGER,
             TriggerMode.RECEIVE_TRIGGER,
         ]:
-            self.trigger_cmd_1 = SequenceCommand.wait_dig_trigger(
-                index=int(self.target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI])
-            )
+            self.trigger_cmd_1 = SequenceCommand.wait_dig_trigger(1, self.target)
             self.trigger_cmd_2 = SequenceCommand.comment_line()
             self.dead_cycles = 0
 

--- a/tests/test_sequenceCommands.py
+++ b/tests/test_sequenceCommands.py
@@ -71,6 +71,21 @@ def test_trigger(value, index):
         SequenceCommand.trigger(value, index)
 
 
+@given(length=st.integers(-10, 100))
+def test_define_trigger(length):
+    if length % 16 != 0 or length < 32:
+        with pytest.raises(ValueError):
+            SequenceCommand.define_trigger(length)
+    else:
+        assert str(length) in SequenceCommand.define_trigger(length)
+
+
+def test_play_trigger():
+    line = SequenceCommand.play_trigger()
+    assert "playWave" in line
+    assert "start_trigger" in line
+
+
 @given(i=st.integers(0, 1000), n=st.integers(0, 1000))
 def test_count_waveform(i, n):
     line = SequenceCommand.count_waveform(i, n)

--- a/tests/test_sequenceCommands.py
+++ b/tests/test_sequenceCommands.py
@@ -174,10 +174,15 @@ def test_init_gauss_scaled(amp, l, p, w):
         assert str(amp) in line
 
 
-@given(i=st.integers(-1, 5))
-def test_wait_trigger(i):
-    if i not in [0, 1, 2]:
+@given(
+    i=st.integers(-1, 5),
+    target=st.sampled_from(
+        [getattr(DeviceTypes, x) for x in ["HDAWG", "UHFQA", "UHFLI"]]
+    ),
+)
+def test_wait_dig_trigger(i, target):
+    if i not in [1, 2]:
         with pytest.raises(ValueError):
-            SequenceCommand.wait_dig_trigger(i)
+            SequenceCommand.wait_dig_trigger(i, target)
     else:
-        SequenceCommand.wait_dig_trigger(i)
+        SequenceCommand.wait_dig_trigger(i, target)


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) Add functions `define_trigger` and `play_trigger`:**
* New sequence command is added: `define_trigger`
It generates a waveform of specified length with marker bit 1 set to 1,
analog part set to 0. This is used to send out trigger signals from the
marker output of the AWG. This function is supposed to replace the
`trigger` method, because using marker signals instead of `setTrigger`
command allows us to have more precise timing.
* New sequence command is added: `play_trigger`
It plays the defined trigger from the AWG core output 1. However, this
signal should still be assigned to the desired Marker Output in DIO
settings by selecting `Output 1 Marker 1`.
##### **2) Add tests for `define_trigger` and `play_trigger`:**
##### **3) Deprecate the sequence command: `trigger`:**
This command is outdated. We do not generate triggers using `setTrigger`
anymore because it does not allow us to have precise timing. We should
use marker waveforms to implement more precise triggering.
##### **4) Update `wait_dig_trigger` helper function:**
The usage of `waitDigTrigger` sequencer command is different for
different devices. For example, in HDAWG it is used as:
`waitDigTrigger(1);`
However, in UHFQA or UHFLI, it is used as:
`waitDigTrigger(1, 1);`
Before this commit, `wait_dig_trigger` helper function was taking this
difference into account, but it was using a confusing indexing with
0,1,2. Also, it was not possible to pass index 2 to the `waitDigTrigger`
command for HDAWG as in:
`waitDigTrigger(2);`
* `wait_dig_trigger` helper function is updated such that it now 
takes the trigger index (1 or 2) and the device type as argument.
Then it generates the correct string using these arguments.
* The usage of the helper function inside the `Sequence` parent class is
 also updated.
##### **5) Update test for `wait_dig_trigger` helper function**