### PR TITLE
Update parent sequence

### DIFF
--- a/src/zhinst/toolkit/helpers/sequences.py
+++ b/src/zhinst/toolkit/helpers/sequences.py
@@ -84,6 +84,8 @@ class Sequence(object):
             signal to send out the triger signal (*'Send and Receive Triger'* or
             :class:`TriggerMode.SEND_AND_RECEIVE_TRIGGER`). (default:
             :class:`TriggerMode.NONE`)
+        trigger_samples (int): The duration of the trigger signal sent out by
+            the AWG Core. It is given in number of samples. (default: 32)
         repetitions (int): The number of repetitions of the experiment.
         alignment (str): The alignment of the played waveform with the trigger
             signal, i.e. if the waveform should start with the trigger (or the
@@ -119,6 +121,10 @@ class Sequence(object):
     trigger_mode = attr.ib(
         default=TriggerMode.SEND_TRIGGER,
         converter=lambda m: TriggerMode.NONE if m == "None" else TriggerMode(m),
+    )
+    trigger_samples = attr.ib(
+        default=32,
+        validator=[is_greater_equal(32), is_multiple(16)],
     )
     repetitions = attr.ib(default=1)
     alignment = attr.ib(

--- a/src/zhinst/toolkit/helpers/sequences.py
+++ b/src/zhinst/toolkit/helpers/sequences.py
@@ -152,6 +152,12 @@ class Sequence(object):
     dead_cycles = attr.ib(
         default=1500, validator=is_greater_equal(0)
     )  # 5 us by default
+    wait_samples = attr.ib(
+        default=228000, validator=is_greater_equal(0)
+    )  # 95 us by default (Assuming HDAWG)
+    dead_samples = attr.ib(
+        default=12000, validator=is_greater_equal(0)
+    )  # 5 us by default (Assuming HDAWG)
     reset_phase = attr.ib(default=False)
 
     def set(self, **settings):
@@ -184,6 +190,12 @@ class Sequence(object):
 
     def update_params(self):
         """Update interrelated parameters."""
+        # Convert wait_time to number of samples
+        self.wait_samples = self.time_to_samples(
+            self.period - self.dead_time + self.trigger_delay
+        )
+        # Convert dead_time to number of samples
+        self.dead_samples = self.time_to_samples(self.dead_time - self.trigger_delay)
         # Set the correct clock rate and trigger latency compensation
         # depending on the device type
         if self.target in [DeviceTypes.HDAWG]:

--- a/src/zhinst/toolkit/helpers/sequences.py
+++ b/src/zhinst/toolkit/helpers/sequences.py
@@ -170,8 +170,17 @@ class Sequence(object):
         return self.sequence
 
     def write_sequence(self):
-        """To be overridden by children classes."""
-        self.sequence = None
+        """Create header for the sequencer program.
+
+        The header displays the sequence type, trigger mode and alignment
+        information of the program. Sequence type is temporarily selected as
+        `None` here. It will be overwritten by the children classes depending
+        on the actual sequence type.
+
+        """
+        self.sequence = SequenceCommand.header_info(
+            SequenceType.NONE, self.trigger_mode, self.alignment
+        )
 
     def update_params(self):
         """Update interrelated parameters."""

--- a/tests/test_sequenceProgram.py
+++ b/tests/test_sequenceProgram.py
@@ -159,11 +159,8 @@ class SequenceProgramMachine(RuleBasedStateMachine):
     @rule()
     def get_sequence(self):
         sequence = self.sequenceProgram.get_seqc()
-        t = self.sequenceProgram.sequence_type.value
-        if t is None:
-            assert sequence is None
-        else:
-            assert t in sequence
+        sequence_type = self.sequenceProgram.sequence_type
+        assert str(sequence_type.value) in sequence
 
 
 TestPrograms = SequenceProgramMachine.TestCase

--- a/tests/test_sequenceProgram.py
+++ b/tests/test_sequenceProgram.py
@@ -144,6 +144,12 @@ class SequenceProgramMachine(RuleBasedStateMachine):
             params = self.sequenceProgram.list_params()
             assert params["sequence_parameters"]["latency_adjustment"] == i
 
+    @rule(i=st.booleans())
+    def change_reset_phase(self, i):
+        self.sequenceProgram.set_params(reset_phase=i)
+        params = self.sequenceProgram.list_params()
+        assert params["sequence_parameters"]["reset_phase"] == i
+
     # @rule(l=st.integers(1, 1000), t=st.floats(100e-9, 10e-6))
     # def change_delays(self, l, t):
     #     test_array = np.linspace(0, t, l)

--- a/tests/test_sequenceProgram.py
+++ b/tests/test_sequenceProgram.py
@@ -134,6 +134,16 @@ class SequenceProgramMachine(RuleBasedStateMachine):
             params = self.sequenceProgram.list_params()
             assert params["sequence_parameters"]["trigger_samples"] == i
 
+    @rule(i=st.integers(-10, 100))
+    def change_latency_adjustment(self, i):
+        if i < 0:
+            with pytest.raises(ValueError):
+                self.sequenceProgram.set_params(latency_adjustment=i)
+        else:
+            self.sequenceProgram.set_params(latency_adjustment=i)
+            params = self.sequenceProgram.list_params()
+            assert params["sequence_parameters"]["latency_adjustment"] == i
+
     # @rule(l=st.integers(1, 1000), t=st.floats(100e-9, 10e-6))
     # def change_delays(self, l, t):
     #     test_array = np.linspace(0, t, l)

--- a/tests/test_sequenceProgram.py
+++ b/tests/test_sequenceProgram.py
@@ -122,6 +122,18 @@ class SequenceProgramMachine(RuleBasedStateMachine):
         else:
             assert "pulse_amplitudes" not in params["sequence_parameters"].keys()
 
+    @rule(i=st.integers(-10, 1000))
+    def change_trigger_samples(self, i):
+        granularity = 16
+        minimum_length = 32
+        if i % granularity != 0 or i < minimum_length:
+            with pytest.raises(ValueError):
+                self.sequenceProgram.set_params(trigger_samples=i)
+        else:
+            self.sequenceProgram.set_params(trigger_samples=i)
+            params = self.sequenceProgram.list_params()
+            assert params["sequence_parameters"]["trigger_samples"] == i
+
     # @rule(l=st.integers(1, 1000), t=st.floats(100e-9, 10e-6))
     # def change_delays(self, l, t):
     #     test_array = np.linspace(0, t, l)


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) Add new attribute `trigger_samples`:**
* In the new triggering method, added in one of the previous commits, we
define the trigger signal using the marker bits. The new attribute
`trigger_samples` is used to specify the length of the trigger signal in
number of samples. This attribute should comply with the granularity and
minimum waveform length specifications of HDAWG instrument. Therefore,
necessary validators are added to this attribute.
* A test for attribute `trigger_samples` is also added

##### **2) Add new attributes related to trigger latency:**
* New attribute added: `latency_cycles`:
Different instruments have different trigger latencies. In order to
compensate for this, it is necessary for some instruments to wait for
certain number of sequencer cycles after receiving the trigger. For
instance, HDAWG needs wait for 27 sequencer cycles after receiving the
trigger because its trigger latency is lower than UHFQA. This way, a
waveform from HDAWG can be aligned with a waveform from UHFQA. In this
case, UHFQA does not need to wait any extra cycles after receiving the
trigger. `latency_cycles` specifies how many cycles an instrument should
wait after receiving the trigger. By default, it is 27 for HDAWG and 0
for UHFQA/UHFLI. This attribute is not accessible directly to the user.
* New attribute added: `latency_adjustment`:
Since `latency_cycles` is not accessible to the user, we introduce
another attribute to allow the user to adjust the number of cycles an
instrument waits for after receiving the trigger. Using the
`latency_adjustment` attribute, the user can increase `latency_cycles`
from its default value. It is set to 0 by default. A test is added to
check if this attribute can be accessed and changed by the user.

##### **3) Update sequence commands:**
* Update helper function `wait`:
This helper function is updated to add a description and return "//" if
waiting time given as input is 0.
* Update helper function `readout_trigger`:
This helper function is updated to use the new QA starting method.
* Update helper function `repeat`:
This helper function is updated to remove unnecessary new line
characters. 
* Update helper function `close_bracket`:
This helper function is updated to remove unnecessary new line
characters in front of the closing bracket '}' . 
* Add new helper function `assign_wave_index`:
This helper function is used to assign index number to the labeled
waveforms.
* Add new helper function `inline_comment`
This command allows us to insert inline comments to the sequencer.
* Add new helper function `space`
This command allows us to insert space character to the sequencer.
* Add new helper function `header_info`:
This helper function is used to display the sequence type, trigger mode
and alignment information at the top of the sequencer program. The
outdated function `header_comment` was only displaying the sequence type
and it is deprecated.
* Related tests are created/updated for these sequence commands.


##### **4) Update `write_sequence` method:**
* The sequencer program is initiated in this method. The header
information of the sequencer program is now written in the
`write_sequence` method of the parent class `Sequence`. Sequence type is
temporarily selected as `None` here. It will be overwritten by the
children classes depending on the actual sequence type.
* `get_sequence` test is also updated. When the sequence type is `None`,
the sequence program is not equal to `None` anymore. It is initiated
with the header information and the sequence type is state as `None` in
this header information, such as:
```
// Zurich Instruments sequencer program
// sequence type:              None
// trigger mode:               Send Trigger
// alignment:                  End with Trigger
// automatically generated:    30/04/2021 @16:17
```

##### **5) Add attributes `wait_samples` and `dead_samples`:**
* New attribute added:`wait_samples`:
Wait time is the portion of the period before t0. Therefore, it is
calculated as: wait time = period - dead_time + trigger_delay
The attribute `wait_samples` is the wait time calculated as above and
converted to units of number of samples. It has a default value
corresponding to 95 us on an HDAWG instrument.
* New attribute added:`dead_samples`:
Dead time is the portion of the period after t0. The attribute
`dead_samples` is the dead time converted to units of number of samples.
It has a default value corresponding to 5 us on an HDAWG instrument.

##### **6) Add new attributes related to trigger commands:**
These attributes are set depending on the trigger mode and trigger
latency compensation
* New attribute added `trigger_cmd_latency`:
This attribute is set to a `wait` command with the argument
`latency_cycles` passed to it if trigger `latency_cycles` is not 0, so
that the instrument waits for `latency_cycles` in order to compensate
for the trigger latency differences in different instruments. An inline
comment is also added to inform the user about this.
* New attribute added `trigger_cmd_define`:
If the trigger mode is `SEND_AND_RECEIVE_TRIGGER` or `SEND_TRIGGER`, it
is set to the `define_trigger` sequencer command with the argument
`trigger_samples` passed to it.
* New attribute added `trigger_cmd_send`:
If the trigger mode is `SEND_AND_RECEIVE_TRIGGER`, this attribute is set
to combination of sequencer commands `wait_dig_trigger` and
`play_trigger`. In this trigger mode, the master instrument waits for
an external clock before sending out the trigger signal. An inline
comment is added to the sequencer to inform the user about this. After
receiving the external clock, the trigger signal is sent out. If the
trigger mode is `SEND_TRIGGER`, this attribute is set to only
`play_trigger` sequencer command.
* New attribute added `trigger_cmd_wait`:
If the trigger mode is `SEND_AND_RECEIVE_TRIGGER` or `SEND_TRIGGER`,
this attribute is set to `wait_dig_trigger` sequencer command, so that
the instrument waits for self triggering. An inline comment is added to
the sequencer to inform the user about this. Self triggering is
necessary for master devices in order to ensure proper alignment of
waveforms with slave devices. If the trigger mode is `RECEIVE_TRIGGER`,
this attribute is set to `wait_dig_trigger` sequencer command, so that
the instrument waits for an external trigger. An inline comment is added
to the sequencer to inform the user about this.

All attributes are set to comment line when they are not used in a
certain trigger mode.

##### **7) Add `readout_cmd_trigger`, `osc_cmd_reset` attribs:**
* New attribute added `readout_cmd_trigger`:
This attribute depends on the device type. It is used to trigger the
quantum analyzer of an instrument. Since only UHFQA has quantum
analyzer, it is set to comment line in other devices. For UHFQA it is
set to `readout_trigger` sequencer command.
* New attribute added `osc_cmd_reset`:
This attribute is used for setting the oscillator phase to 0 if the
`reset_phase` attribute of `Sequence` parent class is set to `True`.
The sequencer command `reset_osc_phase` is used for this purpose. If
`reset_phase` attribute is set to `False, `osc_cmd_reset` is set to
 comment line.
* The docstring is updated to remove the part that states `reset_phase`
option is only available for HDAWG. This option works also for UHFQA
and UHFLI.
* A test is added to check if the user can access and change the
attribute `reset_phase`.

