### PR TITLE
Improve PQSC controller

### DIFF
--- a/src/zhinst/toolkit/control/connection.py
+++ b/src/zhinst/toolkit/control/connection.py
@@ -108,7 +108,10 @@ class ZIConnection:
         print(
             f"Successfully connected to device {serial.upper()} on interface {interface.upper()}"
         )
-        self._awg_module.update(device=serial, index=0)
+        # Check if device has AWG functionality and update the module
+        device_awg_nodes = self._daq.listNodes(f"{serial}/AWG*")
+        if device_awg_nodes != []:
+            self._awg_module.update(device=serial, index=0)
 
     def set(self, *args):
         """Wrapper around the `zi.ziDAQServer.set()` method of the API.

--- a/src/zhinst/toolkit/control/drivers/hdawg.py
+++ b/src/zhinst/toolkit/control/drivers/hdawg.py
@@ -58,7 +58,9 @@ class HDAWG(BaseInstrument):
 
     def __init__(self, name: str, serial: str, discovery=None, **kwargs) -> None:
         super().__init__(name, DeviceTypes.HDAWG, serial, discovery, **kwargs)
-        self._awgs = [AWG(self, i) for i in range(4)]
+        self._awgs = []
+        self.ref_clock = None
+        self.ref_clock_status = None
 
     def connect_device(self, nodetree: bool = True) -> None:
         """Connects the device to the data server and initializes the AWGs.
