### PR TITLE
Update parameters

### DIFF
--- a/src/zhinst/toolkit/control/parsers.py
+++ b/src/zhinst/toolkit/control/parsers.py
@@ -4,12 +4,34 @@
 # of the MIT license. See the LICENSE file for details.
 
 import numpy as np
+import logging
+import traceback
 
 UHFQA_SAMPLE_RATE = 1.8e9
+logging.basicConfig(format="%(levelname)s: %(message)s")
+_logger = logging.getLogger(__name__)
 
 
 class Parse:
     """Input and output parsers for Parameters to validate and parse values."""
+
+    # Define a function to return the parameter name
+    @staticmethod
+    def _parameter_name():
+        frame_list = traceback.StackSummary.extract(traceback.walk_stack(None))
+        for frame in frame_list:
+            if frame.name == "<module>":
+                return frame.line
+
+    # Define a function to format the value string
+    @staticmethod
+    def _format_number(n):
+        if abs(n) > 1e4 or abs(n) < 1e-4:
+            # Use scientific notation for
+            # very large and very small numbers
+            return "{:.3e}".format(n)
+        else:
+            return n
 
     @staticmethod
     def none(v):
@@ -35,48 +57,6 @@ class Parse:
         return map[v]
 
     @staticmethod
-    def set_ref_clock_wo_zsync(v):
-        if isinstance(v, str):
-            map = {"internal": 0, "external": 1}
-            if v.lower() not in map.keys():
-                raise ValueError(f"The input value must be in {map.keys()}.")
-            v = map[v.lower()]
-        elif not isinstance(v, int):
-            raise ValueError(
-                "This value must be either 'internal' or 'external' or an integer."
-            )
-        return v
-
-    @staticmethod
-    def get_ref_clock_wo_zsync(v):
-        v = int(v)
-        map = {0: "internal", 1: "external"}
-        if v not in map.keys():
-            raise ValueError("Invalid value returned from the instrument!")
-        return map[v]
-
-    @staticmethod
-    def set_ref_clock_w_zsync(v):
-        if isinstance(v, str):
-            map = {"internal": 0, "external": 1, "zsync": 2}
-            if v.lower() not in map.keys():
-                raise ValueError(f"The input value must be in {map.keys()}.")
-            v = map[v.lower()]
-        elif not isinstance(v, int):
-            raise ValueError(
-                "This value must be either 'internal', 'external', 'zsync' or an integer."
-            )
-        return v
-
-    @staticmethod
-    def get_ref_clock_w_zsync(v):
-        v = int(v)
-        map = {0: "internal", 1: "external", 2: "zsync"}
-        if v not in map.keys():
-            raise ValueError("Invalid value returned from the instrument!")
-        return map[v]
-
-    @staticmethod
     def get_locked_status(v):
         v = int(v)
         map = {0: "locked", 1: "error", 2: "busy"}
@@ -85,26 +65,69 @@ class Parse:
         return map[v]
 
     @staticmethod
-    def amp1(v):
-        if abs(v) > 1:
-            raise ValueError(f"The given value {v} must be within -1 and +1.")
-        return v
-
-    @staticmethod
-    def abs90(v):
-        if abs(v) >= 90:
-            raise ValueError(f"The given value {v} must be within -90 to +90.")
-        return v
-
-    @staticmethod
     def phase(v):
         return (v + 180) % 360 - 180
 
     @staticmethod
-    def greater0(v):
-        if v <= 0:
-            raise ValueError("This value must be positive!")
+    def greater(v, limit):
+        if v <= limit:
+            raise ValueError(f"This value must be greater than {limit}!")
         return v
