### PR TITLE
Update ´SimpleSequence´ class

### DIFF
--- a/src/zhinst/toolkit/helpers/sequence_commands.py
+++ b/src/zhinst/toolkit/helpers/sequence_commands.py
@@ -4,6 +4,7 @@
 # of the MIT license. See the LICENSE file for details.
 
 from datetime import datetime
+import re
 import numpy as np
 import deprecation
 
@@ -50,6 +51,28 @@ class SequenceCommand(object):
             f"// alignment:                  {alignment.value}\n"
             f"// automatically generated:    {now_string}\n\n"
         )
+
+    @staticmethod
+    def replace_sequence_type(sequence, sequence_type):
+        """Replace the sequence type in the header information of the sequencer
+        program.
+
+        The header information is initiated in the parent class with the
+        default sequence type `None`. This default value should be replaced in
+        the child class with the correct sequence type.
+
+        Arguments:
+            sequence (str): sequencer program that contains the initial header
+            sequence_type (:class:`SequenceType` enum): correct sequence type
+
+        """
+        sequence_updated = re.sub(
+            "// sequence type:              .*?\n",
+            f"// sequence type:              {sequence_type.value}\n",
+            sequence,
+            flags=re.DOTALL,
+        )
+        return sequence_updated
 
     @staticmethod
     def repeat(i):

--- a/tests/test_sequenceCommands.py
+++ b/tests/test_sequenceCommands.py
@@ -27,6 +27,19 @@ def test_header_info(trigger_mode, alignment):
     assert str(alignment.value) in line
 
 
+@given(
+    sequence_type=st.sampled_from(SequenceType),
+    trigger_mode=st.sampled_from(TriggerMode),
+    alignment=st.sampled_from(Alignment),
+)
+def test_replace_sequence_type(sequence_type, trigger_mode, alignment):
+    default_header = SequenceCommand.header_info(
+        SequenceType.NONE, trigger_mode, alignment
+    )
+    line = SequenceCommand.replace_sequence_type(default_header, sequence_type)
+    assert str(sequence_type.value) in line
+
+
 @given(i=st.integers(-1000, -1))
 def test_repeat_negative(i):
     with pytest.raises(ValueError):


### PR DESCRIPTION
#### **The following changes are made to `SimpleSequence` class:**

##### **1) New sequence command added `replace_sequence_type`:**
This helper function is added to replace the sequence type information
in the header. A related test is also added.
##### **2) Header information is updated:**
The header information inserted to the top of the program is updated. It
now includes the trigger mode and alignment as well as the sequence
type. The header information is initiated as a string in the parent
class `Sequence` and written into the `sequence` attribute. The
`SimpleSequence` class calls the `write_sequence` method of the parent
class to get the header information. It then replaces the string 'None'
with the correct sequence type using a new sequence command
`replace_sequence_type` added in this commit.
##### **3) `wait_samples_updated` and ` dead_samples_updated` added:**
These attributes are used to update the number of samples to wait before
and after playing each waveform. Since `delay_times` and
`buffer_lengths` can be different for each waveform, we need to initiate
`wait_samples_updated` and `dead_samples_updated` as lists and set the
initial values of their elements to `wait_samples` and `dead_samples`,
respectively. Then, we update each element of these lists according
`delay_times` and `buffer_lengths` corresponding to that element. Note
that how the lists are updated depends on the alignment option. The
update is done inside `update_params`method after calling
`super().update_params()` and making the necessary updates to
`delay_times` first. Outdated variables are not being used anymore:
`temp`, `wait_cycles`, `dead_cycles`
##### **4) New commands are integrated into the sequence:**
The commands `trigger_cmd_define`, `trigger_cmd_send`,
`trigger_cmd_wait`, `trigger_cmd_latency`, `osc_cmd_reset` and
`readout_cmd_trigger` are now being used to generate the sequence.
Outdated commands are not being used anymore: `trigger_cmd_1`,
`trigger_cmd_2`
##### **5) New helper functions are integrated into the sequence:**
The helper functions `assign_wave_index` and `play_zero` are now being
used to generate the sequence. The outdated function `time_to_cycles` is
not being used anymore.
##### **6) Improved explanation of the code with inline comments:**
We use `inline_comment` helper function to insert explanatory comments
to the sequencer program.
