### PR TITLE
 Enable new trigger mode: ´ZSYNC_TRIGGER´

### DIFF
--- a/src/zhinst/toolkit/helpers/sequence_commands.py
+++ b/src/zhinst/toolkit/helpers/sequence_commands.py
@@ -346,6 +346,11 @@ class SequenceCommand(object):
             return f"waitDigTrigger({index}, 1);\n"
 
     @staticmethod
+    def wait_zsync_trigger():
+        """Insert waitZSyncTrigger(...) command to the sequencer."""
+        return "waitZSyncTrigger();\n"
+
+    @staticmethod
     def readout_trigger():
         """Start the Quantum Analyzer Result and Input units.
 

--- a/src/zhinst/toolkit/helpers/utils.py
+++ b/src/zhinst/toolkit/helpers/utils.py
@@ -53,6 +53,7 @@ class TriggerMode(Enum):
     EXTERNAL_TRIGGER = "External Trigger"  # deprecated
     RECEIVE_TRIGGER = "Receive Trigger"
     SEND_AND_RECEIVE_TRIGGER = "Send and Receive Trigger"
+    ZSYNC_TRIGGER = "ZSync Trigger"
 
 
 class Alignment(Enum):

--- a/tests/test_hdawg.py
+++ b/tests/test_hdawg.py
@@ -12,6 +12,8 @@ def test_init_hdawg():
     assert hd.device_type == DeviceTypes.HDAWG
     with pytest.raises(Exception):
         hd._init_settings()
+    with pytest.raises(Exception):
+        hd.enable_qccs_mode()
 
 
 def test_init_hdawg_awg():
@@ -44,4 +46,6 @@ def test_hdawg_awg_set_get():
     with pytest.raises(Exception):
         awg._apply_sequence_settings(sequence_type=SequenceType.READOUT)
     with pytest.raises(Exception):
-        awg._apply_trigger_settings()
+        awg._apply_receive_trigger_settings()
+    with pytest.raises(Exception):
+        awg._apply_zsync_trigger_settings()

--- a/tests/test_sequenceCommands.py
+++ b/tests/test_sequenceCommands.py
@@ -243,6 +243,10 @@ def test_wait_dig_trigger(i, target):
         SequenceCommand.wait_dig_trigger(i, target)
 
 
+def test_wait_zsync_trigger():
+    assert "waitZSyncTrigger" in SequenceCommand.wait_zsync_trigger()
+
+
 def test_readout_trigger():
     line = SequenceCommand.readout_trigger()
     assert "startQA" in line

--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -15,6 +15,8 @@ def test_init_uhfqa():
     assert qa.result_source is not None
     with pytest.raises(Exception):
         qa._init_settings()
+    with pytest.raises(Exception):
+        qa.enable_qccs_mode()
 
 
 def test_init_uhfqa_awg():
@@ -37,6 +39,10 @@ def test_init_uhfqa_awg():
     with pytest.raises(Exception):
         awg.set_sequence_params(sequence_type="Readout")
         awg.update_readout_params()
+    with pytest.raises(Exception):
+        awg._apply_receive_trigger_settings()
+    with pytest.raises(Exception):
+        awg._apply_zsync_trigger_settings()
 
 
 @given(st.integers(12))


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) Updated `trigger_mode` enums to add ´ZSYNC_TRIGGER´:**
This trigger mode is required when the instruments are connected via
ZSync to a PQSC.
##### **2) Updated parent class `Sequence`:**
`latency_cycles` setting and trigger commands are updated for
´ZSYNC_TRIGGER´ trigger mode. A small correction is also made to
 `CustomSequence` class to call the parent method inside `update_params`
 method, at the beginning of the method. Otherwise, `latency_cycles` is
 not updated correctly in this sequence type.
##### **3) Updated tests in `test_sequenceProgram.py`:**
 `change_trigger_by_enum` and `change_trigger_by_string`
tests are updated to include `ZSYNC_TRIGGER`.
`change_latency_adjustment` test is also updated to check
`latency_cycles` depending on the trigger mode and device type. In order
 to be able to run the tests for different device types, the
 `change_device_type` test is added, as well.
##### **4) New sequence command added `wait_zsync_trigger`:**
This command inserts waitZSyncTrigger(...) command to the sequencer. A
related test is also added in `test_sequenceCommands.py`.
##### **5) Updated UHFQA driver:**
Allowed trigger modes are checked in UHFQA driver. Added
`_apply_zsync_trigger_settings()` to embed ZSYNC trigger mode settings
to the driver to increase automation. `_apply_trigger_settings` is
renamed to `_apply_receive_trigger_settings`. Also added
`enable_qccs_mode` for configuring the DIO settings.
##### **6) Updated HDAWG driver:**
Allowed trigger modes are checked in HDAWG driver. Added
`_apply_zsync_trigger_settings()` to embed ZSYNC trigger mode settings
to the driver to increase automation. `_apply_trigger_settings` is
renamed to `_apply_receive_trigger_settings`. Also added
`enable_qccs_mode` for configuring the DIO settings. Removed the
hardcoded trigger level in HDAWG driver.
