### PR TITLE
Add centralized logging module

### DIFF
--- a/src/zhinst/toolkit/control/drivers/base/awg.py
+++ b/src/zhinst/toolkit/control/drivers/base/awg.py
@@ -6,15 +6,13 @@
 import numpy as np
 import time
 from typing import List, Union
-import logging
-import traceback
 import re
 
 from zhinst.toolkit.helpers import SequenceProgram, Waveform, SequenceType
-from .base import ToolkitError, BaseInstrument
+from .base import BaseInstrument
+from zhinst.toolkit.interface import LoggerModule
 
-logging.basicConfig(format="%(levelname)s: %(message)s")
-_logger = logging.getLogger(__name__)
+_logger = LoggerModule(__name__)
 
 
 class AWGCore:
@@ -174,13 +172,17 @@ class AWGCore:
         """Compiles the current SequenceProgram on the AWG Core.
 
         Raises:
-            ToolkitError: If the AWG Core has not been set up yet.
-            ToolkitError: If the compilation has failed.
-            Warning: If the compilation has finished with a warning.
+            ToolkitConnectionError: If the AWG Core has not been set up
+                yet
+            ToolkitError: if the compilation has failed or if the
+                program upload has failed.
 
         """
         if self._module is None:
-            raise ToolkitError("This AWG is not connected to a awgModule!")
+            _logger.error(
+                "This AWG is not connected to an awgModule!",
+                _logger.ExceptionTypes.ToolkitConnectionError,
+            )
         self._module.update(device=self._parent.serial)
         self._module.update(index=self._index)
         if self._program.sequence_type == SequenceType.SIMPLE:
@@ -196,15 +198,15 @@ class AWGCore:
         statusstring = self._module.get_string("compiler/statusstring")
         if compiler_status == 1:
             _logger.error(
-                f"{self._caller_name()}\n"
-                f"Please check the sequencer code for {self.name}:\n{self._seqc_error(statusstring)}"
+                f"Please check the sequencer code for {self.name}:\n"
+                f"{self._seqc_error(statusstring)}"
                 f"Compiler status string:\n{statusstring}\n",
+                _logger.ExceptionTypes.ToolkitError,
             )
-            raise ToolkitError("Compilation failed")
         elif compiler_status == 2:
             _logger.warning(
-                f"{self._caller_name()}\n"
-                f"Please check the sequencer code for {self.name}:\n{self._seqc_error(statusstring)}"
+                f"Please check the sequencer code for {self.name}:\n"
+                f"{self._seqc_error(statusstring)}"
                 f"Compiler status string:\n{statusstring}\n",
             )
         elif compiler_status == 0:
@@ -215,16 +217,18 @@ class AWGCore:
         ):
             time.sleep(0.1)
             if time.time() - tik >= 100:  # 100s timeout
-                raise ToolkitError(f"{self.name}: Program upload timed out!")
+                _logger.error(
+                    f"{self.name}: Program upload timed out!",
+                    _logger.ExceptionTypes.ToolkitError,
+                )
         elf_status = self._module.get_int("/elf/status")
         if elf_status == 0:
             _logger.info(f"{self.name}: Sequencer status: ELF file uploaded!")
         else:
             _logger.error(
-                f"{self._caller_name()}\n"
                 f"{self.name}: Sequencer status: ELF upload failed!",
+                _logger.ExceptionTypes.ToolkitError,
             )
-            raise ToolkitError(f"{self.name}: ELF upload failed!")
 
     def reset_queue(self) -> None:
         """Resets the waveform queue to an empty list."""
@@ -249,7 +253,7 @@ class AWGCore:
                 the time origin of the sequence. (default: 0)
 
         Raises:
