### PR TITLE
Update `HDAWG` and `UHFQA` parameters

### DIFF
--- a/src/zhinst/toolkit/control/drivers/base/awg.py
+++ b/src/zhinst/toolkit/control/drivers/base/awg.py
@@ -101,6 +101,15 @@ class AWGCore:
     def _setup(self):
         self._module = self._parent._controller._connection.awg_module
 
+    def _init_awg_params(self):
+        """Initialize parameters associated with device AWG nodes.
+
+        Can be overwritten by any AWG core that inherits from the
+        :class:`AWGCore`.
+
+        """
+        pass
+
     @property
     def index(self):
         return self._index

--- a/src/zhinst/toolkit/control/drivers/base/base.py
+++ b/src/zhinst/toolkit/control/drivers/base/base.py
@@ -123,12 +123,22 @@ class BaseInstrument:
         if nodetree:
             self._nodetree = NodeTree(self)
         self._options = self._get("/features/options").split("\n")
+        self._init_params()
         self._init_settings()
 
     def factory_reset(self) -> None:
         """Loads the factory default settings."""
         self._set(f"/system/preset/load", 1)
         _logger.info(f"Factory preset is loaded to device {self.serial.upper()}.")
+
+    def _init_params(self):
+        """Initialize parameters associated with device nodes.
+
+        Can be overwritten by any instrument that inherits from the
+        :class:`BaseInstrument`.
+
+        """
+        pass
 
     def _init_settings(self):
         """Initial device settings.
@@ -249,6 +259,34 @@ class BaseInstrument:
         self._check_connected()
         return self._controller.get_nodetree(prefix, **kwargs)
 
+    def _get_node_dict(self, node: str) -> Dict:
+        """Gets the dictionary associated with the specified node.
+
+        This method uses `_get_nodetree()` to retrieve the nested
+        dictionary associated with the specified node of the device.
+        Then it extracts the value of the outer dictionary to return the
+        inner dictionary containing the keys: 'Node', 'Description',
+        'Unit', etc.
+
+        Arguments:
+            node (str): A string that specifies the node address.
+
+        Raises:
+            ToolkitError: if called and the device is not yet connected to
+                the data server or the node does not exist.
+
+        Returns:
+            The dictionary that containing the keys: 'Node',
+        'Description', 'Unit', etc.
+
+        """
+        # self._check_connected()
+        self._check_node_exists(node)
+        device_node = self.serial + "/" + node
+        nested_dict = self._get_nodetree(device_node)
+        inner_dict = list(nested_dict.values())[0]
+        return inner_dict
+
     def _get_streamingnodes(self) -> List:
         self._check_connected()
         nodes = self._controller.get_nodetree(f"/{self.serial}/*", streamingonly=True)
@@ -273,6 +311,20 @@ class BaseInstrument:
         if not self.is_connected:
             raise ToolkitError(
                 f"The device {self.name} ({self.serial}) is not connected to a Data Server! Use device.setup() to establish a data server connection."
+            )
+
+    def _check_node_exists(self, node: str):
+        """Checks if the the specified node of the device exists.
+
+        Raises:
+            ToolkitError if the node does not exist.
+
+        """
+        device_node = self.serial + "/" + node
+        if self._get_nodetree(device_node) == {}:
+            raise ToolkitError(
+                f"The device {self.name} ({self.serial}) does not have "
+                f"the node {device_node}. Please check the node address."
             )
 
     @property

--- a/src/zhinst/toolkit/control/parsers.py
+++ b/src/zhinst/toolkit/control/parsers.py
@@ -35,6 +35,56 @@ class Parse:
         return map[v]
 
     @staticmethod
+    def set_ref_clock_wo_zsync(v):
+        if isinstance(v, str):
+            map = {"internal": 0, "external": 1}
+            if v.lower() not in map.keys():
+                raise ValueError(f"The input value must be in {map.keys()}.")
+            v = map[v.lower()]
+        elif not isinstance(v, int):
+            raise ValueError(
+                "This value must be either 'internal' or 'external' or an integer."
+            )
+        return v
+
+    @staticmethod
+    def get_ref_clock_wo_zsync(v):
+        v = int(v)
+        map = {0: "internal", 1: "external"}
+        if v not in map.keys():
+            raise ValueError("Invalid value returned from the instrument!")
+        return map[v]
+
+    @staticmethod
+    def set_ref_clock_w_zsync(v):
+        if isinstance(v, str):
+            map = {"internal": 0, "external": 1, "zsync": 2}
+            if v.lower() not in map.keys():
+                raise ValueError(f"The input value must be in {map.keys()}.")
+            v = map[v.lower()]
+        elif not isinstance(v, int):
+            raise ValueError(
+                "This value must be either 'internal', 'external', 'zsync' or an integer."
+            )
+        return v
+
+    @staticmethod
+    def get_ref_clock_w_zsync(v):
+        v = int(v)
+        map = {0: "internal", 1: "external", 2: "zsync"}
+        if v not in map.keys():
+            raise ValueError("Invalid value returned from the instrument!")
+        return map[v]
+
+    @staticmethod
+    def get_locked_status(v):
+        v = int(v)
+        map = {0: "locked", 1: "error", 2: "busy"}
+        if v not in map.keys():
+            raise ValueError("Invalid value returned from the instrument!")
+        return map[v]
+
+    @staticmethod
     def amp1(v):
         if abs(v) > 1:
             raise ValueError(f"The given value {v} must be within -1 and +1.")

--- a/tests/test_baseInstrument.py
+++ b/tests/test_baseInstrument.py
@@ -54,11 +54,15 @@ def test_check_connection():
     with pytest.raises(ToolkitError):
         instr._check_connected()
     with pytest.raises(ToolkitError):
+        instr._check_node_exists("sigouts/0/on")
+    with pytest.raises(ToolkitError):
         instr.connect_device()
     with pytest.raises(ToolkitError):
         instr._get("sigouts/0/on")
     with pytest.raises(ToolkitError):
         instr._set("sigouts/0/on", 1)
+    with pytest.raises(ToolkitError):
+        instr._get_node_dict("sigouts/0/on")
 
 
 def test_serials():

--- a/tests/test_hdawg.py
+++ b/tests/test_hdawg.py
@@ -3,34 +3,74 @@ from hypothesis import given, assume, strategies as st
 from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
 import numpy as np
 
-from .context import HDAWG, HDAWG_AWG, DeviceTypes, SequenceType
+from .context import HDAWG, HDAWG_AWG, DeviceTypes, SequenceType, TriggerMode
 
 
 def test_init_hdawg():
     hd = HDAWG("name", "dev1234")
-    assert len(hd._awgs) == 4
+    assert len(hd._awgs) == 0
+    assert len(hd.awgs) == 0
     assert hd.device_type == DeviceTypes.HDAWG
+    assert hd.ref_clock is None
+    assert hd.ref_clock_status is None
+    with pytest.raises(Exception):
+        hd._init_awg_cores()
+    with pytest.raises(Exception):
+        hd._init_params()
     with pytest.raises(Exception):
         hd._init_settings()
+
+
+def test_methods_hdawg():
+    hd = HDAWG("name", "dev1234")
+    with pytest.raises(Exception):
+        hd.connect_device()
+    with pytest.raises(Exception):
+        hd.factory_reset()
     with pytest.raises(Exception):
         hd.enable_qccs_mode()
 
 
 def test_init_hdawg_awg():
     awg = HDAWG_AWG(HDAWG("name", "dev1234"), 0)
-    assert awg.output1 is not None
-    assert awg.output2 is not None
-    assert awg.gain1 is not None
-    assert awg.gain2 is not None
-    assert awg.modulation_freq is not None
-    assert awg.modulation_phase_shift is not None
-    assert awg.__repr__() != ""
+    assert awg._iq_modulation is False
+    assert awg.output1 is None
+    assert awg.output2 is None
+    assert awg.gain1 is None
+    assert awg.gain2 is None
+    assert awg.modulation_freq is None
+    assert awg.modulation_phase_shift is None
+    with pytest.raises(Exception):
+        awg._init_awg_params()
 
 
-def test_hdawg_awg_set_get():
+@given(i=st.booleans())
+def test_repr_str_hdawg_awg(i):
+    awg = HDAWG_AWG(HDAWG("name", "dev1234"), 0)
+    awg._iq_modulation = i
+    if i:
+        with pytest.raises(Exception):
+            awg.__repr__()
+    else:
+        assert "IQ Modulation DISABLED" in awg.__repr__()
+
+
+@given(
+    sequence_type=st.sampled_from(
+        [SequenceType.READOUT, SequenceType.PULSED_SPEC, SequenceType.CW_SPEC]
+    ),
+    trigger_mode=st.sampled_from(
+        [TriggerMode.ZSYNC_TRIGGER, TriggerMode.RECEIVE_TRIGGER]
+    ),
+)
+def test_hdawg_awg_set_get(sequence_type, trigger_mode):
     awg = HDAWG_AWG(HDAWG("name", "dev1234"), 0)
     with pytest.raises(Exception):
         awg.outputs(["on", "on"])
+    with pytest.raises(Exception):
+        awg.outputs(["on"])
+    with pytest.raises(Exception):
+        awg.outputs("on")
     with pytest.raises(Exception):
         awg.outputs()
     with pytest.raises(Exception):
@@ -42,9 +82,13 @@ def test_hdawg_awg_set_get():
     with pytest.raises(Exception):
         awg.disable_iq_modulation()
     with pytest.raises(Exception):
-        awg._apply_sequence_settings(sequence_type="1234")
+        awg.set_sequence_params(sequence_type="text")
     with pytest.raises(Exception):
-        awg._apply_sequence_settings(sequence_type=SequenceType.READOUT)
+        awg.set_sequence_params(sequence_type=sequence_type)
+    with pytest.raises(Exception):
+        awg.set_sequence_params(trigger_mode="text")
+    with pytest.raises(Exception):
+        awg.set_sequence_params(trigger_mode=trigger_mode)
     with pytest.raises(Exception):
         awg._apply_receive_trigger_settings()
     with pytest.raises(Exception):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -27,6 +27,68 @@ def test_get_on_off(n):
             Parse.get_on_off(n)
 
 
+@given(st.integers(0, 5))
+def test_set_ref_clock_wo_zsync(n):
+    map = {0: "internal", 1: "external", 2: "INTERNAL", 3: "EXTERNAL", 4: 0, 5: 1}
+    val = Parse.set_ref_clock_wo_zsync(map[n])
+    assert val in [0, 1]
+    with pytest.raises(ValueError):
+        Parse.set_ref_clock_wo_zsync([])
+    with pytest.raises(ValueError):
+        Parse.set_ref_clock_wo_zsync("a;kdhf")
+
+
+@given(st.integers(0, 3))
+def test_get_ref_clock_wo_zsync(n):
+    if n < 2:
+        v = Parse.get_ref_clock_wo_zsync(n)
+        assert v in ["internal", "external"]
+    else:
+        with pytest.raises(ValueError):
+            Parse.get_ref_clock_wo_zsync(n)
+
+
+@given(st.integers(0, 8))
+def test_set_ref_clock_w_zsync(n):
+    map = {
+        0: "internal",
+        1: "external",
+        2: "zsync",
+        3: "INTERNAL",
+        4: "EXTERNAL",
+        5: "ZSYNC",
+        6: 0,
+        7: 1,
+        8: 2,
+    }
+    val = Parse.set_ref_clock_w_zsync(map[n])
+    assert val in [0, 1, 2]
+    with pytest.raises(ValueError):
+        Parse.set_ref_clock_w_zsync([])
+    with pytest.raises(ValueError):
+        Parse.set_ref_clock_w_zsync("a;kdhf")
+
+
+@given(st.integers(0, 4))
+def test_get_ref_clock_w_zsync(n):
+    if n < 3:
+        v = Parse.get_ref_clock_w_zsync(n)
+        assert v in ["internal", "external", "zsync"]
+    else:
+        with pytest.raises(ValueError):
+            Parse.get_ref_clock_w_zsync(n)
+
+
+@given(st.integers(0, 4))
+def test_get_locked_status(n):
+    if n < 3:
+        v = Parse.get_locked_status(n)
+        assert v in ["locked", "error", "busy"]
+    else:
+        with pytest.raises(ValueError):
+            Parse.get_locked_status(n)
+
+
 @given(st.floats(-2, 2))
 def test_amp1(v):
     if abs(v) > 1:

--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -3,49 +3,125 @@ from hypothesis import given, assume, strategies as st
 from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
 import numpy as np
 
-from .context import UHFQA, UHFQA_AWG, ReadoutChannel, DeviceTypes
+from .context import (
+    UHFQA,
+    UHFQA_AWG,
+    ReadoutChannel,
+    DeviceTypes,
+    SequenceType,
+    TriggerMode,
+)
 
 
 def test_init_uhfqa():
     qa = UHFQA("name", "dev1234")
     assert qa.device_type == DeviceTypes.UHFQA
-    assert qa._awg is not None
-    assert len(qa.channels) == 10
-    assert qa.integration_time is not None
-    assert qa.result_source is not None
+    assert qa._awg is None
+    assert qa.awg is None
+    assert len(qa._channels) == 0
+    assert len(qa.channels) == 0
+    assert qa.integration_time is None
+    assert qa.result_source is None
+    with pytest.raises(Exception):
+        qa._init_awg_cores()
+    with pytest.raises(Exception):
+        qa._init_readout_channels()
+    with pytest.raises(Exception):
+        qa._init_params()
     with pytest.raises(Exception):
         qa._init_settings()
+
+
+def test_methods_uhfqa():
+    qa = UHFQA("name", "dev1234")
+    with pytest.raises(Exception):
+        qa.connect_device()
+    with pytest.raises(Exception):
+        qa.factory_reset()
+    with pytest.raises(Exception):
+        qa.arm()
+    with pytest.raises(Exception):
+        qa.arm(length=1024)
+    with pytest.raises(Exception):
+        qa.arm(averages=10)
     with pytest.raises(Exception):
         qa.enable_qccs_mode()
 
 
-def test_init_uhfqa_awg():
+@given(delay_adj=st.integers(-300, 1300))
+def test_qa_delay(delay_adj):
+    qa = UHFQA("name", "dev1234")
+    assert 0 == qa.qa_delay()
+    with pytest.raises(Exception):
+        qa.qa_delay(delay_adj)
+
+
+@given(rows=st.integers(1, 20), cols=st.integers(1, 20))
+def test_crosstalk_matrix(rows, cols):
+    qa = UHFQA("name", "dev1234")
+    matrix = np.random.rand(rows, cols)
+    with pytest.raises(Exception):
+        qa.crosstalk_matrix()
+    with pytest.raises(Exception):
+        qa.crosstalk_matrix(matrix)
+
+
+@given(channels=st.lists(elements=st.integers(1, 20), min_size=1, max_size=10))
+def test_enable_readout_channels(channels):
+    qa = UHFQA("name", "dev1234")
+    with pytest.raises(Exception):
+        qa.enable_readout_channels(channels)
+
+
+@given(channels=st.lists(elements=st.integers(1, 20), min_size=1, max_size=10))
+def test_disable_readout_channels(channels):
+    qa = UHFQA("name", "dev1234")
+    with pytest.raises(Exception):
+        qa.disable_readout_channels(channels)
+
+
+@given(
+    sequence_type=st.sampled_from(SequenceType),
+    trigger_mode=st.sampled_from(
+        [TriggerMode.ZSYNC_TRIGGER, TriggerMode.RECEIVE_TRIGGER]
+    ),
+)
+def test_init_uhfqa_awg(sequence_type, trigger_mode):
     awg = UHFQA_AWG(UHFQA("name", "dev1234"), 0)
-    assert awg.output1 is not None
-    assert awg.output2 is not None
-    assert awg.gain1 is not None
-    assert awg.gain2 is not None
+    assert awg.output1 is None
+    assert awg.output2 is None
+    assert awg.gain1 is None
+    assert awg.gain2 is None
     assert awg.__repr__() != ""
     with pytest.raises(Exception):
         awg.outputs(["on", "on"])
     with pytest.raises(Exception):
+        awg.outputs(["on"])
+    with pytest.raises(Exception):
+        awg.outputs("on")
+    with pytest.raises(Exception):
         awg.outputs()
     with pytest.raises(Exception):
-        awg.output1("on")
-    with pytest.raises(Exception):
-        awg.output1()
-    with pytest.raises(Exception):
         awg.update_readout_params()
     with pytest.raises(Exception):
-        awg.set_sequence_params(sequence_type="Readout")
-        awg.update_readout_params()
+        awg.compile()
+    with pytest.raises(Exception):
+        awg.set_sequence_params(sequence_type="text")
+    with pytest.raises(Exception):
+        awg.set_sequence_params(sequence_type=sequence_type)
+    with pytest.raises(Exception):
+        awg.set_sequence_params(trigger_mode="text")
+    with pytest.raises(Exception):
+        awg.set_sequence_params(trigger_mode=trigger_mode)
     with pytest.raises(Exception):
         awg._apply_receive_trigger_settings()
     with pytest.raises(Exception):
         awg._apply_zsync_trigger_settings()
+    with pytest.raises(Exception):
+        awg._init_awg_params()
 
 
-@given(st.integers(12))
+@given(i=st.integers(1, 20))
 def test_init_readout_channel(i):
     if i not in range(10):
         with pytest.raises(ValueError):
@@ -53,11 +129,14 @@ def test_init_readout_channel(i):
     else:
         ch = ReadoutChannel(UHFQA("name", "dev1234"), i)
         assert ch.index == i
-        assert ch.rotation is not None
-        assert ch.threshold is not None
-        assert ch.result is not None
+        assert ch.rotation is None
+        assert ch.threshold is None
+        assert ch.result is None
         assert not ch.enabled()
-        assert ch.__repr__() != ""
+        with pytest.raises(Exception):
+            ch.__repr__()
+    with pytest.raises(Exception):
+        ch._init_channel_params()
 
 
 def test_set_get_params_channel():
@@ -73,11 +152,25 @@ def test_set_get_params_channel():
         ch.disable()
     with pytest.raises(Exception):
         ch.readout_frequency(1)
-
-
-@given(delay_adj=st.integers(-300, 1300))
-def test_qa_delay(delay_adj):
-    qa = UHFQA("name", "dev1234")
-    assert 0 == qa.qa_delay()
     with pytest.raises(Exception):
-        qa.qa_delay(delay_adj)
+        ch._set_int_weights()
+    with pytest.raises(Exception):
+        ch._reset_int_weights()
+    with pytest.raises(Exception):
+        ch._average_result(1000)
+
+
+@given(length=st.integers(1, 5000), freq=st.floats(-1e9, 2e9), phase=st.integers(0, 90))
+def test_demod_weights(length, freq, phase):
+    ch = ReadoutChannel(UHFQA("name", "dev1234"), 0)
+    if length > 4096:
+        with pytest.raises(ValueError):
+            ch._demod_weights(length, freq, phase)
+    elif freq <= 0:
+        with pytest.raises(ValueError):
+            ch._demod_weights(length, freq, phase)
+    else:
+        clk_rate = 1.8e9
+        x = np.arange(0, length)
+        y = np.sin(2 * np.pi * freq * x / clk_rate + np.deg2rad(phase))
+        assert max(abs(y - ch._demod_weights(length, freq, phase))) < 1e-3


### PR DESCRIPTION
#### **The following changes are made in this update:**

##### **1) Add `_check_node_exists` method to `BaseInstrument` class:**
This method is only for internal use. It is used to check if the
specified node exists in the device.
##### **2) Add `_get_node_dict` method to `BaseInstrument` class:**
This method is only for internal use. It is used to retrieve the
dictionary associated with the specified node.
##### **3) Add `_init_params` method to `BaseInstrument` class:**
This method is only for internal use. It is called inside
`connect_device` method to initialize the device parameters associated
with the nodes of the device.
##### **3) Add `_init_awg_params` method to `AWGCore` class:**
This method is only for internal use. It is called inside
`_init_awg_cores` method of the `HDAWG` and `UHFQA` classes to
initialize the device AWG parameters associated with the nodes of the
device AWGs.
##### **4) Update `_init_` method of `HDAWG` class:**
AWG Core class is not called in this method anymore. The `_awgs`
attribute is initiated as an empty list instead. Two parameters added
and initiated as `None`: `ref_clock` and `ref_clock_status`
##### **5) Add `_init_params` method to `HDAWG` class:**
This method is only for internal use and it overwrites the
`_init_params` method of `BaseInstrument`. It expands the parameters
initiated in `_init_` method. `ref_clock` is used to set and get the
reference clock source for the HDAWG. `ref_clock_status` is used to get
the locking status of the reference clock. The node dictionaries
associated with these parameters are extracted from the device using
`_get_node_dict` method.
##### **6) Add `_init_awg_params` method to HDAWG `AWG` child class:**
This method is only for internal use. It is similar to `_init_params`
method of `HDAWG` class but is is a method of `AWG` child class of
`HDAWG` class. It overwrites th `_init_awg_params` method of `AWGCore`
class. It expands the parameters initiated in `_init_` method of `AWG`
child class. The node dictionaries associated with these parameters are
extracted from the device using `_get_node_dict` method.
##### **7) Add `_init_awg_cores` method to `HDAWG` class:**
This method is only for internal use and it is called inside the
`connect_device` method of the `HDAWG` class. It calls the AWG Core
class to initialize device AWG Cores and assigns them to the list
`_awgs`. Then AWG modules are initiated for each core. Then the AWG
parameters are initiated for each core using `_init_awg_params` method.
##### **8) Update `_init_` method of `UHFQA` class:**
`AWG` Core class and `ReadoutChannel` class are not called in this
method anymore. The `_awg` attribute is initiated as `None.` The
`_channels` attribute is initiated as an empty list. Other parameters
are initiated as `None`. A new parameter added: `ref_clock`. It is used
to set and get the reference clock source for the UHFQA.
##### **9) Add `_init_params` method to `UHFQA` class:**
This method is only for internal use and it overwrites the
`_init_params` method of `BaseInstrument`. It expands the parameters
initiated in `_init_` method. The node dictionaries
associated with these parameters are extracted from the device using
`_get_node_dict` method.
##### **10) Add `_init_awg_params` method to UHFQA `AWG` child class:**
This method is only for internal use. It is similar to `_init_params`
method of `UHFQA` class but is is a method of `AWG` child class of
`UHFQA` class. It overwrites th `_init_awg_params` method of `AWGCore`
class. It expands the parameters initiated in `_init_` method of `AWG`
child class. The node dictionaries associated with these parameters are
extracted from the device using `_get_node_dict` method.
##### **11) Add `_init_channel_params` method to `ReadoutChannel`:**
This method is only for internal use. It is similar to `_init_params`
method of `UHFQA` class but is is a method of `ReadoutChannel` child
class of `UHFQA` class. It expands the parameters initiated in `_init_`
method of `ReadoutChannel` child class. The node dictionaries associated
with these parameters are extracted from the device using
`_get_node_dict` method.
##### **12) Add `_init_awg_cores` method to `UHFQA` class:**
This method is only for internal use and it is called inside the
`connect_device` method of the `UHFQA` class. It calls the AWG Core
class to initialize device AWG Core and assigns it to the attribute
`_awg`. Then AWG module and AWG parameters are initiated using `_setup`
and `_init_awg_params` methods, respectively.
##### **13) Add `_init_readout_channels` method to `UHFQA` class:**
This method is only for internal use and it is called inside the
`connect_device` method of the `UHFQA` class. It calls the
`ReadoutChannel` class to initialize device readout channels and assigns
them to the list `_channels`. Then readout channel parameters are
initiated using `_init_channel_params`method for each channel.
##### **14) New parsers added for new parameters.**
##### **15) Tests for drivers are updated.**