### PR TITLE
Update `PQSC` class

### DIFF
--- a/tests/test_pqsc.py
+++ b/tests/test_pqsc.py
@@ -7,18 +7,24 @@ from .context import PQSC, DeviceTypes
 
 
 def test_init_pqsc():
-    pqsc = PQSC("name", "dev1234")
+    pqsc = PQSC("name", "dev10000")
     assert pqsc.device_type == DeviceTypes.PQSC
     assert pqsc.ref_clock is None
     assert pqsc.ref_clock_actual is None
     assert pqsc.ref_clock_status is None
     assert pqsc.progress is None
+    assert pqsc._enable is None
+    assert pqsc.repetitions is None
+    assert pqsc.holdoff is None
     with pytest.raises(Exception):
         pqsc._init_params()
+    pqsc._init_settings()
+    with pytest.raises(Exception):
+        pqsc.is_running
 
 
 def test_methods_pqsc():
-    pqsc = PQSC("name", "dev1234")
+    pqsc = PQSC("name", "dev10000")
     with pytest.raises(Exception):
         pqsc.connect_device()
     with pytest.raises(Exception):
@@ -26,8 +32,26 @@ def test_methods_pqsc():
     with pytest.raises(Exception):
         pqsc.arm()
     with pytest.raises(Exception):
+        pqsc.arm(repetitions=100)
+    with pytest.raises(Exception):
+        pqsc.arm(holdoff=2e-6)
+    with pytest.raises(Exception):
         pqsc.run()
     with pytest.raises(Exception):
         pqsc.stop()
     with pytest.raises(Exception):
+        pqsc.wait_done()
+    with pytest.raises(Exception):
         pqsc.check_ref_clock()
+
+
+@given(
+    single_port=st.integers(0, 17),
+    port_list=st.lists(st.integers(0, 17), min_size=1, max_size=18, unique=True),
+)
+def test_check_zsync_connection(single_port, port_list):
+    pqsc = PQSC("name", "dev10000")
+    with pytest.raises(Exception):
+        pqsc.check_zsync_connection(ports=single_port)
+    with pytest.raises(Exception):
+        pqsc.check_zsync_connection(ports=port_list)


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) New parameters added to `PQSC` class:**
* `_enable` is added for internal use.
* `repetitions` and `holdoff` are public attributes and can also be used
 by the user.
##### **2) `arm` method is updated:**
* `stop` method is called to stop the instrument in the beginning.
* `repetitions` and `holdoff` parameters are used to set the related
settings. Using the defined parameters is preferred instead of using
`_set` method with the node address because parameters allow checking
minimum value and multiplicity.
##### **3) `run` and `stop` methods are updated:**
`_enable` parameter is used to run or stop the instrument.
##### **4) New attribute `is_running` added**
##### **5) New method `wait_done` added**
##### **6) Improved comments and docstring**
##### **7) Improved tests in `test_pqsc.py`:**
* Changed the device serial to a more realistic number.
* Added new attributes `_enable`, `repetitions` and `holdoff` to
`test_init_pqsc`
* Added `_init_settings` and `is_running` to `test_init_pqsc`
* Added `wait_done` to `test_methods_pqsc`
* Test `arm` with `holdoff` and `repetitions` settings in
`test_methods_pqsc`
* Added `test_check_zsync_connection`