-            Exception: If the sequence is not of type *'Simple'* or
+            ToolkitError: If the sequence is not of type *'Simple'* or
                 *'Custom'*.
 
         """
@@ -257,8 +261,10 @@ class AWGCore:
             SequenceType.SIMPLE,
             SequenceType.CUSTOM,
         ]:
-            raise Exception(
-                "Waveform upload only possible for 'Simple' and 'Custom' sequence programs!"
+            _logger.error(
+                "Waveform upload only possible for 'Simple' and 'Custom' sequence "
+                "programs!",
+                _logger.ExceptionTypes.ToolkitError,
             )
         self._waveforms.append(Waveform(wave1, wave2, delay=delay))
         print(f"Current length of queue: {len(self._waveforms)}")
@@ -282,11 +288,14 @@ class AWGCore:
                 the time origin of the sequence. (default: 0)
 
         Raises:
-            ToolkitError: If the given index is out of range.
+            ValueError: If the given index is out of range.
 
         """
         if i not in range(len(self._waveforms)):
-            raise ToolkitError("Index out of range!")
+            _logger.error(
+                "Index out of range!",
+                _logger.ExceptionTypes.ValueError,
+            )
         self._waveforms[i].replace_data(wave1, wave2, delay=delay)
 
     def upload_waveforms(self) -> None:
@@ -375,15 +384,3 @@ class AWGCore:
                 seqc_error += f"   {i + 1: >{number_width}}   {line.strip()}\n"
         seqc_error += "\n"
         return seqc_error
-
-    def _caller_name(self):
-        """Return the caller name.
-
-        This method returns the line that calls a function. It is used
-        to display a logging message to the user and show which line
-        caused an error or warning.
-        """
-        frame_list = traceback.StackSummary.extract(traceback.walk_stack(None))
-        for frame in frame_list:
-            if frame.name == "<module>":
-                return frame.line

--- a/src/zhinst/toolkit/control/drivers/pqsc.py
+++ b/src/zhinst/toolkit/control/drivers/pqsc.py
@@ -5,14 +5,13 @@
 
 import numpy as np
 import time
-import logging
 
 from zhinst.toolkit.control.drivers.base import BaseInstrument
-from zhinst.toolkit.interface import DeviceTypes
+from zhinst.toolkit.interface import DeviceTypes, LoggerModule
 from zhinst.toolkit.control.node_tree import Parameter
 from zhinst.toolkit.control.parsers import Parse
 
-_logger = logging.getLogger(__name__)
+_logger = LoggerModule(__name__)
 
 
 class PQSC(BaseInstrument):
@@ -174,6 +173,10 @@ class PQSC(BaseInstrument):
             timeout (int): Maximum time in seconds the program waits
                 when `blocking` is set to `True`. (default: 30)
 
+        Raises:
+            ToolkitError: If ZSync connection to the instruments on the
+                specified ports is not established.
+
         """
         if type(ports) is not list:
             ports = [ports]
@@ -190,9 +193,10 @@ class PQSC(BaseInstrument):
                 zsync_connection_status = self._get(f"zsyncs/{port}/connection/status")
             # Throw an exception if the instrument is still not connected after timeout
             if zsync_connection_status != 2:
-                raise Exception(
+                _logger.error(
                     f"Check ZSync connection to the instrument on port {port} "
-                    f"(port {port + 1} on the rear panel) of PQSC."
+                    f"(port {port + 1} on the rear panel) of PQSC.",
+                    _logger.ExceptionTypes.ToolkitError,
                 )
             else:
                 _logger.info(

--- a/src/zhinst/toolkit/control/drivers/shfqa.py
+++ b/src/zhinst/toolkit/control/drivers/shfqa.py
@@ -3,7 +3,6 @@
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.
 
-import logging
 import time
 
 from zhinst.toolkit.control.drivers.base import (
@@ -13,11 +12,11 @@ from zhinst.toolkit.control.drivers.base import (
     SHFScope,
     SHFSweeper,
 )
-from zhinst.toolkit.interface import DeviceTypes
+from zhinst.toolkit.interface import DeviceTypes, LoggerModule
 from zhinst.toolkit.control.node_tree import Parameter
 from zhinst.toolkit.control.parsers import Parse
 
-_logger = logging.getLogger(__name__)
+_logger = LoggerModule(__name__)
 
 
 class SHFQA(BaseInstrument):
@@ -71,7 +70,9 @@ class SHFQA(BaseInstrument):
 
     def factory_reset(self) -> None:
         """Loads the factory default settings."""
-        _logger.info(f"Factory preset is not supported in {self.serial.upper()}.")
+        _logger.warning(
+            f"Factory preset is not yet supported in SHFQA " f"{self.serial.upper()}."
+        )
 
     def _init_settings(self):
         """Sets initial device settings on startup."""
@@ -318,7 +319,7 @@ class Generator(SHFGenerator):
             ),
             device=self._device,
         )
-    
+
     def _apply_sequence_settings(self, **kwargs):
         # check sequence type
         if "sequence_type" in kwargs.keys():

--- a/src/zhinst/toolkit/control/drivers/shfqa.py
+++ b/src/zhinst/toolkit/control/drivers/shfqa.py
@@ -32,6 +32,12 @@ class SHFQA(BaseInstrument):
     four :class:`Generator` s that are specific for the device and
     inherit from the :class:`SHFGenerator` class.
 
+    Attributes:
+        allowed_sequences (list): A list of :class:`SequenceType` s
+            that the instrument supports.
+        allowed_trigger_modes (list): A list of :class:`TriggerMode` s
+            that the instrument supports.
+
     """
 
     def __init__(self, name: str, serial: str, discovery=None, **kwargs) -> None:
