### PR TITLE
Fix bugs

### DIFF
--- a/src/zhinst/toolkit/control/drivers/base/base.py
+++ b/src/zhinst/toolkit/control/drivers/base/base.py
@@ -12,6 +12,9 @@ import zhinst.ziPython as zi
 from zhinst.toolkit.control.connection import DeviceConnection, ZIConnection
 from zhinst.toolkit.control.node_tree import NodeTree
 from zhinst.toolkit.interface import InstrumentConfiguration, DeviceTypes
+from zhinst.toolkit.control.node_tree import Parameter
+from zhinst.toolkit.control.parsers import Parse
+
 
 _logger = logging.getLogger(__name__)
 
@@ -174,7 +177,22 @@ class BaseInstrument:
         :class:`BaseInstrument`.
 
         """
-        pass
+        self.data_server_version = Parameter(
+            self,
+            self._get_node_dict(f"/zi/about/revision"),
+            device=self,
+            get_parser=Parse.version_parser,
+        )
+        self.firmware_version = Parameter(
+            self,
+            self._get_node_dict(f"/system/fwrevision"),
+            device=self,
+        )
+        self.fpga_version = Parameter(
+            self,
+            self._get_node_dict(f"/system/fpgarevision"),
+            device=self,
+        )
 
     def _init_settings(self):
         """Initial device settings.
