### PR TITLE
Update PQSC, HDAWG and UHFQA drivers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ attrs
 pytest
 hypothesis
 deprecation
+jsonschema

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ requirements = [
     "zhinst>=20.01",
     "attrs",
     "deprecation>=2.1.0",
+    "jsonschema>=3.2.0",
 ]
 
 

--- a/src/zhinst/toolkit/control/drivers/base/__init__.py
+++ b/src/zhinst/toolkit/control/drivers/base/__init__.py
@@ -5,4 +5,5 @@ from .shf_scope import SHFScope
 from .shf_sweeper import SHFSweeper
 from .daq import DAQModule
 from .sweeper import SweeperModule
+from .ct import CommandTable
 from .base import BaseInstrument, ToolkitError

--- a/src/zhinst/toolkit/control/drivers/base/ct.py
+++ b/src/zhinst/toolkit/control/drivers/base/ct.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2021 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
+import json
+import urllib
+import jsonschema
+
+from .base import ToolkitError
+from .awg import AWGCore
+
+
+class CommandTable:
+    """Implement a CommandTable representation.
+
+    The :class:`CommandTable` class implements the basic functionality
+    of the command table allowing the user to write and upload their
+    own command table.
+
+    """
+
+    def __init__(self, parent: AWGCore, ct_schema_url: str) -> None:
+        self._parent = parent
+        self._index = self._parent._index
+        self._device = self._parent._parent
+        self._ct_schema_url = ct_schema_url
+
+    def load(self, table):
+        """Load a given command table to the instrument"""
+        # Check if the input is a valid JSON
+        table_updated = self._validate(table)
+        # Convert the json object
+        # Load the command table to the device
+        node = f"awgs/{self._index}/commandtable/data"
+        self._device._setVector(node, json.dumps(table_updated))
+
+    def _validate(self, table):
+        """ Ensure command table is valid JSON and compliant with schema"""
+        # Validation only works if the command table is in dictionary
+        # format (json object). Make the encessary conversion
+        table_updated = self._to_dict(table)
+        with urllib.request.urlopen(self._ct_schema_url) as f:
+            ct_schema_str = f.read().decode()
+        ct_schema_dict = json.loads(ct_schema_str)
+        jsonschema.validate(
+            table_updated, schema=ct_schema_dict, cls=jsonschema.Draft4Validator
+        )
+        return table_updated
+
+    def _to_dict(self, table):
+        """Check the input type and convert it to json object (dict)"""
+        if isinstance(table, str):
+            table_updated = json.loads(table)
+        elif isinstance(table, list):
+            table_updated = {
+                "$schema": "http://docs.zhinst.com/hdawg/commandtable/v2/schema",
+                "header": {"version": "0.2", "partial": False},
+                "table": table,
+            }
+        elif isinstance(table, dict):
+            table_updated = table
+        else:
+            raise ToolkitError(
+                "The command table should be specified as either a string, or a list "
+                "of entries without a header, or a valid json as a dictionary."
+            )
+        return table_updated

--- a/tests/test_awg.py
+++ b/tests/test_awg.py
@@ -19,7 +19,7 @@ def test_init_awg(i, j):
     assert awg._parent == instr
     assert awg._index == i
     assert awg.waveforms == []
-    assert awg.name == f"name-{i}"
+    assert awg.name == f"name-awg-{i}"
     assert awg._program is not None
     params = awg.sequence_params["sequence_parameters"]
     if j == 0:

--- a/tests/test_hdawg.py
+++ b/tests/test_hdawg.py
@@ -17,8 +17,7 @@ def test_init_hdawg():
         hd._init_awg_cores()
     with pytest.raises(Exception):
         hd._init_params()
-    with pytest.raises(Exception):
-        hd._init_settings()
+    hd._init_settings()
 
 
 def test_methods_hdawg():

--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -167,12 +167,12 @@ def test_demod_weights(length, freq, phase):
     ch = ReadoutChannel(UHFQA("name", "dev1234"), 0)
     if length > 4096:
         with pytest.raises(ValueError):
-            ch._demod_weights(length, freq, phase)
+            ch._demod_weights(length, 1.0, freq, phase)
     elif freq <= 0:
         with pytest.raises(ValueError):
-            ch._demod_weights(length, freq, phase)
+            ch._demod_weights(length, 1.0, freq, phase)
     else:
         clk_rate = 1.8e9
         x = np.arange(0, length)
         y = np.sin(2 * np.pi * freq * x / clk_rate + np.deg2rad(phase))
-        assert max(abs(y - ch._demod_weights(length, freq, phase))) < 1e-3
+        assert max(abs(y - ch._demod_weights(length, 1.0, freq, phase))) < 1e-3


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) An interface for command table is added to HDAWG driver:**
This interface allows users to upload their command table to the device
##### **2) `single` parameter is added to HDAWG and UHFQA AWG:**
This parameter specifies if rerun is enabled or not in the AWG.
##### **3) `check_zsync_connection` method is added to PQSC driver:**
This method checks if the ZSync connection on the given port is
successful or not.
##### **4) `factory_reset` method of UHFQA is updated:**
This method now enables the single mode of AWG and reset the QA delay to
its default value. Setting these manually is necessary because
these settings are not done automatically at power on or after loading
the factory preset to the device.
##### **5) `int_weights_envelope` method is added to UHFQA:**
This method is used to take a list of envelope values to multiply with
the integration weights. `_set_int_weights` and `_demod_weights` are
updated to calculate the integration weights based on the
`int_weights_envelope`.
##### **6) `compile` method of AWG is updated :**
This method is updated to add `logging.warning` and `logging.error`
depending on the compiler status. These logger messages guides the user
better for solving the issues with the seqc program. Also, it is now
possible to upload waveforms in `Custom` sequence type.