@@ -70,7 +72,21 @@ class HDAWG(BaseInstrument):
 
         """
         super().connect_device(nodetree=nodetree)
+        self._awgs = [AWG(self, i) for i in range(4)]
         [awg._setup() for awg in self.awgs]
+        self.ref_clock = Parameter(
+            self,
+            self._get_node_dict(f"system/clocks/referenceclock/source"),
+            device=self,
+            set_parser=Parse.set_ref_clock_w_zsync,
+            get_parser=Parse.get_ref_clock_w_zsync,
+        )
+        self.ref_clock_status = Parameter(
+            self,
+            self._get_node_dict(f"system/clocks/referenceclock/status"),
+            device=self,
+            get_parser=Parse.get_locked_status,
+        )
 
     def factory_reset(self) -> None:
         """Loads the factory default settings."""
@@ -92,10 +108,23 @@ class HDAWG(BaseInstrument):
         ]
         self._set(settings)
 
+    def enable_manual_mode(self) -> None:
+        settings = [
+            # Set internal clock to be used as reference
+            ("/system/clocks/referenceclock/source", "internal"),
+            # Configure DIO settigns to factory default values
+            # Set interface standard to use on the 32-bit DIO to LVCMOS
+            ("/dios/0/interface", 0),
+            # Enable manual control of the DIO output bits
+            ("/dios/0/mode", "manual"),
+            # Disable drive for all DIO bits
+            ("/dios/0/drive", 0b0000),
+        ]
+        self._set(settings)
+
     def _init_settings(self):
         """Sets initial device settings on startup."""
         settings = [
-            ("/system/clocks/referenceclock/source", 1),
             ("awgs/*/single", 1),
         ]
         self._set(settings)
@@ -158,75 +187,39 @@ class AWG(AWGCore):
         self._iq_modulation = False
         self.output1 = Parameter(
             self,
-            dict(
-                Node=f"sigouts/{2*self._index}/on",
-                Description="Enables or disables both ouputs of the AWG. Either can be {'1', '0'} or {'on', 'off'}.",
-                Type="Integer",
-                Properties="Read, Write",
-                Unit="None",
-            ),
+            self._parent._get_node_dict(f"sigouts/{2*self._index}/on"),
             device=self._parent,
             set_parser=Parse.set_on_off,
             get_parser=Parse.get_on_off,
         )
         self.output2 = Parameter(
             self,
-            dict(
-                Node=f"sigouts/{2*self._index+1}/on",
-                Description="Enables or disables both ouputs of the AWG. Either can be {'1', '0'} or {'on', 'off'}.",
-                Type="Integer",
-                Properties="Read, Write",
-                Unit="None",
-            ),
+            self._parent._get_node_dict(f"sigouts/{2*self._index+1}/on"),
             device=self._parent,
             set_parser=Parse.set_on_off,
             get_parser=Parse.get_on_off,
         )
         self.modulation_freq = Parameter(
             self,
-            dict(
-                Node=f"oscs/{4 * self._index}/freq",
-                Description="Sets the modulation frequency of the AWG output channels.",
-                Type="Double",
-                Properties="Read, Write",
-                Unit="Hz",
-            ),
+            self._parent._get_node_dict(f"oscs/{4 * self._index}/freq"),
             device=self._parent,
             set_parser=Parse.greater0,
         )
         self.modulation_phase_shift = Parameter(
             self,
-            dict(
-                Node=f"sines/{2 * self._index + 1}/phaseshift",
-                Description="Sets the modulation phase shift between the two AWG output channels.",
-                Type="Double",
-                Properties="Read, Write",
-                Unit="Degrees",
-            ),
+            self._parent._get_node_dict(f"sines/{2 * self._index + 1}/phaseshift"),
             device=self._parent,
             set_parser=Parse.phase,
         )
         self.gain1 = Parameter(
             self,
-            dict(
-                Node=f"awgs/{self._index}/outputs/0/gains/0",
-                Description="Sets the gain of the first output channel.",
-                Type="Double",
-                Properties="Read, Write",
-                Unit="None",
-            ),
+            self._parent._get_node_dict(f"awgs/{self._index}/outputs/0/gains/0"),
             device=self._parent,
             set_parser=Parse.amp1,
         )
         self.gain2 = Parameter(
             self,
-            dict(
-                Node=f"awgs/{self._index}/outputs/1/gains/1",
-                Description="Sets the gain of the second output channel.",
-                Type="Double",
-                Properties="Read, Write",
-                Unit="None",
-            ),
+            self._parent._get_node_dict(f"awgs/{self._index}/outputs/1/gains/1"),
             device=self._parent,
             set_parser=Parse.amp1,
         )

--- a/src/zhinst/toolkit/control/drivers/pqsc.py
+++ b/src/zhinst/toolkit/control/drivers/pqsc.py
@@ -4,9 +4,15 @@
 # of the MIT license. See the LICENSE file for details.
 
 import numpy as np
+import time
+import logging
 
 from zhinst.toolkit.control.drivers.base import BaseInstrument
 from zhinst.toolkit.interface import DeviceTypes
+from zhinst.toolkit.control.node_tree import Parameter
+from zhinst.toolkit.control.parsers import Parse
+
+_logger = logging.getLogger(__name__)
 
 
 class PQSC(BaseInstrument):
@@ -28,7 +34,126 @@ class PQSC(BaseInstrument):
 
     def __init__(self, name: str, serial: str, discovery=None, **kwargs) -> None:
         super().__init__(name, DeviceTypes.PQSC, serial, discovery, **kwargs)
+        self.ref_clock = None
+        self.ref_clock_actual = None
+        self.ref_clock_status = None
+        self.progress = None
+
+    def connect_device(self, nodetree: bool = True) -> None:
+        """Connects the device to the data server.
+
+        Keyword Arguments:
+            nodetree (bool): A flag that specifies if all the parameters from
+                the device's nodetree should be added to the object's attributes
+                as `zhinst-toolkit` Parameters. (default: True)
+
+        """
+        super().connect_device(nodetree=nodetree)
+        self.ref_clock = Parameter(
+            self,
+            self._get_node_dict(f"system/clocks/referenceclock/in/source"),
+            device=self,
+            set_parser=Parse.set_ref_clock_wo_zsync,
+            get_parser=Parse.get_ref_clock_wo_zsync,
+        )
+        self.ref_clock_actual = Parameter(
+            self,
+            self._get_node_dict(f"system/clocks/referenceclock/in/sourceactual"),
+            device=self,
+            get_parser=Parse.get_ref_clock_wo_zsync,
+        )
+        self.ref_clock_status = Parameter(
+            self,
+            self._get_node_dict(f"system/clocks/referenceclock/in/status"),
+            device=self,
+            get_parser=Parse.get_locked_status,
+        )
+        self.progress = Parameter(
+            self,
+            self._get_node_dict(f"execution/progress"),
+            device=self,
+        )
 
     def factory_reset(self) -> None:
         """Loads the factory default settings."""
         super().factory_reset()
+
+    def arm(self, repetitions=None, holdoff=None) -> None:
+        """Prepare PQSC for triggering the instruments.
+
+        This method configures the execution engine of the PQSC and
+        clears the register bank. Optionally, the *number of triggers*
+        and *hold-off time* can be set when specified as keyword
+        arguments. If they are not specified, they are not changed.
+
+        Note that the PQSC is disabled at the end of the hold-off time
+        after sending out the last trigger. Therefore, the hold-off time
+        should be long enought such that the PQSC is still enabled when
+        the feedback arrives. Otherwise, the feedback cannot be processed.
+
+        Keyword Arguments:
+            repetitions (int): If specified, the number of triggers sent
+                over ZSync ports will be set. (default: None)
+            holdoff (double): If specified, the time between repeated
+                triggers sent over ZSync ports will be set. It has a
+                minimum value and a granularity of 100 ns. (default: None)
+
+        """
+        # Stop the PQSC if it is already running
+        self._set("execution/enable", 0)
+        if repetitions is not None:
+            self._set("execution/repetitions", int(repetitions))
+        if holdoff is not None:
+            if holdoff < 100e-9:
+                raise ValueError("Hold-off time cannot be smaller than 100 ns!")
+            elif holdoff % 100e-9 > 1e-10:
+                raise ValueError("Hold-off time must be multiples of 100 ns!")
+            else:
+                self._set("execution/holdoff", holdoff)
+        # Clear register bank
+        self._set("feedback/registerbank/reset", 1)
+
+    def run(self) -> None:
+        """Start sending triggers.
+
+        This method activates the trigger generation to trigger all
+        connected instruments over ZSync ports.
+        """
+        self._set("execution/enable", 1)
+
+    def stop(self) -> None:
+        """Stops the trigger generation."""
+        self._set("execution/enable", 0)
+
+    def check_ref_clock(self, blocking=True, timeout=30) -> None:
+        """Check if reference clock is locked succesfully.
+
+        Keyword Arguments:
+            blocking (bool): A flag that specifies if the program should
+                be blocked until the reference clock is 'locked'.
+                (default: False)
+            timeout (int): Maximum time in seconds the program waits
+                when `blocking` is set to `True`. (default: 5)
+
+        """
+        ref_clock_set = self._get("system/clocks/referenceclock/in/source")
+        ref_clock_status = self._get("system/clocks/referenceclock/in/status")
+        start_time = time.time()
+        while (
+            blocking and start_time + timeout >= time.time() and ref_clock_status != 0
+        ):
+            time.sleep(1)
+            # Check again if status is 'locked' and update the variable.
+            ref_clock_status = self._get("system/clocks/referenceclock/in/status")
+        # Throw an exception if the clock is still not locked after timeout
+        ref_clock_actual = self._get("system/clocks/referenceclock/in/sourceactual")
+        if ref_clock_actual != ref_clock_set:
+            raise Exception(
+                "There was an error locking PQSC onto reference clock signal. Try again."
+            )
+        else:
+            _logger.info("Reference clock has been succesfully locked on.")
+
+    def _init_settings(self):
+        """Sets initial device settings on startup."""
+        pass

--- a/src/zhinst/toolkit/control/parsers.py
+++ b/src/zhinst/toolkit/control/parsers.py
@@ -35,6 +35,56 @@ class Parse:
         return map[v]
 
     @staticmethod
+    def set_ref_clock_wo_zsync(v):
+        if isinstance(v, str):
+            map = {"internal": 0, "external": 1}
+            if v.lower() not in map.keys():
+                raise ValueError(f"The input value must be in {map.keys()}.")
+            v = map[v.lower()]
+        elif not isinstance(v, int):
+            raise ValueError(
+                "This value must be either 'internal' or 'external' or an integer."
+            )
+        return v
+
+    @staticmethod
+    def get_ref_clock_wo_zsync(v):
+        v = int(v)
+        map = {0: "internal", 1: "external"}
+        if v not in map.keys():
+            raise ValueError("Invalid value returned from the instrument!")
+        return map[v]
+
+    @staticmethod
+    def set_ref_clock_w_zsync(v):
+        if isinstance(v, str):
+            map = {"internal": 0, "external": 1, "zsync": 2}
+            if v.lower() not in map.keys():
+                raise ValueError(f"The input value must be in {map.keys()}.")
+            v = map[v.lower()]
+        elif not isinstance(v, int):
+            raise ValueError(
+                "This value must be either 'internal', 'external', 'zsync' or an integer."
+            )
+        return v
+
+    @staticmethod
+    def get_ref_clock_w_zsync(v):
+        v = int(v)
+        map = {0: "internal", 1: "external", 2: "zsync"}
+        if v not in map.keys():
+            raise ValueError("Invalid value returned from the instrument!")
+        return map[v]
+
+    @staticmethod
+    def get_locked_status(v):
+        v = int(v)
+        map = {0: "locked", 1: "error", 2: "busy"}
+        if v not in map.keys():
+            raise ValueError("Invalid value returned from the instrument!")
+        return map[v]
+
+    @staticmethod
     def amp1(v):
         if abs(v) > 1:
             raise ValueError(f"The given value {v} must be within -1 and +1.")

--- a/tests/test_hdawg.py
+++ b/tests/test_hdawg.py
@@ -10,10 +10,22 @@ def test_init_hdawg():
     hd = HDAWG("name", "dev1234")
     assert len(hd._awgs) == 4
     assert hd.device_type == DeviceTypes.HDAWG
+    assert hd.ref_clock is None
+    assert hd.ref_clock_status is None
     with pytest.raises(Exception):
         hd._init_settings()
+
+
+def test_methods_hdawg():
+    hd = HDAWG("name", "dev1234")
+    with pytest.raises(Exception):
+        hd.connect_device()
+    with pytest.raises(Exception):
+        hd.factory_reset()
     with pytest.raises(Exception):
         hd.enable_qccs_mode()
+    with pytest.raises(Exception):
+        hd.enable_manual_mode()
 
 
 def test_init_hdawg_awg():

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -27,6 +27,68 @@ def test_get_on_off(n):
             Parse.get_on_off(n)
 
 
+@given(st.integers(0, 5))
+def test_set_ref_clock_wo_zsync(n):
+    map = {0: "internal", 1: "external", 2: "INTERNAL", 3: "EXTERNAL", 4: 0, 5: 1}
+    val = Parse.set_ref_clock_wo_zsync(map[n])
+    assert val in [0, 1]
+    with pytest.raises(ValueError):
+        Parse.set_ref_clock_wo_zsync([])
+    with pytest.raises(ValueError):
+        Parse.set_ref_clock_wo_zsync("a;kdhf")
+
+
+@given(st.integers(0, 3))
+def test_get_ref_clock_wo_zsync(n):
+    if n < 2:
+        v = Parse.get_ref_clock_wo_zsync(n)
+        assert v in ["internal", "external"]
+    else:
+        with pytest.raises(ValueError):
+            Parse.get_ref_clock_wo_zsync(n)
+
+
+@given(st.integers(0, 8))
+def test_set_ref_clock_w_zsync(n):
+    map = {
+        0: "internal",
+        1: "external",
+        2: "zsync",
+        3: "INTERNAL",
+        4: "EXTERNAL",
+        5: "ZSYNC",
+        6: 0,
+        7: 1,
+        8: 2,
+    }
+    val = Parse.set_ref_clock_w_zsync(map[n])
+    assert val in [0, 1, 2]
+    with pytest.raises(ValueError):
+        Parse.set_ref_clock_w_zsync([])
+    with pytest.raises(ValueError):
+        Parse.set_ref_clock_w_zsync("a;kdhf")
+
+
+@given(st.integers(0, 4))
+def test_get_ref_clock_w_zsync(n):
+    if n < 3:
+        v = Parse.get_ref_clock_w_zsync(n)
+        assert v in ["internal", "external", "zsync"]
+    else:
+        with pytest.raises(ValueError):
+            Parse.get_ref_clock_w_zsync(n)
+
+
+@given(st.integers(0, 4))
+def test_get_locked_status(n):
+    if n < 3:
+        v = Parse.get_locked_status(n)
+        assert v in ["locked", "error", "busy"]
+    else:
+        with pytest.raises(ValueError):
+            Parse.get_locked_status(n)
+
+
 @given(st.floats(-2, 2))
 def test_amp1(v):
     if abs(v) > 1:

--- a/tests/test_pqsc.py
+++ b/tests/test_pqsc.py
@@ -1,0 +1,31 @@
+import pytest
+from hypothesis import given, assume, strategies as st
+from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
+import numpy as np
+
+from .context import PQSC, DeviceTypes
+
+
+def test_init_pqsc():
+    pqsc = PQSC("name", "dev1234")
+    assert pqsc.device_type == DeviceTypes.PQSC
+    assert pqsc.ref_clock is None
+    assert pqsc.ref_clock_actual is None
+    assert pqsc.ref_clock_status is None
+    assert pqsc.progress is None
+
+
+def test_methods_pqsc():
+    pqsc = PQSC("name", "dev1234")
+    with pytest.raises(Exception):
+        pqsc.connect_device()
+    with pytest.raises(Exception):
+        pqsc.factory_reset()
+    with pytest.raises(Exception):
+        pqsc.arm()
+    with pytest.raises(Exception):
+        pqsc.run()
+    with pytest.raises(Exception):
+        pqsc.stop()
+    with pytest.raises(Exception):
+        pqsc.check_ref_clock()

--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -9,14 +9,36 @@ from .context import UHFQA, UHFQA_AWG, ReadoutChannel, DeviceTypes
 def test_init_uhfqa():
     qa = UHFQA("name", "dev1234")
     assert qa.device_type == DeviceTypes.UHFQA
-    assert qa._awg is not None
-    assert len(qa.channels) == 10
-    assert qa.integration_time is not None
-    assert qa.result_source is not None
+    assert qa._awg is None
+    assert len(qa.channels) == 0
+    assert qa.integration_time is None
+    assert qa.result_source is None
+    assert qa.ref_clock is None
+    assert qa._qa_delay_user is None
     with pytest.raises(Exception):
         qa._init_settings()
+
+
+def test_methods_uhfqa():
+    qa = UHFQA("name", "dev1234")
+    with pytest.raises(Exception):
+        qa.connect_device()
+    with pytest.raises(Exception):
+        qa.factory_reset()
+    with pytest.raises(Exception):
+        qa.crosstalk_matrix()
+    with pytest.raises(Exception):
+        qa.enable_readout_channels()
+    with pytest.raises(Exception):
+        qa.disable_readout_channels()
     with pytest.raises(Exception):
         qa.enable_qccs_mode()
+    with pytest.raises(Exception):
+        qa.enable_manual_mode()
+    with pytest.raises(Exception):
+        qa.arm()
+    with pytest.raises(Exception):
+        qa._qa_delay_default()
 
 
 def test_init_uhfqa_awg():


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) `connect_device` method is added:**
This method is used to connect the PQSC to the data server.
##### **2) `arm` method is added:**
This method prepares the PQSC to send out trigger signals. It first,
disables the PQSC if it is running. Then it configures the number of
triggers and the time between repeated trigger, using the optional
arguments `repetitions` and `holdoff`, respectively. Then it clears the
register bank.
##### **3) `run` and `stop` methods are added:**
These methods are used to enable and disable the PQSC.
##### **4) New parameters added to PQSC:**
`ref_clock` is used to set and get the reference clock source for the
PQSC. `ref_clock_actual` is used to get the actual reference clock
source the PQSC is configured to at that moment. Note that the actual
reference clock source can be different then the intended clock source
for a short time since it takes some time for the PQSC to lock to the
clock source. `ref_clock_status` is used to get the locking status of
the reference clock. New parsers are implemented for these parameters.
`progress` is used to get the percentage of repeated triggers sent out
so far.
##### **5) `check_ref_clock` method is added:**
This method is used to check if the reference clock is locked or not. If
the argument `blocking` is set to true, it waits until the locking is
successfully completed. The maximum amount of time to wait is specified
by the `timeout` parameter.
##### **6) HDAWG controller is updated:**
`ref_clock` and `ref_clock_status` parameters are added, similar to PQSC
driver. `enable_manual_mode` method is added to reset the HDAWG to
default settings to disable QCCS mode.
##### **7) UHFQA controller is updated:**
`ref_clock` parameter is added, similar to PQSC and HDAWG drivers.
`enable_manual_mode` method is added, similar to HDAWG driver.
##### **8) AWG node existence check added to `connection.py`:**
Inside `connect_device` method, the AWG module is updated only if the
device has AWG functionality.
##### **9) Updated tests for PQSC, HDAWG and UHFQA