@@ -42,6 +48,13 @@ class SHFQA(BaseInstrument):
         self.ref_clock_actual = None
         self.ref_clock_status = None
         self.timebase = None
+        self._allowed_sequences = [
+            SequenceType.NONE,
+            SequenceType.CUSTOM,
+        ]
+        self._allowed_trigger_modes = [
+            TriggerMode.NONE,
+        ]
 
     def connect_device(self, nodetree: bool = True) -> None:
         """Connects the device to the data server.
@@ -132,6 +145,14 @@ class SHFQA(BaseInstrument):
     @property
     def scope(self):
         return self._scope
+
+    @property
+    def allowed_sequences(self):
+        return self._allowed_sequences
+
+    @property
+    def allowed_trigger_modes(self):
+        return self._allowed_trigger_modes
 
 
 class Channel(SHFChannel):
@@ -297,6 +318,22 @@ class Generator(SHFGenerator):
             ),
             device=self._device,
         )
+    
+    def _apply_sequence_settings(self, **kwargs):
+        # check sequence type
+        if "sequence_type" in kwargs.keys():
+            t = SequenceType(kwargs["sequence_type"])
+            if t not in self._device.allowed_sequences:
+                raise ToolkitError(
+                    f"Sequence type {t} must be one of {[s.value for s in self._device.allowed_sequences]}!"
+                )
+        # check trigger mode
+        if "trigger_mode" in kwargs.keys():
+            t = TriggerMode(kwargs["trigger_mode"])
+            if t not in self._device.allowed_trigger_modes:
+                raise ToolkitError(
+                    f"Trigger mode {t} must be one of {[s.value for s in self._device.allowed_trigger_modes]}!"
+                )
 
 
 class Sweeper(SHFSweeper):

--- a/src/zhinst/toolkit/control/parsers.py
+++ b/src/zhinst/toolkit/control/parsers.py
@@ -4,25 +4,16 @@
 # of the MIT license. See the LICENSE file for details.
 
 import numpy as np
-import logging
-import traceback
+
+from zhinst.toolkit.interface import LoggerModule
 
 UHFQA_SAMPLE_RATE = 1.8e9
 SHFQA_SAMPLE_RATE = 2e9
-logging.basicConfig(format="%(levelname)s: %(message)s")
-_logger = logging.getLogger(__name__)
+_logger = LoggerModule(__name__)
 
 
 class Parse:
     """Input and output parsers for Parameters to validate and parse values."""
-
-    # Define a function to return the parameter name
-    @staticmethod
-    def _parameter_name():
-        frame_list = traceback.StackSummary.extract(traceback.walk_stack(None))
-        for frame in frame_list:
-            if frame.name == "<module>":
-                return frame.line
 
     # Define a function to format the value string
     @staticmethod
@@ -43,10 +34,16 @@ class Parse:
         if isinstance(v, str):
             map = {"on": 1, "off": 0}
             if v.lower() not in map.keys():
-                raise ValueError(f"The input value must be in {map.keys()}.")
+                _logger.error(
+                    f"The input value must be in {map.keys()}.",
+                    _logger.ExceptionTypes.ValueError,
+                )
             v = map[v.lower()]
         elif not isinstance(v, int):
-            raise ValueError("This value must be either 'on' or 'off' or an integer.")
+            _logger.error(
+                "This value must be either 'on' or 'off' or an integer.",
+                _logger.ExceptionTypes.ValueError,
+            )
         return v
 
     @staticmethod
@@ -54,7 +51,10 @@ class Parse:
         v = int(v)
         map = {1: "on", 0: "off"}
         if v not in map.keys():
-            raise ValueError("Invalid value returned from the instrument!")
+            _logger.error(
+                "Invalid value returned from the instrument!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return map[v]
 
     @staticmethod
@@ -62,10 +62,16 @@ class Parse:
         if isinstance(v, bool):
             map = {True: 1, False: 0}
             if v not in map.keys():
-                raise ValueError(f"The input value must be in {map.keys()}.")
+                _logger.error(
+                    f"The input value must be in {map.keys()}.",
+                    _logger.ExceptionTypes.ValueError,
+                )
             v = map[v]
         elif not isinstance(v, int):
-            raise ValueError("This value must be either True or False or an integer.")
+            _logger.error(
+                "This value must be either True or False or an integer.",
+                _logger.ExceptionTypes.ValueError,
+            )
         return v
 
     @staticmethod
@@ -73,7 +79,10 @@ class Parse:
         v = int(v)
         map = {1: True, 0: False}
         if v not in map.keys():
-            raise ValueError("Invalid value returned from the instrument!")
+            _logger.error(
+                "Invalid value returned from the instrument!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return map[v]
 
     @staticmethod
@@ -81,7 +90,10 @@ class Parse:
         v = int(v)
         map = {0: "locked", 1: "error", 2: "busy"}
         if v not in map.keys():
-            raise ValueError("Invalid value returned from the instrument!")
+            _logger.error(
+                "Invalid value returned from the instrument!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return map[v]
 
     @staticmethod
@@ -91,14 +103,16 @@ class Parse:
     @staticmethod
     def greater(v, limit):
         if v <= limit:
-            raise ValueError(f"This value must be greater than {limit}!")
+            _logger.error(
+                f"This value must be greater than {limit}!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return v
 
     @staticmethod
     def greater_equal(v, limit):
         if v < limit:
             _logger.warning(
-                f"{Parse._parameter_name()}\n"
                 f"The value {Parse._format_number(v)} must be greater than or equal to "
                 f"{Parse._format_number(limit)} and will be rounded up to: "
                 f"{Parse._format_number(limit)}",
@@ -110,14 +124,16 @@ class Parse:
     @staticmethod
     def smaller(v, limit):
         if v >= limit:
-            raise ValueError(f"This value must be smaller than {limit}!")
+            _logger.error(
+                f"This value must be smaller than {limit}!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return v
 
     @staticmethod
     def smaller_equal(v, limit):
         if v > limit:
             _logger.warning(
-                f"{Parse._parameter_name()}\n"
                 f"The value {Parse._format_number(v)} must be smaller than or equal to "
                 f"{Parse._format_number(limit)} and will be rounded down to: "
                 f"{Parse._format_number(limit)}",
@@ -133,7 +149,6 @@ class Parse:
         elif rounding == "nearest":
             v_rounded = round(v / factor) * factor
             _logger.warning(
-                f"{Parse._parameter_name()}\n"
                 f"The value {Parse._format_number(v)} is not a multiple of "
                 f"{Parse._format_number(factor)} and will be rounded to nearest "
                 f"multiple: {Parse._format_number(v_rounded)}",
@@ -142,7 +157,6 @@ class Parse:
         elif rounding == "down":
             v_rounded = round(v // factor) * factor
             _logger.warning(
-                f"{Parse._parameter_name()}\n"
                 f"The value {Parse._format_number(v)} is not a multiple of "
                 f"{Parse._format_number(factor)} and will be rounded down to greatest "
                 f"multiple: {Parse._format_number(v_rounded)}",

--- a/src/zhinst/toolkit/interface/__init__.py
+++ b/src/zhinst/toolkit/interface/__init__.py
@@ -1,1 +1,1 @@
-from .interface import InstrumentConfiguration, DeviceTypes
+from .interface import InstrumentConfiguration, DeviceTypes, LoggerModule

--- a/src/zhinst/toolkit/interface/interface.py
+++ b/src/zhinst/toolkit/interface/interface.py
@@ -5,6 +5,8 @@
 
 import attr
 from enum import Enum
+import logging
+import traceback
 
 
 class DeviceTypes(Enum):
@@ -62,3 +64,126 @@ class InstrumentConfiguration:
     @property
     def instrument(self):
         return self._instrument
+
+
+class LoggerModule:
+    """Implement a custom logging module.
+
+    Arguments:
+        name (str): Name used to instantiate the logger object using
+            the function `logging.getLogger(name)`. When the
+            `LoggerModule` class is imported to another module,
+            `__name__` should be used as argument.  That’s because in a
+             module, `__name__` is the module’s name in the Python
+             package namespace.
+
+    """
+
+    def __init__(self, name):
+        self._name = name
+        self._custom_field = {"callername": ""}
+        self._logger = logging.getLogger(self._name)
+        self._syslog = logging.StreamHandler()
+        self._formatter = logging.Formatter(
+            "%(levelname)s: %(callername)s\n%(message)s"
+        )
+        self._syslog.setFormatter(self._formatter)
+        self._logger.addHandler(self._syslog)
+        self._logger = logging.LoggerAdapter(self._logger, self._custom_field)
+
+    class ExceptionTypes(Enum):
+        """Enum of exception types."""
+
+        ToolkitConnectionError = "ToolkitConnectionError"
+        ToolkitNodeTreeError = "ToolkitNodeTreeError"
+        ValueError = "ValueError"
+        TypeError = "TypeError"
+        ToolkitError = "ToolkitError"
+
+    class ToolkitConnectionError(Exception):
+        """Custom Exception class for ToolkitConnectionError"""
+
+        pass
+
+    class ToolkitNodeTreeError(Exception):
+        """Custom Exception class for ToolkitNodeTreeError"""
+
+        pass
+
+    class ToolkitError(Exception):
+        """Custom Exception class for ToolkitError"""
+
+        pass
+
+    @staticmethod
+    def _get_caller():
+        """Update the caller name.
+
+        This method extracts the line attribute of the FrameSummary object
+        with the name `<module>` . This line attribute corresponds to the line
+        of code in the user notebook that eventually calls this function.
+        """
+        frame_list = traceback.StackSummary.extract(traceback.walk_stack(None))
+        for frame in frame_list:
+            if frame.name == "<module>":
+                return frame.line
+
+    def info(self, msg, *args, **kwargs):
+        """Logs a message with level INFO on the log.
+
+        Updates the caller name before logging the message and passes
+        all arguments and keyword arguments to the underlying `info`
+        method.
+
+        Argumentss:
+            msg (str): The message string
+        """
+        self._custom_field["callername"] = LoggerModule._get_caller()
+        self._logger = logging.LoggerAdapter(self._logger, self._custom_field)
+        self._logger.info(msg, *args, **kwargs)
+
+    def warning(self, msg, *args, **kwargs):
+        """Logs a message with level WARNING on the log.
+
+        Updates the caller name before logging the message and passes
+        all arguments and keyword arguments to the underlying `warning`
+        method.
+
+        Argumentss:
+            msg (str): The message string
+        """
+        self._custom_field["callername"] = LoggerModule._get_caller()
+        self._logger = logging.LoggerAdapter(self._logger, self._custom_field)
+        if "pytest" not in self._custom_field["callername"]:
+            self._logger.warning(msg, *args, **kwargs)
+
+    def error(self, msg, exception_type, *args, **kwargs):
+        """Logs a message with level ERROR on the log.
+
+        Updates the caller name before logging the message and passes
+        all arguments and keyword arguments to the underlying `error`
+        method. It eventually raises an exception depending on the
+        exception type specified by the `exception_type` argument.
+
+        Arguments:
+            msg (str): The message string
+            exception_type (class:`ExceptionTypes`): Type enum for the
+                exception to be raised.
+
+        """
+        self._custom_field["callername"] = LoggerModule._get_caller()
+        self._logger = logging.LoggerAdapter(self._logger, self._custom_field)
+        if "pytest" not in self._custom_field["callername"]:
+            self._logger.error(msg, *args, **kwargs)
+        if exception_type == LoggerModule.ExceptionTypes.ToolkitConnectionError:
+            raise LoggerModule.ToolkitConnectionError(msg)
+        elif exception_type == LoggerModule.ExceptionTypes.ToolkitNodeTreeError:
+            raise LoggerModule.ToolkitNodeTreeError(msg)
+        elif exception_type == LoggerModule.ExceptionTypes.ValueError:
+            raise ValueError(msg)
+        elif exception_type == LoggerModule.ExceptionTypes.TypeError:
+            raise TypeError(msg)
+        elif exception_type == LoggerModule.ExceptionTypes.ToolkitError:
+            raise LoggerModule.ToolkitError(msg)
+        else:
+            raise Exception(msg)

--- a/tests/context.py
+++ b/tests/context.py
@@ -38,4 +38,8 @@ from zhinst.toolkit.control.node_tree import (
 from zhinst.toolkit.control.parsers import Parse
 from zhinst.toolkit.helpers import Waveform, SequenceCommand, SequenceProgram
 from zhinst.toolkit import SequenceType, TriggerMode, Alignment
-from zhinst.toolkit.interface import InstrumentConfiguration, DeviceTypes
+from zhinst.toolkit.interface import (
+    InstrumentConfiguration,
+    DeviceTypes,
+    LoggerModule,
+)

--- a/tests/test_baseInstrument.py
+++ b/tests/test_baseInstrument.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from .context import (
     BaseInstrument,
-    ToolkitError,
+    LoggerModule,
     DeviceTypes,
     ZIConnection,
     ziDiscovery,
@@ -64,30 +64,30 @@ def test_check_connection():
         interface="1GbE",
         discovery=DiscoveryMock(),
     )
-    with pytest.raises(ToolkitError):
+    with pytest.raises(LoggerModule.ToolkitConnectionError):
         instr._check_connected()
-    with pytest.raises(ToolkitError):
+    with pytest.raises(LoggerModule.ToolkitConnectionError):
         instr._check_node_exists("sigouts/0/on")
-    with pytest.raises(ToolkitError):
+    with pytest.raises(LoggerModule.ToolkitConnectionError):
         instr.connect_device()
-    with pytest.raises(ToolkitError):
+    with pytest.raises(LoggerModule.ToolkitConnectionError):
         instr._get("sigouts/0/on")
-    with pytest.raises(ToolkitError):
+    with pytest.raises(LoggerModule.ToolkitConnectionError):
         instr._set("sigouts/0/on", 1)
     with pytest.raises(TypeError):
         instr._get_node_dict("sigouts/0/on")
-    with pytest.raises(ToolkitError):
+    with pytest.raises(LoggerModule.ToolkitConnectionError):
         instr._get_node_dict("zi/about/revision")
-    with pytest.raises(ToolkitError):
+    with pytest.raises(LoggerModule.ToolkitConnectionError):
         instr._get_streamingnodes()
 
 
 def test_serials():
-    with pytest.raises(ToolkitError):
+    with pytest.raises(LoggerModule.ToolkitError):
         BaseInstrument(
             "name", DeviceTypes.PQSC, None, interface="1GbE", discovery=DiscoveryMock()
         )
-    with pytest.raises(ToolkitError):
+    with pytest.raises(LoggerModule.ToolkitError):
         BaseInstrument(
             "name", DeviceTypes.PQSC, 10000, interface="1GbE", discovery=DiscoveryMock()
         )

--- a/tests/test_hdawg.py
+++ b/tests/test_hdawg.py
@@ -13,6 +13,23 @@ def test_init_hdawg():
     assert hd.device_type == DeviceTypes.HDAWG
     assert hd.ref_clock is None
     assert hd.ref_clock_status is None
+    assert hd.allowed_sequences == [
+        SequenceType.NONE,
+        SequenceType.SIMPLE,
+        SequenceType.TRIGGER,
+        SequenceType.RABI,
+        SequenceType.T1,
+        SequenceType.T2,
+        SequenceType.CUSTOM,
+    ]
+    assert hd.allowed_trigger_modes == [
+        TriggerMode.NONE,
+        TriggerMode.SEND_TRIGGER,
+        TriggerMode.EXTERNAL_TRIGGER,
+        TriggerMode.RECEIVE_TRIGGER,
+        TriggerMode.SEND_AND_RECEIVE_TRIGGER,
+        TriggerMode.ZSYNC_TRIGGER,
+    ]
     with pytest.raises(Exception):
         hd._init_awg_cores()
     with pytest.raises(Exception):

--- a/tests/test_pqsc.py
+++ b/tests/test_pqsc.py
@@ -3,7 +3,7 @@ from hypothesis import given, assume, strategies as st
 from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
 import numpy as np
 
-from .context import PQSC, DeviceTypes
+from .context import PQSC, DeviceTypes, LoggerModule
 
 
 def test_init_pqsc():
@@ -16,42 +16,48 @@ def test_init_pqsc():
     assert pqsc._enable is None
     assert pqsc.repetitions is None
     assert pqsc.holdoff is None
-    with pytest.raises(Exception):
+    with pytest.raises(LoggerModule.ToolkitConnectionError):
         pqsc._init_params()
     pqsc._init_settings()
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.is_running
 
 
 def test_methods_pqsc():
     pqsc = PQSC("name", "dev10000")
-    with pytest.raises(Exception):
+    with pytest.raises(LoggerModule.ToolkitConnectionError):
         pqsc.connect_device()
-    with pytest.raises(Exception):
+    with pytest.raises(LoggerModule.ToolkitConnectionError):
         pqsc.factory_reset()
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.arm()
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.arm(repetitions=100)
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.arm(holdoff=2e-6)
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.run()
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.stop()
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.wait_done()
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.check_ref_clock()
 
 
 @given(
     single_port=st.integers(0, 17),
+)
+def test_check_zsync_connection_single_port(single_port):
+    pqsc = PQSC("name", "dev10000")
+    with pytest.raises(LoggerModule.ToolkitConnectionError):
+        pqsc.check_zsync_connection(ports=single_port)
+
+
+@given(
     port_list=st.lists(st.integers(0, 17), min_size=1, max_size=18, unique=True),
 )
-def test_check_zsync_connection(single_port, port_list):
+def test_check_zsync_connection_port_list(port_list):
     pqsc = PQSC("name", "dev10000")
-    with pytest.raises(Exception):
-        pqsc.check_zsync_connection(ports=single_port)
-    with pytest.raises(Exception):
+    with pytest.raises(LoggerModule.ToolkitConnectionError):
         pqsc.check_zsync_connection(ports=port_list)

--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -26,6 +26,20 @@ def test_init_uhfqa():
     assert qa.averaging_mode is None
     assert qa.ref_clock is None
     assert qa._qa_delay_user == 0
+    assert qa.allowed_sequences == [
+        SequenceType.NONE,
+        SequenceType.SIMPLE,
+        SequenceType.READOUT,
+        SequenceType.CW_SPEC,
+        SequenceType.PULSED_SPEC,
+        SequenceType.CUSTOM,
+    ]
+    assert qa.allowed_trigger_modes == [
+        TriggerMode.NONE,
+        TriggerMode.EXTERNAL_TRIGGER,
+        TriggerMode.RECEIVE_TRIGGER,
+        TriggerMode.ZSYNC_TRIGGER,
+    ]
     with pytest.raises(Exception):
         qa._init_awg_cores()
     with pytest.raises(Exception):


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) `LoggerModule` class is added to `interface.py`:**
This is class implements a customized logging module. It is
imported by the individual modules in zhinst-toolkit by passing
`__name__` as the `name` argument. It formats the log message to display
 the caller information. In case of an error message, it raises an
 exception depending on the `exception_type` argument.
##### **2) Centralized logger integrated into the following modules:**
* `BaseInstrument` module in `base.py`
* `PQSC` module in `pqsc.py`
* `SHFQA` module in `shfqa.py`
* `AWGCore` module in `awg.py`
* `SHFGenerator` module in `shf_generator.py`
* `Parse` module in `parsers.py`
* `TriggerSequence` class in `sequences.py`