### PR TITLE
Improve PQSC controller

### DIFF
--- a/src/zhinst/toolkit/control/connection.py
+++ b/src/zhinst/toolkit/control/connection.py
@@ -108,7 +108,10 @@ class ZIConnection:
         print(
             f"Successfully connected to device {serial.upper()} on interface {interface.upper()}"
         )
-        self._awg_module.update(device=serial, index=0)
+        # Check if device has AWG functionality and update the module
+        device_awg_nodes = self._daq.listNodes(f"{serial}/AWG*")
+        if device_awg_nodes != []:
+            self._awg_module.update(device=serial, index=0)
 
     def set(self, *args):
         """Wrapper around the `zi.ziDAQServer.set()` method of the API.

--- a/src/zhinst/toolkit/control/drivers/hdawg.py
+++ b/src/zhinst/toolkit/control/drivers/hdawg.py
@@ -94,6 +94,20 @@ class HDAWG(BaseInstrument):
         ]
         self._set(settings)
 
+    def enable_manual_mode(self) -> None:
+        settings = [
+            # Set internal clock to be used as reference
+            ("/system/clocks/referenceclock/source", "internal"),
+            # Configure DIO settigns to factory default values
+            # Set interface standard to use on the 32-bit DIO to LVCMOS
+            ("/dios/0/interface", 0),
+            # Enable manual control of the DIO output bits
+            ("/dios/0/mode", "manual"),
+            # Disable drive for all DIO bits
+            ("/dios/0/drive", 0b0000),
+        ]
+        self._set(settings)
+
     def _init_awg_cores(self):
         """Initialize the AWGs cores of the device."""
         self._awgs = [AWG(self, i) for i in range(4)]

--- a/src/zhinst/toolkit/control/drivers/pqsc.py
+++ b/src/zhinst/toolkit/control/drivers/pqsc.py
@@ -4,9 +4,15 @@
 # of the MIT license. See the LICENSE file for details.
 
 import numpy as np
+import time
+import logging
 
 from zhinst.toolkit.control.drivers.base import BaseInstrument
 from zhinst.toolkit.interface import DeviceTypes
+from zhinst.toolkit.control.node_tree import Parameter
+from zhinst.toolkit.control.parsers import Parse
+
+_logger = logging.getLogger(__name__)
 
 
 class PQSC(BaseInstrument):
@@ -28,7 +34,129 @@ class PQSC(BaseInstrument):
 
     def __init__(self, name: str, serial: str, discovery=None, **kwargs) -> None:
         super().__init__(name, DeviceTypes.PQSC, serial, discovery, **kwargs)
+        self.ref_clock = None
+        self.ref_clock_actual = None
+        self.ref_clock_status = None
+        self.progress = None
+
+    def connect_device(self, nodetree: bool = True) -> None:
+        """Connects the device to the data server.
+
+        Keyword Arguments:
+            nodetree (bool): A flag that specifies if all the parameters from
+                the device's nodetree should be added to the object's attributes
+                as `zhinst-toolkit` Parameters. (default: True)
+
+        """
+        super().connect_device(nodetree=nodetree)
 
     def factory_reset(self) -> None:
         """Loads the factory default settings."""
         super().factory_reset()
+
+    def arm(self, repetitions=None, holdoff=None) -> None:
+        """Prepare PQSC for triggering the instruments.
+
+        This method configures the execution engine of the PQSC and
+        clears the register bank. Optionally, the *number of triggers*
+        and *hold-off time* can be set when specified as keyword
+        arguments. If they are not specified, they are not changed.
+
+        Note that the PQSC is disabled at the end of the hold-off time
+        after sending out the last trigger. Therefore, the hold-off time
+        should be long enought such that the PQSC is still enabled when
+        the feedback arrives. Otherwise, the feedback cannot be processed.
+
+        Keyword Arguments:
+            repetitions (int): If specified, the number of triggers sent
+                over ZSync ports will be set. (default: None)
+            holdoff (double): If specified, the time between repeated
+                triggers sent over ZSync ports will be set. It has a
+                minimum value and a granularity of 100 ns. (default: None)
+
+        """
+        # Stop the PQSC if it is already running
+        self._set("execution/enable", 0)
+        if repetitions is not None:
+            self._set("execution/repetitions", int(repetitions))
+        if holdoff is not None:
+            if holdoff < 100e-9:
+                raise ValueError("Hold-off time cannot be smaller than 100 ns!")
+            elif holdoff % 100e-9 > 1e-10:
+                raise ValueError("Hold-off time must be multiples of 100 ns!")
+            else:
+                self._set("execution/holdoff", holdoff)
+        # Clear register bank
+        self._set("feedback/registerbank/reset", 1)
+
+    def run(self) -> None:
+        """Start sending triggers.
+
+        This method activates the trigger generation to trigger all
+        connected instruments over ZSync ports.
+        """
+        self._set("execution/enable", 1)
+
+    def stop(self) -> None:
+        """Stops the trigger generation."""
+        self._set("execution/enable", 0)
+
+    def check_ref_clock(self, blocking=True, timeout=30) -> None:
+        """Check if reference clock is locked succesfully.
+
+        Keyword Arguments:
+            blocking (bool): A flag that specifies if the program should
+                be blocked until the reference clock is 'locked'.
+                (default: False)
+            timeout (int): Maximum time in seconds the program waits
+                when `blocking` is set to `True`. (default: 5)
+
+        """
+        ref_clock_set = self._get("system/clocks/referenceclock/in/source")
+        ref_clock_status = self._get("system/clocks/referenceclock/in/status")
+        start_time = time.time()
+        while (
+            blocking and start_time + timeout >= time.time() and ref_clock_status != 0
+        ):
+            time.sleep(1)
+            # Check again if status is 'locked' and update the variable.
+            ref_clock_status = self._get("system/clocks/referenceclock/in/status")
+        # Throw an exception if the clock is still not locked after timeout
+        ref_clock_actual = self._get("system/clocks/referenceclock/in/sourceactual")
+        if ref_clock_actual != ref_clock_set:
+            raise Exception(
+                "There was an error locking PQSC onto reference clock signal. Try again."
+            )
+        else:
+            _logger.info("Reference clock has been succesfully locked on.")
+
+    def _init_settings(self):
+        """Sets initial device settings on startup."""
+        pass
+
+    def _init_params(self):
+        """Initialize parameters associated with device nodes."""
+        self.ref_clock = Parameter(
+            self,
+            self._get_node_dict(f"system/clocks/referenceclock/in/source"),
+            device=self,
+            set_parser=Parse.set_ref_clock_wo_zsync,
+            get_parser=Parse.get_ref_clock_wo_zsync,
+        )
+        self.ref_clock_actual = Parameter(
+            self,
+            self._get_node_dict(f"system/clocks/referenceclock/in/sourceactual"),
+            device=self,
+            get_parser=Parse.get_ref_clock_wo_zsync,
+        )
+        self.ref_clock_status = Parameter(
+            self,
+            self._get_node_dict(f"system/clocks/referenceclock/in/status"),
+            device=self,
+            get_parser=Parse.get_locked_status,
+        )
+        self.progress = Parameter(
+            self,
+            self._get_node_dict(f"execution/progress"),
+            device=self,
+        )

--- a/src/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/src/zhinst/toolkit/control/drivers/uhfqa.py
@@ -211,6 +211,20 @@ class UHFQA(BaseInstrument):
         ]
         self._set(settings)
 
+    def enable_manual_mode(self) -> None:
+        settings = [
+            # Use internal clock as reference
+            ("/system/extclk", "internal"),
+            # Configure DIO settigns to factory default values
+            # Clock DIO internally with a frequency of 56.25 MHz
+            ("/dios/0/extclk", 0),
+            # Enable manual control of the DIO output bits
+            ("/dios/0/mode", "manual"),
+            # Disable drive for all DIO bits
+            ("/dios/0/drive", 0b0000),
+        ]
+        self._set(settings)
+
     def arm(self, length=None, averages=None) -> None:
         """Prepare UHFQA for result acquisition.
 

