### PR TITLE
Update `BaseInstrument` class

### DIFF
--- a/src/zhinst/toolkit/control/drivers/hdawg.py
+++ b/src/zhinst/toolkit/control/drivers/hdawg.py
@@ -132,6 +132,7 @@ class HDAWG(BaseInstrument):
 
     def _init_params(self):
         """Initialize parameters associated with device nodes."""
+        super()._init_params()
         self.ref_clock = Parameter(
             self,
             self._get_node_dict(f"system/clocks/referenceclock/source"),

--- a/src/zhinst/toolkit/control/drivers/pqsc.py
+++ b/src/zhinst/toolkit/control/drivers/pqsc.py
@@ -184,6 +184,7 @@ class PQSC(BaseInstrument):
 
     def _init_params(self):
         """Initialize parameters associated with device nodes."""
+        super()._init_params()
         self.ref_clock = Parameter(
             self,
             self._get_node_dict(f"system/clocks/referenceclock/in/source"),

--- a/src/zhinst/toolkit/control/drivers/shfqa.py
+++ b/src/zhinst/toolkit/control/drivers/shfqa.py
@@ -86,6 +86,7 @@ class SHFQA(BaseInstrument):
 
     def _init_params(self):
         """Initialize parameters associated with device nodes."""
+        super()._init_params()
         self.ref_clock = Parameter(
             self,
             self._get_node_dict(f"system/clocks/referenceclock/in/source"),

--- a/src/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/src/zhinst/toolkit/control/drivers/uhfqa.py
@@ -329,6 +329,8 @@ class UHFQA(BaseInstrument):
         [channel._init_channel_params() for channel in self.channels]
 
     def _init_params(self):
+        """Initialize parameters associated with device nodes."""
+        super()._init_params()
         self.integration_time = Parameter(
             self,
             dict(

--- a/src/zhinst/toolkit/control/parsers.py
+++ b/src/zhinst/toolkit/control/parsers.py
@@ -187,3 +187,12 @@ class Parse:
     @staticmethod
     def shfqa_samples2time(v):
         return v / SHFQA_SAMPLE_RATE
+
+    @staticmethod
+    def version_parser(v):
+        """ Convert the obtained data version string to correct format"""
+        v = str(v)
+        year = v[:2]
+        month = v[2:4]
+        build = v[4:]
+        return f"{year}.{month}.{build}"

--- a/tests/test_baseInstrument.py
+++ b/tests/test_baseInstrument.py
@@ -29,7 +29,11 @@ class ConnectionMock:
         pass
 
     def list_nodes(self, *args, **kwargs):
-        return "{}"
+        return (
+            '{"node_address": '
+            '{"Node": "node_address", '
+            '"Description": "description" }}'
+        )
 
     def get(self, *args, **kwargs):
         return {"node": {"value": [""]}}
@@ -37,19 +41,28 @@ class ConnectionMock:
 
 def test_init_instrument():
     instr = BaseInstrument(
-        "name", DeviceTypes.PQSC, "dev1234", interface="1GbE", discovery=DiscoveryMock()
+        "name",
+        DeviceTypes.PQSC,
+        "dev10000",
+        interface="1GbE",
+        discovery=DiscoveryMock(),
     )
     assert instr.nodetree is None
     assert instr.name == "name"
     assert instr.device_type == DeviceTypes.PQSC
-    assert instr.serial == "dev1234"
+    assert instr.serial == "dev10000"
     assert instr.interface == "1GbE"
-    assert instr.is_connected == False
+    assert instr.is_connected is False
+    assert instr.options is None
 
 
 def test_check_connection():
     instr = BaseInstrument(
-        "name", DeviceTypes.PQSC, "dev1234", interface="1GbE", discovery=DiscoveryMock()
+        "name",
+        DeviceTypes.PQSC,
+        "dev10000",
+        interface="1GbE",
+        discovery=DiscoveryMock(),
     )
     with pytest.raises(ToolkitError):
         instr._check_connected()
@@ -61,8 +74,12 @@ def test_check_connection():
         instr._get("sigouts/0/on")
     with pytest.raises(ToolkitError):
         instr._set("sigouts/0/on", 1)
-    with pytest.raises(ToolkitError):
+    with pytest.raises(TypeError):
         instr._get_node_dict("sigouts/0/on")
+    with pytest.raises(ToolkitError):
+        instr._get_node_dict("zi/about/revision")
+    with pytest.raises(ToolkitError):
+        instr._get_streamingnodes()
 
 
 def test_serials():
@@ -72,26 +89,38 @@ def test_serials():
         )
     with pytest.raises(ToolkitError):
         BaseInstrument(
-            "name", DeviceTypes.PQSC, 1234, interface="1GbE", discovery=DiscoveryMock()
+            "name", DeviceTypes.PQSC, 10000, interface="1GbE", discovery=DiscoveryMock()
         )
 
     BaseInstrument(
-        "name", DeviceTypes.PQSC, "dev1234", interface="1GbE", discovery=DiscoveryMock()
+        "name",
+        DeviceTypes.PQSC,
+        "dev10000",
+        interface="1GbE",
+        discovery=DiscoveryMock(),
     )
     BaseInstrument(
-        "name", DeviceTypes.PQSC, "DEV1234", interface="1GbE", discovery=DiscoveryMock()
+        "name",
+        DeviceTypes.PQSC,
+        "DEV10000",
+        interface="1GbE",
+        discovery=DiscoveryMock(),
     )
 
 
 def test_serial_normalization():
     inst = BaseInstrument(
-        "name", DeviceTypes.PQSC, "DEV1234", interface="1GbE", discovery=DiscoveryMock()
+        "name",
+        DeviceTypes.PQSC,
+        "DEV10000",
+        interface="1GbE",
+        discovery=DiscoveryMock(),
     )
     inst.setup(ConnectionMock())
     inst.connect_device()
-    assert inst.serial == "dev1234"
+    assert inst.serial == "dev10000"
 
 
 def test_default_discovery():
-    inst = BaseInstrument("name", DeviceTypes.PQSC, "DEV1234", interface="1GbE")
+    inst = BaseInstrument("name", DeviceTypes.PQSC, "DEV10000", interface="1GbE")
     assert isinstance(inst._controller.discovery, ziDiscovery)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -49,3 +49,13 @@ def test_complex2deg_and_back(deg):
     complex = Parse.deg2complex(deg)
     d = Parse.complex2deg(complex)
     assert abs(d - deg) < 1e-5
+
+
+@given(year=st.integers(0, 99), month=st.integers(1, 12), build=st.integers(0, 99999))
+def test_version_parser(year, month, build):
+    # Add leading zeros to year and month number and convert to string
+    year = str(year).zfill(2)
+    month = str(month).zfill(2)
+    build = str(build)
+    version = Parse.version_parser(year + month + build)
+    assert version == year + "." + month + "." + build


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) New parameters added to `BaseInstrument`:**
`data_server_version`, `firmware_version` and `fpga_version` are
parameters common to all devices. Therefore, they are added to the
`BaseInstrument` class.
##### **2) `_get_node_dict` method is updated:**
`_command_to_node` method from `DeviceConnection` class is called to
 add the device serial to the node string if it does not start with
 '/zi/'. This check is necessary because the `data_server_version`
 parameter node starts with '/zi/' and no device serial should be added
 to this node string.
##### **3) `_check_node_exists` method is updated:**
This method now takes as argument the full node address with the device
serial is added.
##### **4) `_init_params` method of device specific drivers updated:**
The device specific drivers of HDAWG, should first call the method from
the `BaseDriver` to initialize the parameters common to all drivers.
Then they initialize the parameters specific to that instrument.
##### **5) `version_parser` added to `Parse` class:**
This method is used to convert the obtained data version string to
`{year}.{month}.{build}` format
##### **6) `_options` attribute initialized as `None`**
##### **7) `test_baseInstrument` tests are improved:**
* Test serial number is changed to a more realistic number.
* `list_nodes` method in `ConnectionMock` is updated to be more
realistic.
* Tests added for `_get_streamingnodes` and `options` attribute
* Test for `_get_node_dict` method updated.