@@ -352,9 +370,8 @@ class BaseInstrument:
         'Description', 'Unit', etc.
 
         """
-        # self._check_connected()
-        self._check_node_exists(node)
-        device_node = self.serial + "/" + node
+        device_node = self._controller._command_to_node(node)
+        self._check_node_exists(device_node)
         nested_dict = self._get_nodetree(device_node)
         inner_dict = list(nested_dict.values())[0]
         return inner_dict
@@ -385,14 +402,13 @@ class BaseInstrument:
                 f"The device {self.name} ({self.serial}) is not connected to a Data Server! Use device.setup() to establish a data server connection."
             )
 
-    def _check_node_exists(self, node: str):
+    def _check_node_exists(self, device_node: str):
         """Checks if the the specified node of the device exists.
 
         Raises:
             ToolkitError if the node does not exist.
 
         """
-        device_node = self.serial + "/" + node
         if self._get_nodetree(device_node) == {}:
             raise ToolkitError(
                 f"The device {self.name} ({self.serial}) does not have "

--- a/src/zhinst/toolkit/control/drivers/hdawg.py
+++ b/src/zhinst/toolkit/control/drivers/hdawg.py
@@ -132,6 +132,7 @@ class HDAWG(BaseInstrument):
 
     def _init_params(self):
         """Initialize parameters associated with device nodes."""
+        super()._init_params()
         self.ref_clock = Parameter(
             self,
             self._get_node_dict(f"system/clocks/referenceclock/source"),
@@ -212,6 +213,13 @@ class AWG(AWGCore):
         self.modulation_phase_shift = None
         self.gain1 = None
         self.gain2 = None
+        self.single = None
+        self.zsync_register_mask = None
+        self.zsync_register_shift = None
+        self.zsync_register_offset = None
+        self.zsync_decoder_mask = None
+        self.zsync_decoder_shift = None
+        self.zsync_decoder_offset = None
 
     def _init_awg_params(self):
         self.output1 = Parameter(
@@ -264,6 +272,60 @@ class AWG(AWGCore):
             device=self._parent,
             set_parser=Parse.set_true_false,
             get_parser=Parse.get_true_false,
+        )
+        self.zsync_register_mask = Parameter(
+            self,
+            self._parent._get_node_dict(f"awgs/{self._index}/zsync/register/mask"),
+            device=self._parent,
+            set_parser=[
+                lambda v: Parse.smaller_equal(v, 15),
+                lambda v: Parse.greater_equal(v, 0),
+            ],
+        )
+        self.zsync_register_shift = Parameter(
+            self,
+            self._parent._get_node_dict(f"awgs/{self._index}/zsync/register/shift"),
+            device=self._parent,
+            set_parser=[
+                lambda v: Parse.smaller_equal(v, 3),
+                lambda v: Parse.greater_equal(v, 0),
+            ],
+        )
+        self.zsync_register_offset = Parameter(
+            self,
+            self._parent._get_node_dict(f"awgs/{self._index}/zsync/register/offset"),
+            device=self._parent,
+            set_parser=[
+                lambda v: Parse.smaller_equal(v, 1023),
+                lambda v: Parse.greater_equal(v, 0),
+            ],
+        )
+        self.zsync_decoder_mask = Parameter(
+            self,
+            self._parent._get_node_dict(f"awgs/{self._index}/zsync/decoder/mask"),
+            device=self._parent,
+            set_parser=[
+                lambda v: Parse.smaller_equal(v, 255),
+                lambda v: Parse.greater_equal(v, 0),
+            ],
+        )
+        self.zsync_decoder_shift = Parameter(
+            self,
+            self._parent._get_node_dict(f"awgs/{self._index}/zsync/decoder/shift"),
+            device=self._parent,
+            set_parser=[
+                lambda v: Parse.smaller_equal(v, 7),
+                lambda v: Parse.greater_equal(v, 0),
+            ],
+        )
+        self.zsync_decoder_offset = Parameter(
+            self,
+            self._parent._get_node_dict(f"awgs/{self._index}/zsync/decoder/offset"),
+            device=self._parent,
+            set_parser=[
+                lambda v: Parse.smaller_equal(v, 1023),
+                lambda v: Parse.greater_equal(v, 0),
+            ],
         )
 
     def _init_ct(self):

--- a/src/zhinst/toolkit/control/drivers/shfqa.py
+++ b/src/zhinst/toolkit/control/drivers/shfqa.py
@@ -25,7 +25,7 @@ class SHFQA(BaseInstrument):
 
     Inherits from :class:`BaseInstrument` and defines device specific
     methods and properties. All Channels of the :class:`SHFQA` can be
-    accessed through the property `channels` that is a list of four
+    accessed through the property `qachannels` that is a list of four
     :class:`Channel` s that are specific for the device and inherit from
     the :class:`SHFChannel` class. All Generators of the :class:`SHFQA`
     can be accessed through the property `generators` that is a list of
@@ -36,7 +36,7 @@ class SHFQA(BaseInstrument):
 
     def __init__(self, name: str, serial: str, discovery=None, **kwargs) -> None:
         super().__init__(name, DeviceTypes.SHFQA, serial, discovery, **kwargs)
-        self._channels = []
+        self._qachannels = []
         self._scope = None
         self.ref_clock = None
         self.ref_clock_actual = None
@@ -74,10 +74,10 @@ class SHFQA(BaseInstrument):
 
     def _init_channels(self):
         """Initialize the channels of the device."""
-        self._channels = [Channel(self, i) for i in range(self._num_channels())]
-        [channel._init_channel_params() for channel in self.channels]
-        [channel._init_generator() for channel in self.channels]
-        [channel._init_sweeper() for channel in self.channels]
+        self._qachannels = [Channel(self, i) for i in range(self._num_channels())]
+        [channel._init_channel_params() for channel in self.qachannels]
+        [channel._init_generator() for channel in self.qachannels]
+        [channel._init_sweeper() for channel in self.qachannels]
 
     def _init_scope(self):
         """Initialize the scope of the device."""
@@ -86,6 +86,7 @@ class SHFQA(BaseInstrument):
 
     def _init_params(self):
         """Initialize parameters associated with device nodes."""
+        super()._init_params()
         self.ref_clock = Parameter(
             self,
             self._get_node_dict(f"system/clocks/referenceclock/in/source"),
@@ -125,8 +126,8 @@ class SHFQA(BaseInstrument):
         time.sleep(0.2)
 
     @property
-    def channels(self):
-        return self._channels
+    def qachannels(self):
+        return self._qachannels
 
     @property
     def scope(self):

--- a/src/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/src/zhinst/toolkit/control/drivers/uhfqa.py
@@ -329,6 +329,7 @@ class UHFQA(BaseInstrument):
         [channel._init_channel_params() for channel in self.channels]
 
     def _init_params(self):
+        super()._init_params()
         self.integration_time = Parameter(
             self,
             dict(
@@ -365,7 +366,10 @@ class UHFQA(BaseInstrument):
             self,
             self._get_node_dict("qas/0/result/mode"),
             device=self,
-            mapping=MAPPINGS["averaging_mode"],
+            mapping={
+                0: "Cyclic",
+                1: "Sequential",
+            },
         )
         self.ref_clock = Parameter(
             self,
@@ -375,7 +379,11 @@ class UHFQA(BaseInstrument):
         )
 
     def _init_settings(self):
-        self.awg.single(True)
+        settings = [
+            # Enable single shot mode of AWG
+            ("awgs/0/single", 1),
+        ]
+        self._set(settings)
 
     @property
     def awg(self):

--- a/src/zhinst/toolkit/control/parsers.py
+++ b/src/zhinst/toolkit/control/parsers.py
@@ -22,7 +22,12 @@ class Parse:
         frame_list = traceback.StackSummary.extract(traceback.walk_stack(None))
         for frame in frame_list:
             if frame.name == "<module>":
-                return frame.line
+                if frame.line:
+                    return frame.line
+                else:
+                    for frame in frame_list:
+                        print(frame.name,"= ", frame.line,"= ", frame.locals)
+
 
     # Define a function to format the value string
     @staticmethod
@@ -187,3 +192,11 @@ class Parse:
     @staticmethod
     def shfqa_samples2time(v):
         return v / SHFQA_SAMPLE_RATE
+
+    @staticmethod
+    def version_parser(v):
+        v = str(v)
+        year = v[:2]
+        month = v[2:4]
+        build = v[4:]
+        return f"{year}.{month}.{build}"


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) `_init_settings` method in UHFQA:**
The AWG object and parameters should not be used inside this method
because when this method is called, the AWG and the parameters are not
initiated yet and they are set to `None`. The node addresses should be
used instead.