--- a/tests/test_hdawg.py
+++ b/tests/test_hdawg.py
@@ -29,6 +29,8 @@ def test_methods_hdawg():
         hd.factory_reset()
     with pytest.raises(Exception):
         hd.enable_qccs_mode()
+    with pytest.raises(Exception):
+        hd.enable_manual_mode()
 
 
 def test_init_hdawg_awg():

--- a/tests/test_pqsc.py
+++ b/tests/test_pqsc.py
@@ -1,0 +1,33 @@
+import pytest
+from hypothesis import given, assume, strategies as st
+from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
+import numpy as np
+
+from .context import PQSC, DeviceTypes
+
+
+def test_init_pqsc():
+    pqsc = PQSC("name", "dev1234")
+    assert pqsc.device_type == DeviceTypes.PQSC
+    assert pqsc.ref_clock is None
+    assert pqsc.ref_clock_actual is None
+    assert pqsc.ref_clock_status is None
+    assert pqsc.progress is None
+    with pytest.raises(Exception):
+        pqsc._init_params()
+
+
+def test_methods_pqsc():
+    pqsc = PQSC("name", "dev1234")
+    with pytest.raises(Exception):
+        pqsc.connect_device()
+    with pytest.raises(Exception):
+        pqsc.factory_reset()
+    with pytest.raises(Exception):
+        pqsc.arm()
+    with pytest.raises(Exception):
+        pqsc.run()
+    with pytest.raises(Exception):
+        pqsc.stop()
+    with pytest.raises(Exception):
+        pqsc.check_ref_clock()

--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -46,6 +46,8 @@ def test_methods_uhfqa():
         qa.arm(averages=10)
     with pytest.raises(Exception):
         qa.enable_qccs_mode()
+    with pytest.raises(Exception):
+        qa.enable_manual_mode()
 
 
 @given(delay_adj=st.integers(-300, 1300))


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) `connect_device` method is added:**
This method is used to connect the PQSC to the data server.
##### **2) `arm` method is added:**
This method prepares the PQSC to send out trigger signals. It first,
disables the PQSC if it is running. Then it configures the number of
triggers and the time between repeated trigger, using the optional
arguments `repetitions` and `holdoff`, respectively. Then it clears the
register bank.
##### **3) `run` and `stop` methods are added:**
These methods are used to enable and disable the PQSC.
##### **4) New parameters added to PQSC:**
`ref_clock` is used to set and get the reference clock source for the
PQSC. `ref_clock_actual` is used to get the actual reference clock
source the PQSC is configured to at that moment. Note that the actual
reference clock source can be different then the intended clock source
for a short time since it takes some time for the PQSC to lock to the
clock source. `ref_clock_status` is used to get the locking status of
the reference clock. New parsers are implemented for these parameters.
`progress` is used to get the percentage of repeated triggers sent out
so far.
##### **5) `check_ref_clock` method is added:**
This method is used to check if the reference clock is locked or not. If
the argument `blocking` is set to true, it waits until the locking is
successfully completed. The maximum amount of time to wait is specified
by the `timeout` parameter.
##### **6) HDAWG and UHFQA controllers updated:**
`enable_manual_mode` method is added to both drivers to reset them to
default settings to disable QCCS mode.
##### **7) AWG node existence check added to `connection.py`:**
Inside `connect_device` method, the AWG module is updated only if the
device has AWG functionality.
##### **8) Updated tests for PQSC, HDAWG and UHFQA
