### PR TITLE
Update spectroscopy sequence

### DIFF
--- a/tests/test_sequenceProgram.py
+++ b/tests/test_sequenceProgram.py
@@ -153,7 +153,12 @@ class SequenceProgramMachine(RuleBasedStateMachine):
     def change_reset_phase(self, i):
         self.sequenceProgram.set_params(reset_phase=i)
         params = self.sequenceProgram.list_params()
-        assert params["sequence_parameters"]["reset_phase"] == i
+        sequence_type = params["sequence_type"]
+        reset_phase = params["sequence_parameters"]["reset_phase"]
+        if sequence_type == SequenceType.PULSED_SPEC:
+            assert reset_phase is True
+        else:
+            assert reset_phase is i
 
     # @rule(l=st.integers(1, 1000), t=st.floats(100e-9, 10e-6))
     # def change_delays(self, l, t):

--- a/tests/test_sequenceProgram.py
+++ b/tests/test_sequenceProgram.py
@@ -65,9 +65,12 @@ class SequenceProgramMachine(RuleBasedStateMachine):
         }
         self.sequenceProgram.set_params(trigger_mode=types[t])
         params = self.sequenceProgram.list_params()
-        if params["sequence_type"] != SequenceType.TRIGGER:
-            params = params["sequence_parameters"]
-            assert params["trigger_mode"] == types[t]
+        sequence_type = params["sequence_type"]
+        trigger_mode = params["sequence_parameters"]["trigger_mode"]
+        if t not in [1, 4] and sequence_type == SequenceType.TRIGGER:
+            assert trigger_mode == types[1]
+        else:
+            assert trigger_mode == types[t]
 
     @rule(t=st.integers(-1, 4))
     def change_trigger_by_string(self, t):
@@ -81,12 +84,14 @@ class SequenceProgramMachine(RuleBasedStateMachine):
         }
         self.sequenceProgram.set_params(trigger_mode=types[t])
         params = self.sequenceProgram.list_params()
-        if params["sequence_type"] != SequenceType.TRIGGER:
-            params = params["sequence_parameters"]
-            if t == -1:
-                assert params["trigger_mode"].value is None
-            else:
-                assert params["trigger_mode"].value == types[t]
+        sequence_type = params["sequence_type"]
+        trigger_mode = params["sequence_parameters"]["trigger_mode"]
+        if t not in [1, 4] and sequence_type == SequenceType.TRIGGER:
+            assert trigger_mode.value == types[1]
+        elif t == -1:
+            assert trigger_mode.value is None
+        else:
+            assert trigger_mode.value == types[t]
 
     @rule(t=st.integers(0, 1))
     def change_alignment_by_enum(self, t):

--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -67,3 +67,11 @@ def test_set_get_params_channel():
         ch.disable()
     with pytest.raises(Exception):
         ch.readout_frequency(1)
+
+
+@given(delay_adj=st.integers(-300, 1300))
+def test_qa_delay(delay_adj):
+    qa = UHFQA("name", "dev1234")
+    assert 0 == qa.qa_delay()
+    with pytest.raises(Exception):
+        qa.qa_delay(delay_adj)


### PR DESCRIPTION
#### **The following changes are made in this update:**

#### **Update ´PulsedSpectroscopySequence´ class:**
##### **1) Docstring is updated:**
The docstring is changed reflect the changes made to this class
and follow the line length limit of 72.
##### **2) Header information is updated:**
The header information inserted to the top of the program is updated. It
now includes the trigger mode and alignment as well as the sequence
type. The header information is initiated as a string in the parent
class `Sequence` and written into the `sequence` attribute. The
`PulsedSpectroscopySequence` class calls the `write_sequence` method of
the parent class to get the header information. It then replaces the
string 'None' with the correct sequence type.
##### **3) `pulse_samples` attribute added:**
This attribute is specific to the child class
`PulsedSpectroscopySequence`. It is used to convert the pulse length to
the number of samples.
##### **4) `wait_samples_updated` and ` dead_samples_updated` added:**
These attributes are used to update the number of samples to wait before
and after playing each waveform. The pulse length is not taken into
account while the calculations are done in the parent class `Sequence`.
Therefore, we update these attributes in the child class
`PulsedSpectroscopySequence`. Note that how these attributes  are
updated depends on the alignment option. The update is done inside
`update_params` method after calling `super().update_params()` and
making the necessary updates to `pulse_samples` first. Outdated
variables are not being used anymore: `temp`, `wait_cycles`,
`dead_cycles`.
##### **5) `reset_phase` attribute hardcoded to be `True`:**
This sequence type requires the oscillator phase to be reset before
playing the pulse. Therefore, the user preference is ignored and
`reset_phase` attribute is set to 0 inside `update_params` method. The
related test is also updated to to respond this change.
##### **6) New commands are integrated into the sequence:**
The commands trigger_cmd_wait`, `trigger_cmd_latency`, `osc_cmd_reset`,
`readout_cmd_trigger` are now being used to generate the sequence.
Outdated commands are not being used.
##### **7) Improved explanation of the code with inline comments:**
We use `inline_comment` helper function to insert explanatory comments
to the sequencer program.

#### **Embed necessary settings for pulsed spectroscopy:**
##### **1) Implement ´_qa_delay_default´ method:**
This method is added to the `UHFQA` class because it is specific to this
instrument. It is used to automatically determine the default value of 
quantum analyzer delay depending on enabling of deskew matrix. The 
method is only for internal use.
##### **2) Implement ´qa_delay´ method:**
This method is added to the `UHFQA` class because it is specific to this
instrument. It is added to allow the user to make adjustments to quantum
analyzer delay. If no argument is passed to it, it returns the current 
value of the QA delay adjustment.
##### **3) Add `_qa_delay_user` attribute:**
This attribute holds the current value of the quantum analyzer delay 
adjustment. By default it is set to 0. It is not directly accessible to 
the user but the user can change it using the ´qa_delay´ method.
##### **4) Docstring edited:**
Docstring is updated to respect the line length limit of 72. Also one 
line of example code added to show how to use the `qa_delay` method.
##### **5) Embed the settings for pulsed spectroscopy:**
`_apply_pulsed_settings` of the device-specific AWG Core for UHFQA is 
updated to embed the necessary settings for pulsed spectroscopy into the
UHFQA driver to increase automation.