### PR TITLE
Update `UHFQA` class

### DIFF
--- a/src/zhinst/toolkit/control/drivers/base/awg.py
+++ b/src/zhinst/toolkit/control/drivers/base/awg.py
@@ -138,11 +138,11 @@ class AWGCore:
 
     def __repr__(self):
         params = self.sequence_params["sequence_parameters"]
-        s = f"{self._parent.name}: {super().__repr__()}\n"
+        s = f"{super().__repr__()}\n"
         s += f"    parent  : {self._parent}\n"
         s += f"    index   : {self._index}\n"
         s += f"    sequence: \n"
-        s += f"           type: {self.sequence_params['sequence_type']}\n"
+        s += f"            type: {self.sequence_params['sequence_type']}\n"
         for i in params.items():
             s += f"            {i}\n"
         return s

--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -14,14 +14,18 @@ from .context import (
 
 
 def test_init_uhfqa():
-    qa = UHFQA("name", "dev1234")
+    qa = UHFQA("name", "dev2000")
     assert qa.device_type == DeviceTypes.UHFQA
     assert qa._awg is None
     assert qa.awg is None
     assert len(qa._channels) == 0
     assert len(qa.channels) == 0
     assert qa.integration_time is None
+    assert qa.integration_length is None
     assert qa.result_source is None
+    assert qa.averaging_mode is None
+    assert qa.ref_clock is None
+    assert qa._qa_delay_user == 0
     with pytest.raises(Exception):
         qa._init_awg_cores()
     with pytest.raises(Exception):
@@ -33,7 +37,7 @@ def test_init_uhfqa():
 
 
 def test_methods_uhfqa():
-    qa = UHFQA("name", "dev1234")
+    qa = UHFQA("name", "dev2000")
     with pytest.raises(Exception):
         qa.connect_device()
     with pytest.raises(Exception):
@@ -52,15 +56,17 @@ def test_methods_uhfqa():
 
 @given(delay_adj=st.integers(-300, 1300))
 def test_qa_delay(delay_adj):
-    qa = UHFQA("name", "dev1234")
-    assert 0 == qa.qa_delay()
+    qa = UHFQA("name", "dev2000")
+    assert qa.qa_delay() == 0
     with pytest.raises(Exception):
         qa.qa_delay(delay_adj)
+    with pytest.raises(Exception):
+        qa._qa_delay_default()
 
 
 @given(rows=st.integers(1, 20), cols=st.integers(1, 20))
 def test_crosstalk_matrix(rows, cols):
-    qa = UHFQA("name", "dev1234")
+    qa = UHFQA("name", "dev2000")
     matrix = np.random.rand(rows, cols)
     with pytest.raises(Exception):
         qa.crosstalk_matrix()
@@ -70,14 +76,14 @@ def test_crosstalk_matrix(rows, cols):
 
 @given(channels=st.lists(elements=st.integers(1, 20), min_size=1, max_size=10))
 def test_enable_readout_channels(channels):
-    qa = UHFQA("name", "dev1234")
+    qa = UHFQA("name", "dev2000")
     with pytest.raises(Exception):
         qa.enable_readout_channels(channels)
 
 
 @given(channels=st.lists(elements=st.integers(1, 20), min_size=1, max_size=10))
 def test_disable_readout_channels(channels):
-    qa = UHFQA("name", "dev1234")
+    qa = UHFQA("name", "dev2000")
     with pytest.raises(Exception):
         qa.disable_readout_channels(channels)
 
@@ -89,11 +95,12 @@ def test_disable_readout_channels(channels):
     ),
 )
 def test_init_uhfqa_awg(sequence_type, trigger_mode):
-    awg = UHFQA_AWG(UHFQA("name", "dev1234"), 0)
+    awg = UHFQA_AWG(UHFQA("name", "dev2000"), 0)
     assert awg.output1 is None
     assert awg.output2 is None
     assert awg.gain1 is None
     assert awg.gain2 is None
+    assert awg.single is None
     assert awg.__repr__() != ""
     with pytest.raises(Exception):
         awg.outputs(["on", "on"])
@@ -104,10 +111,6 @@ def test_init_uhfqa_awg(sequence_type, trigger_mode):
     with pytest.raises(Exception):
         awg.outputs()
     with pytest.raises(Exception):
-        awg.update_readout_params()
-    with pytest.raises(Exception):
-        awg.compile()
-    with pytest.raises(Exception):
         awg.set_sequence_params(sequence_type="text")
     with pytest.raises(Exception):
         awg.set_sequence_params(sequence_type=sequence_type)
@@ -116,6 +119,8 @@ def test_init_uhfqa_awg(sequence_type, trigger_mode):
     with pytest.raises(Exception):
         awg.set_sequence_params(trigger_mode=trigger_mode)
     with pytest.raises(Exception):
+        awg.compile()
+    with pytest.raises(Exception):
         awg._apply_receive_trigger_settings()
     with pytest.raises(Exception):
         awg._apply_zsync_trigger_settings()
@@ -123,18 +128,45 @@ def test_init_uhfqa_awg(sequence_type, trigger_mode):
         awg._init_awg_params()
 
 
