### PR TITLE
Update `pytest` command in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,5 @@ jobs:
 
       - name: "Run pytest targets for ${{ matrix.python-version }}"
         run: |
-          pytest --cov=. .
+          pytest --cov=zhinst.toolkit tests/
           codecov


### PR DESCRIPTION
With the updated command, the coverage should now run on the source files only, not on the `setup.py` and test files themselves.