### PR TITLE
Add `allowed_sequences`, `allowed_trigger_modes`

### DIFF
--- a/tests/context.py
+++ b/tests/context.py
@@ -5,9 +5,15 @@
 
 
 from zhinst.ziPython import ziDiscovery
-from zhinst.toolkit import HDAWG, UHFQA, UHFLI, MFLI, PQSC, MultiDeviceConnection
+from zhinst.toolkit import HDAWG, UHFQA, UHFLI, MFLI, PQSC, SHFQA, MultiDeviceConnection
 from zhinst.toolkit.control.drivers.uhfqa import AWG as UHFQA_AWG, ReadoutChannel
 from zhinst.toolkit.control.drivers.hdawg import AWG as HDAWG_AWG
+from zhinst.toolkit.control.drivers.shfqa import (
+    Channel as SHFQA_Channel,
+    Generator as SHFQA_Generator,
+    Sweeper as SHFQA_Sweeper,
+    Scope as SHFQA_Scope,
+)
 from zhinst.toolkit.control.drivers.mfli import (
     DAQModule as DAQModule_MFLI,
     SweeperModule as Sweeper_MFLI,

--- a/tests/test_hdawg.py
+++ b/tests/test_hdawg.py
@@ -13,6 +13,23 @@ def test_init_hdawg():
     assert hd.device_type == DeviceTypes.HDAWG
     assert hd.ref_clock is None
     assert hd.ref_clock_status is None
+    assert hd.allowed_sequences == [
+        SequenceType.NONE,
+        SequenceType.SIMPLE,
+        SequenceType.TRIGGER,
+        SequenceType.RABI,
+        SequenceType.T1,
+        SequenceType.T2,
+        SequenceType.CUSTOM,
+    ]
+    assert hd.allowed_trigger_modes == [
+        TriggerMode.NONE,
+        TriggerMode.SEND_TRIGGER,
+        TriggerMode.EXTERNAL_TRIGGER,
+        TriggerMode.RECEIVE_TRIGGER,
+        TriggerMode.SEND_AND_RECEIVE_TRIGGER,
+        TriggerMode.ZSYNC_TRIGGER,
+    ]
     with pytest.raises(Exception):
         hd._init_awg_cores()
     with pytest.raises(Exception):

--- a/tests/test_shfqa.py
+++ b/tests/test_shfqa.py
@@ -1,0 +1,40 @@
+import pytest
+
+from .context import (
+    SHFQA,
+    SHFQA_Channel,
+    SHFQA_Generator,
+    SHFQA_Sweeper,
+    SHFQA_Scope,
+    DeviceTypes,
+    SequenceType,
+    TriggerMode,
+    ToolkitError,
+)
+
+
+def test_init_shfqa():
+    qa = SHFQA("name", "dev12000")
+    assert qa.device_type == DeviceTypes.SHFQA
+    assert len(qa._channels) == 0
+    assert len(qa.channels) == 0
+    assert qa._scope is None
+    assert qa.scope is None
+    assert qa.ref_clock is None
+    assert qa.ref_clock_actual is None
+    assert qa.ref_clock_status is None
+    assert qa.timebase is None
+    assert qa.allowed_sequences == [
+        SequenceType.NONE,
+        SequenceType.CUSTOM,
+    ]
+    assert qa.allowed_trigger_modes == [
+        TriggerMode.NONE,
+    ]
+    with pytest.raises(AttributeError):
+        qa._init_channels()
+    with pytest.raises(TypeError):
+        qa._init_scope()
+    with pytest.raises(ToolkitError):
+        qa._init_params()
+    qa._init_settings()

--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -26,6 +26,20 @@ def test_init_uhfqa():
     assert qa.averaging_mode is None
     assert qa.ref_clock is None
     assert qa._qa_delay_user == 0
+    assert qa.allowed_sequences == [
+        SequenceType.NONE,
+        SequenceType.SIMPLE,
+        SequenceType.READOUT,
+        SequenceType.CW_SPEC,
+        SequenceType.PULSED_SPEC,
+        SequenceType.CUSTOM,
+    ]
+    assert qa.allowed_trigger_modes == [
+        TriggerMode.NONE,
+        TriggerMode.EXTERNAL_TRIGGER,
+        TriggerMode.RECEIVE_TRIGGER,
+        TriggerMode.ZSYNC_TRIGGER,
+    ]
     with pytest.raises(Exception):
         qa._init_awg_cores()
     with pytest.raises(Exception):


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) New device attribute `allowed_sequences`:**
A list of allowed sequence types are added as attributes of the
following devices:
* UHFQA
* HDAWG
* SHFQA

##### **2) New device attribute `allowed_trigger_modes`:**
A list of allowed trigger modes are added as attributes of the
following devices:
* UHFQA
* HDAWG
* SHFQA

##### **3) Updated list of allowed trigger modes in UHFQA `:**
"Send Trigger" and "Send and Receive Trigger" modes are not tested on
UHFQA, therefore they are removed from the list of allowed trigger
modes.

##### **4) Updated tests to check new attributes `:**
* `test_init_hdawg` in `test_hdawg.py`
* `test_init_uhfqa` in `test_uhfqa.py`

##### **5) Added test for `SHFQA` to check new attributes `:**
`test_init_shfqa` in `test_shfqa.py`