+@given(sequence_type=st.sampled_from(SequenceType))
+def test_update_readout_params(sequence_type):
+    uhf = UHFQA("name", "dev2000")
+    with pytest.raises(Exception):
+        uhf._init_awg_cores()
+    with pytest.raises(Exception):
+        uhf._init_readout_channels()
+    with pytest.raises(Exception):
+        uhf.awg.set_sequence_params(sequence_type=sequence_type)
+    if sequence_type == SequenceType.READOUT:
+        with pytest.raises(Exception):
+            uhf.channels[0].enable()
+        uhf.awg.update_readout_params()
+    else:
+        with pytest.raises(Exception):
+            uhf.awg.update_readout_params()
+
+
 @given(i=st.integers(1, 20))
 def test_init_readout_channel(i):
     if i not in range(10):
         with pytest.raises(ValueError):
-            ch = ReadoutChannel(UHFQA("name", "dev1234"), i)
+            ch = ReadoutChannel(UHFQA("name", "dev2000"), i)
     else:
-        ch = ReadoutChannel(UHFQA("name", "dev1234"), i)
+        with pytest.raises(Exception):
+            uhf = UHFQA("name", "dev2000")
+            uhf._init_readout_channels()
+        ch = uhf.channels[i]
         assert ch.index == i
+        assert ch._parent == uhf
+        assert not ch._enabled
+        assert not ch.enabled()
+        assert ch._readout_frequency == 100e6
+        assert ch._readout_amplitude == 1
+        assert ch._int_weights_envelope == 1.0
+        assert ch._phase_shift == 0
         assert ch.rotation is None
         assert ch.threshold is None
         assert ch.result is None
-        assert not ch.enabled()
         with pytest.raises(Exception):
             ch.__repr__()
     with pytest.raises(Exception):
@@ -142,7 +174,7 @@ def test_init_readout_channel(i):
 
 
 def test_set_get_params_channel():
-    ch = ReadoutChannel(UHFQA("name", "dev1234"), 0)
+    ch = ReadoutChannel(UHFQA("name", "dev2000"), 0)
     assert ch.readout_frequency() == 100e6
     ch.readout_amplitude(0.5)
     assert ch.readout_amplitude() == 0.5
@@ -162,9 +194,27 @@ def test_set_get_params_channel():
         ch._average_result(1000)
 
 
+@given(
+    single_value=st.floats(-2, 2),
+    value_list=st.lists(st.floats(0, 1), min_size=1, max_size=4096),
+)
+def test_int_weights_envelope(single_value, value_list):
+    ch = ReadoutChannel(UHFQA("name", "dev2000"), 0)
+    with pytest.raises(Exception):
+        ch.int_weights_envelope(single_value)
+    if single_value < 0:
+        assert ch.int_weights_envelope() == 0
+    elif single_value > 1:
+        assert ch.int_weights_envelope() == 1
+    else:
+        assert ch.int_weights_envelope() == single_value
+    with pytest.raises(Exception):
+        ch.int_weights_envelope(value_list)
+
+
 @given(length=st.integers(1, 5000), freq=st.floats(-1e9, 2e9), phase=st.integers(0, 90))
 def test_demod_weights(length, freq, phase):
-    ch = ReadoutChannel(UHFQA("name", "dev1234"), 0)
+    ch = ReadoutChannel(UHFQA("name", "dev2000"), 0)
     if length > 4096:
         with pytest.raises(ValueError):
             ch._demod_weights(length, 1.0, freq, phase)


### PR DESCRIPTION
Update `UHFQA` class

#### **The following changes are made in this update:**
##### **1) `_init_settings` method is updated:**
* The AWG object and its parameters should not be used inside this
method because when this method is called, the AWG core and its
parameters are not initiated yet and they are set to `None`. The node
addresses should be used instead to set the initial settings.
* The `qa_delay` adjustment is set to 0 as initial setting.
##### **2) `single` attribute is initialized as `None`**
##### **3) `__repr__` method of `AWGCore` class is updated:**
* The device name is removed from the string representation `__repr__`
of the AWG object.
##### **4) `int_weights_envelope` method is updated:**
If the envelope is given as a list, the length of the list is compared
with the integration length and a `ToolkitError` is raised if they do
not match.
##### **5) Documentation improved:**
* A more realistic device serial is used in the docstring.
* Docstring of `enable_qccs_mode` is updated.
* Docstring is added to `enable_manual_mode`
* The docstring of `AWG` class is improved.
* Typos corrected in the comments and docstrings.
* Type of attributes changed from Parameter to zhinst.toolkit.control
.node_tree.Parameter since the former one does not link to the Parameter
 class in the documentation.
##### **6) `test_uhfqa` tests are improved:**
* Test serial number is changed to a more realistic number.
* `test_init_uhfqa` test is updated to check if
`integration_length`, `averaging_mode` and `ref_clock` are initialized
as `None` and `_qa_delay_user` is initialized as 0.
* `test_qa_delay` is updated to test `_qa_delay_default`
* `test_init_uhfqa_awg` is updated. It checks if `single` is initiated
as `None`. `update_readout_params` is removed from this test. `compile`
is called after setting the sequence type.
* test_update_readout_params test is added to test 
`update_readout_params`. When the sequence type is 
`SequenceType.READOUT`, the readout channel is enabled and calling 
`update_readout_params` does not raise an Exception. For other sequence 
types, `update_readout_params` should raise an  Exception.
* `test_init_readout_channel` is updated to check the `_parent`,
`_enabled`, `_readout_frequency`, `_readout_amplitude`,
`_int_weights_envelope` and `_phase_shift` attributes.
* `test_int_weights_envelope` added to test `int_weights_envelope`
method.