### PR TITLE
Remove hardcoded integration time

### DIFF
--- a/src/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/src/zhinst/toolkit/control/drivers/uhfqa.py
@@ -567,7 +567,6 @@ class ReadoutChannel:
         """Enables weighted integration for this channel."""
         self._enabled = True
         self._parent._set("qas/0/integration/mode", 0)
-        self._parent.integration_time(2e-6)
         self._set_int_weights()
 
     def disable(self) -> None:


### PR DESCRIPTION
When a channel gets enabled, the integration time is always set to 2us. Remove this side effect.

This has been added in 3c68113cbf072b885f2c6c3750a40553662c1a58 , but I suppose it's a mistake.

@bahadirdonmez 

cc. @mjruckriegel 