+
+    @staticmethod
+    def greater_equal(v, limit):
+        if v < limit:
+            _logger.warning(
+                f"{Parse._parameter_name()}\n"
+                f"The value {Parse._format_number(v)} must be greater than or equal to "
+                f"{Parse._format_number(limit)} and will be rounded up to: "
+                f"{Parse._format_number(limit)}",
+            )
+            return limit
+        else:
+            return v
+
+    @staticmethod
+    def smaller(v, limit):
+        if v >= limit:
+            raise ValueError(f"This value must be smaller than {limit}!")
+        return v
+
+    @staticmethod
+    def smaller_equal(v, limit):
+        if v > limit:
+            _logger.warning(
+                f"{Parse._parameter_name()}\n"
+                f"The value {Parse._format_number(v)} must be smaller than or equal to "
+                f"{Parse._format_number(limit)} and will be rounded down to: "
+                f"{Parse._format_number(limit)}",
+            )
+            return limit
+        else:
+            return v
+
+    @staticmethod
+    def multiple_of(v, factor, rounding):
+        if abs(round(v / factor) * factor - v) < 1e-12:
+            return v
+        elif rounding == "nearest":
+            v_rounded = round(v / factor) * factor
+            _logger.warning(
+                f"{Parse._parameter_name()}\n"
+                f"The value {Parse._format_number(v)} is not a multiple of "
+                f"{Parse._format_number(factor)} and will be rounded to nearest "
+                f"multiple: {Parse._format_number(v_rounded)}",
+            )
+            return v_rounded
+        elif rounding == "down":
+            v_rounded = round(v // factor) * factor
+            _logger.warning(
+                f"{Parse._parameter_name()}\n"
+                f"The value {Parse._format_number(v)} is not a multiple of "
+                f"{Parse._format_number(factor)} and will be rounded down to greatest "
+                f"multiple: {Parse._format_number(v_rounded)}",
+            )
+            return v_rounded
 
     @staticmethod
     def deg2complex(v):
@@ -116,10 +139,14 @@ class Parse:
 
     @staticmethod
     def uhfqa_time2samples(v):
-        Parse.greater0(v)
-        return int(round(v * UHFQA_SAMPLE_RATE))
+        min_samples = 4
+        multiplicity_samples = 4
+        min_time = min_samples / UHFQA_SAMPLE_RATE
+        multiplicity_time = multiplicity_samples / UHFQA_SAMPLE_RATE
+        v_rounded = Parse.greater_equal(v, min_time)
+        v_rounded = Parse.multiple_of(v_rounded, multiplicity_time, "down")
+        return int(round(v_rounded * UHFQA_SAMPLE_RATE))
 
     @staticmethod
     def uhfqa_samples2time(v):
-        Parse.greater0(v)
         return v / UHFQA_SAMPLE_RATE

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -27,58 +27,6 @@ def test_get_on_off(n):
             Parse.get_on_off(n)
 
 
-@given(st.integers(0, 5))
-def test_set_ref_clock_wo_zsync(n):
-    map = {0: "internal", 1: "external", 2: "INTERNAL", 3: "EXTERNAL", 4: 0, 5: 1}
-    val = Parse.set_ref_clock_wo_zsync(map[n])
-    assert val in [0, 1]
-    with pytest.raises(ValueError):
-        Parse.set_ref_clock_wo_zsync([])
-    with pytest.raises(ValueError):
-        Parse.set_ref_clock_wo_zsync("a;kdhf")
-
-
-@given(st.integers(0, 3))
-def test_get_ref_clock_wo_zsync(n):
-    if n < 2:
-        v = Parse.get_ref_clock_wo_zsync(n)
-        assert v in ["internal", "external"]
-    else:
-        with pytest.raises(ValueError):
-            Parse.get_ref_clock_wo_zsync(n)
-
-
-@given(st.integers(0, 8))
-def test_set_ref_clock_w_zsync(n):
-    map = {
-        0: "internal",
-        1: "external",
-        2: "zsync",
-        3: "INTERNAL",
-        4: "EXTERNAL",
-        5: "ZSYNC",
-        6: 0,
-        7: 1,
-        8: 2,
-    }
-    val = Parse.set_ref_clock_w_zsync(map[n])
-    assert val in [0, 1, 2]
-    with pytest.raises(ValueError):
-        Parse.set_ref_clock_w_zsync([])
-    with pytest.raises(ValueError):
-        Parse.set_ref_clock_w_zsync("a;kdhf")
-
-
-@given(st.integers(0, 4))
-def test_get_ref_clock_w_zsync(n):
-    if n < 3:
-        v = Parse.get_ref_clock_w_zsync(n)
-        assert v in ["internal", "external", "zsync"]
-    else:
-        with pytest.raises(ValueError):
-            Parse.get_ref_clock_w_zsync(n)
-
-
 @given(st.integers(0, 4))
 def test_get_locked_status(n):
     if n < 3:
@@ -87,33 +35,6 @@ def test_get_locked_status(n):
     else:
         with pytest.raises(ValueError):
             Parse.get_locked_status(n)
-
-
-@given(st.floats(-2, 2))
-def test_amp1(v):
-    if abs(v) > 1:
-        with pytest.raises(ValueError):
-            Parse.amp1(v)
-    else:
-        assert abs(Parse.amp1(v)) <= 1
-
-
-@given(st.integers(-180, 180))
-def test_abs90(v):
-    if abs(v) >= 90:
-        with pytest.raises(ValueError):
-            Parse.abs90(v)
-    else:
-        assert abs(Parse.abs90(v)) < 90
-
-
-@given(st.floats(-1, 1))
-def test_greater0(v):
-    if v <= 0:
-        with pytest.raises(ValueError):
-            Parse.greater0(v)
-    else:
-        assert Parse.greater0(v) > 0
 
 
 @given(st.floats(0.0001, 1.0))


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) `Parameter` class in `node_tree.py` is updated:**
* A new input is added: `auto_mapping`. This setting specifies whether
an automatic mapping should be constructed from the allowed options
information obtained from the device. A private function
`_construct_auto_mapping` is added to construct the mapping. Note that,
automatic mapping construction only happens if no manual mapping is
specified in the parameter settings.
* `_getter` and `_setter` functions are updated to work with mappings
which have several values assigned to the same key. This can be the case
when mapping is automatically generated from the options of the node.
New helper functions `_invert_mapping` and `_flatten_mapping_values` are
added for `_getter` and `_setter`. Also the `_setter` function is
updated to deal with list of set_parser functions as well as single
set_parser function.
* `_reformat_options_dict` method is added to insert new line characters
between each allowed value in options so that it the options are
displayed in a more human readable format in the docstring.
##### **2) `Parse` class in `parsers.py` is updated:**
Some of the parsers used for mapping are removed because the mapping is
now automatically constructed from node options. The parsers `greater0`,
`amp1` and `abs90` are removed since they were too specific. More
general parsers are added: `greater`, `greater_equal`, `smaller`,
`smaller_equal`, `multiple_of`. The parsers `uhfqa_time2samples` and
`uhfqa_samples2time` are updated with the new added parsers.
##### **3) UHFQA driver updates:**
The parameter `integration_time` is updated to correct its description.
A new parameter `integration_length` is added. Docstring is updated.
##### **4) HDAWG driver updates:**
Docstring is updated.
##### **5) PQSC driver updates:**
The content of `check_ref_clock` function is moved to `BaseInstrument`
class and made private. This private function is called inside the
device specific drivers if the device supports it. Currently only PQSC
and SHFQA support this function. Docstring is updated.