### PR TITLE
Add centralized logging module

### DIFF
--- a/src/zhinst/toolkit/control/multi_device_connection.py
+++ b/src/zhinst/toolkit/control/multi_device_connection.py
@@ -7,10 +7,12 @@ import numpy as np
 import json
 import pathlib
 
-from zhinst.toolkit.interface import InstrumentConfiguration
+from zhinst.toolkit.interface import InstrumentConfiguration, LoggerModule
 from zhinst.toolkit.control.connection import ZIConnection
 from zhinst.toolkit.control.drivers import *
-from zhinst.toolkit.control.drivers.base import ToolkitError, BaseInstrument
+from zhinst.toolkit.control.drivers.base import BaseInstrument
+
+_logger = LoggerModule(__name__)
 
 
 class MultiDeviceConnection:
@@ -113,9 +115,12 @@ class MultiDeviceConnection:
         elif isinstance(device, MFLI):
             self._mflis = device
         elif isinstance(device, SHFQA):
-            self.shfqas[device.name] = device
+            self._shfqas[device.name] = device
         else:
-            raise ToolkitError("This device is not recognized!")
+            _logger.error(
+                "This device is not recognized!",
+                _logger.ExceptionTypes.ToolkitError,
+            )
         device.setup(connection=self._shared_connection)
         device.connect_device()
 

--- a/src/zhinst/toolkit/control/node_tree.py
+++ b/src/zhinst/toolkit/control/node_tree.py
@@ -7,9 +7,9 @@ import numpy as np
 import re
 from typing import List, Dict, Callable
 
+from zhinst.toolkit.interface import LoggerModule
 
-class ToolkitNodeTreeError(Exception):
-    pass
+_logger = LoggerModule(__name__)
 
 
 class Parameter:
@@ -122,8 +122,9 @@ class Parameter:
             if self._map is not None:
                 allowed_values = list(self._map.keys())
                 if value not in allowed_values:
-                    raise ToolkitNodeTreeError(
-                        f"The value '{value}' is not in {allowed_values}."
+                    _logger.error(
+                        f"The value '{value}' is not in {allowed_values}.",
+                        _logger.ExceptionTypes.ValueError,
                     )
                 value = self._map[value]
                 # If the mapping has more than one value assigned to the
@@ -133,7 +134,10 @@ class Parameter:
             self._cached_value = self._get_parser(value)
             return self._cached_value
         else:
-            raise ToolkitNodeTreeError("This parameter is not gettable!")
+            _logger.error(
+                "This parameter is not gettable!",
+                _logger.ExceptionTypes.ToolkitNodeTreeError,
+            )
 
     def _setter(self, value):
         """Implements a setter for the :class:`Parameter`.
@@ -159,16 +163,18 @@ class Parameter:
                     # Construct a list from all allowed values in the mapping
                     allowed_values = self._flatten_mapping_values()
                     if value not in allowed_values:
-                        raise ToolkitNodeTreeError(
-                            f"The value '{value}' is not in {allowed_values}."
+                        _logger.error(
+                            f"The value '{value}' is not in {allowed_values}.",
+                            _logger.ExceptionTypes.ValueError,
                         )
                     inverse_map = self._invert_mapping()
                     value = inverse_map[value]
                 elif self._map is not None and isinstance(value, int):
                     allowed_values = list(self._map.keys())
                     if value not in allowed_values:
-                        raise ToolkitNodeTreeError(
-                            f"The value '{value}' is not in {allowed_values}."
+                        _logger.error(
+                            f"The value '{value}' is not in {allowed_values}.",
+                            _logger.ExceptionTypes.ValueError,
                         )
                 # If the set_parser is a list of callables, call them
                 # one by one inside a loop
@@ -189,7 +195,10 @@ class Parameter:
                 self._cached_value = self._get_parser(value)
             return self._cached_value
         else:
-            raise ToolkitNodeTreeError("This parameter is not settable!")
+            _logger.error(
+                "This parameter is not settable!",
+                _logger.ExceptionTypes.ToolkitNodeTreeError,
+            )
 
     def _invert_mapping(self):
         """Invert the map dictionary to create inverse mapping."""
@@ -230,10 +239,10 @@ class Parameter:
         a mapping will be automatically constructed from the options.
         The key values are converted from str to int."""
         if self._options is None:
-            raise ToolkitNodeTreeError(
-                "Automatic mapping cannot be constructed. "
-                "This node does not contain any information "
-                "regarding the allowed options!"
+            _logger.error(
+                "Automatic mapping cannot be constructed. This node does not "
+                "contain any information regarding the allowed options!",
+                _logger.ExceptionTypes.ToolkitNodeTreeError,
             )
         elif self._options is not None:
             map_from_options = {}

--- a/src/zhinst/toolkit/control/parsers.py
+++ b/src/zhinst/toolkit/control/parsers.py
@@ -4,25 +4,16 @@
 # of the MIT license. See the LICENSE file for details.
 
 import numpy as np
-import logging
-import traceback
+
+from zhinst.toolkit.interface import LoggerModule
 
 UHFQA_SAMPLE_RATE = 1.8e9
 SHFQA_SAMPLE_RATE = 2e9
-logging.basicConfig(format="%(levelname)s: %(message)s")
-_logger = logging.getLogger(__name__)
+_logger = LoggerModule(__name__)
 
 
 class Parse:
     """Input and output parsers for Parameters to validate and parse values."""
-
-    # Define a function to return the parameter name
-    @staticmethod
-    def _parameter_name():
-        frame_list = traceback.StackSummary.extract(traceback.walk_stack(None))
-        for frame in frame_list:
-            if frame.name == "<module>":
-                return frame.line
 
     # Define a function to format the value string
     @staticmethod
@@ -43,10 +34,16 @@ class Parse:
         if isinstance(v, str):
             map = {"on": 1, "off": 0}
             if v.lower() not in map.keys():
-                raise ValueError(f"The input value must be in {map.keys()}.")
+                _logger.error(
+                    f"The input value must be in {map.keys()}.",
+                    _logger.ExceptionTypes.ValueError,
+                )
             v = map[v.lower()]
         elif not isinstance(v, int):
-            raise ValueError("This value must be either 'on' or 'off' or an integer.")
+            _logger.error(
+                "This value must be either 'on' or 'off' or an integer.",
+                _logger.ExceptionTypes.ValueError,
+            )
         return v
 
     @staticmethod
@@ -54,7 +51,10 @@ class Parse:
         v = int(v)
         map = {1: "on", 0: "off"}
         if v not in map.keys():
-            raise ValueError("Invalid value returned from the instrument!")
+            _logger.error(
+                "Invalid value returned from the instrument!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return map[v]
 
     @staticmethod
@@ -62,10 +62,16 @@ class Parse:
         if isinstance(v, bool):
             map = {True: 1, False: 0}
             if v not in map.keys():
-                raise ValueError(f"The input value must be in {map.keys()}.")
+                _logger.error(
+                    f"The input value must be in {map.keys()}.",
+                    _logger.ExceptionTypes.ValueError,
+                )
             v = map[v]
         elif not isinstance(v, int):
-            raise ValueError("This value must be either True or False or an integer.")
+            _logger.error(
+                "This value must be either True or False or an integer.",
+                _logger.ExceptionTypes.ValueError,
+            )
         return v
 
     @staticmethod
@@ -73,7 +79,10 @@ class Parse:
         v = int(v)
         map = {1: True, 0: False}
         if v not in map.keys():
-            raise ValueError("Invalid value returned from the instrument!")
+            _logger.error(
+                "Invalid value returned from the instrument!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return map[v]
 
     @staticmethod
@@ -81,7 +90,10 @@ class Parse:
         v = int(v)
         map = {0: "locked", 1: "error", 2: "busy"}
         if v not in map.keys():
-            raise ValueError("Invalid value returned from the instrument!")
+            _logger.error(
+                "Invalid value returned from the instrument!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return map[v]
 
     @staticmethod
@@ -91,14 +103,16 @@ class Parse:
     @staticmethod
     def greater(v, limit):
         if v <= limit:
-            raise ValueError(f"This value must be greater than {limit}!")
+            _logger.error(
+                f"This value must be greater than {limit}!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return v
 
     @staticmethod
     def greater_equal(v, limit):
         if v < limit:
             _logger.warning(
-                f"{Parse._parameter_name()}\n"
                 f"The value {Parse._format_number(v)} must be greater than or equal to "
                 f"{Parse._format_number(limit)} and will be rounded up to: "
                 f"{Parse._format_number(limit)}",
@@ -110,14 +124,16 @@ class Parse:
     @staticmethod
     def smaller(v, limit):
         if v >= limit:
-            raise ValueError(f"This value must be smaller than {limit}!")
+            _logger.error(
+                f"This value must be smaller than {limit}!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return v
 
     @staticmethod
     def smaller_equal(v, limit):
         if v > limit:
             _logger.warning(
-                f"{Parse._parameter_name()}\n"
                 f"The value {Parse._format_number(v)} must be smaller than or equal to "
                 f"{Parse._format_number(limit)} and will be rounded down to: "
                 f"{Parse._format_number(limit)}",
@@ -133,7 +149,6 @@ class Parse:
         elif rounding == "nearest":
             v_rounded = round(v / factor) * factor
             _logger.warning(
-                f"{Parse._parameter_name()}\n"
                 f"The value {Parse._format_number(v)} is not a multiple of "
                 f"{Parse._format_number(factor)} and will be rounded to nearest "
                 f"multiple: {Parse._format_number(v_rounded)}",
@@ -142,7 +157,6 @@ class Parse:
         elif rounding == "down":
             v_rounded = round(v // factor) * factor
             _logger.warning(
-                f"{Parse._parameter_name()}\n"
                 f"The value {Parse._format_number(v)} is not a multiple of "
                 f"{Parse._format_number(factor)} and will be rounded down to greatest "
                 f"multiple: {Parse._format_number(v_rounded)}",

--- a/src/zhinst/toolkit/helpers/sequence_commands.py
+++ b/src/zhinst/toolkit/helpers/sequence_commands.py
@@ -8,8 +8,10 @@ import re
 import numpy as np
 import deprecation
 
-from zhinst.toolkit.interface import DeviceTypes
+from zhinst.toolkit.interface import DeviceTypes, LoggerModule
 from zhinst.toolkit._version import version as __version__
+
+_logger = LoggerModule(__name__)
 
 
 class SequenceCommand(object):
@@ -79,7 +81,10 @@ class SequenceCommand(object):
         if i == "inf":
             return f"while(true){{\n"
         if i < 0:
-            raise ValueError("Invalid number of repetitions!")
+            _logger.error(
+                "Invalid number of repetitions!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return f"repeat({int(i)}){{\n"
 
     @staticmethod
@@ -116,7 +121,10 @@ class SequenceCommand(object):
 
         """
         if i < 0:
-            raise ValueError("Wait time cannot be negative!")
+            _logger.error(
+                "Wait time cannot be negative!",
+                _logger.ExceptionTypes.ValueError,
+            )
         if i == 0:
             return "//\n"
         else:
@@ -136,14 +144,23 @@ class SequenceCommand(object):
 
         """
         if i < 0:
-            raise ValueError("Number of samples cannot be negative!")
+            _logger.error(
+                "Number of samples cannot be negative!",
+                _logger.ExceptionTypes.ValueError,
+            )
         elif target in [DeviceTypes.HDAWG]:
             if i < 32:
-                raise ValueError("Number of samples cannot be lower than 32 samples!")
+                _logger.error(
+                    "Number of samples cannot be lower than 32 samples!",
+                    _logger.ExceptionTypes.ValueError,
+                )
             return f"playZero({int(round(i / 16) * 16)});\n"
         elif target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI]:
             if i < 16:
-                raise ValueError("Number of samples cannot be lower than 16 samples!")
+                _logger.error(
+                    "Number of samples cannot be lower than 16 samples!",
+                    _logger.ExceptionTypes.ValueError,
+                )
             return f"playZero({int(round(i / 8) * 8)});\n"
 
     @staticmethod
@@ -158,9 +175,15 @@ class SequenceCommand(object):
     )
     def trigger(value, index=1):
         if value not in [0, 1]:
-            raise ValueError("Invalid Trigger Value!")
+            _logger.error(
+                "Invalid Trigger Value!",
+                _logger.ExceptionTypes.ValueError,
+            )
         if index not in [1, 2]:
-            raise ValueError("Invalid Trigger Index!")
+            _logger.error(
+                "Invalid Trigger Index!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return f"setTrigger({value << (index - 1)});\n"
 
     @staticmethod
@@ -173,9 +196,15 @@ class SequenceCommand(object):
             length (int): length of marker waveform in number of samples. (default: 32)
         """
         if length < 32:
-            raise ValueError("Trigger cannot be shorter than 32 samples!")
+            _logger.error(
+                "Trigger cannot be shorter than 32 samples!",
+                _logger.ExceptionTypes.ValueError,
+            )
         if length % 16:
-            raise ValueError("Trigger Length has to be multiple of 16!")
+            _logger.error(
+                "Trigger Length has to be multiple of 16!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return f"wave start_trigger = marker({length},1);\n"
 
     @staticmethod
@@ -196,7 +225,10 @@ class SequenceCommand(object):
 
         """
         if i < 0:
-            raise ValueError("Waveform Index cannot be negative!")
+            _logger.error(
+                "Waveform Index cannot be negative!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return f"assignWaveIndex(w{i + 1}_1, w{i + 1}_2, {i});\n"
 
     @staticmethod
@@ -206,21 +238,33 @@ class SequenceCommand(object):
     @staticmethod
     def play_wave_scaled(amp1, amp2):
         if abs(amp1) > 1 or abs(amp2) > 1:
-            raise ValueError("Amplitude cannot be larger than 1.0!")
+            _logger.error(
+                "Amplitude cannot be larger than 1.0!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return f"playWave({amp1}*w_1, {amp2}*w_2);\n"
 
     @staticmethod
     def play_wave_indexed(i):
         if i < 0:
-            raise ValueError("Invalid Waveform Index!")
+            _logger.error(
+                "Invalid Waveform Index!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return f"playWave(w{i + 1}_1, w{i + 1}_2);\n"
 
     @staticmethod
     def play_wave_indexed_scaled(amp1, amp2, i):
         if i < 0:
-            raise ValueError("Invalid Waveform Index!")
+            _logger.error(
+                "Invalid Waveform Index!",
+                _logger.ExceptionTypes.ValueError,
+            )
         if abs(amp1) > 1 or abs(amp2) > 1:
-            raise ValueError("Amplitude cannot be larger than 1.0!")
+            _logger.error(
+                "Amplitude cannot be larger than 1.0!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return f"playWave({amp1}*w{i+1}_1, {amp2}*w{i+2}_2);\n"
 
     @staticmethod
@@ -238,17 +282,32 @@ class SequenceCommand(object):
 
         """
         if i < 0:
-            raise ValueError("Invalid Values for waveform buffer!")
+            _logger.error(
+                "Invalid Values for waveform buffer!",
+                _logger.ExceptionTypes.ValueError,
+            )
         elif target in [DeviceTypes.HDAWG]:
             if length < 32:
-                raise ValueError("Buffer Length cannot be lower than 32 samples!")
+                _logger.error(
+                    "Buffer Length cannot be lower than 32 samples!",
+                    _logger.ExceptionTypes.ValueError,
+                )
             elif length % 16:
-                raise ValueError("Buffer Length has to be multiple of 16!")
+                _logger.error(
+                    "Buffer Length has to be multiple of 16!",
+                    _logger.ExceptionTypes.ValueError,
+                )
         elif target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI]:
             if length < 16:
-                raise ValueError("Buffer Length cannot be lower than 16 samples!")
+                _logger.error(
+                    "Buffer Length cannot be lower than 16 samples!",
+                    _logger.ExceptionTypes.ValueError,
+                )
             elif length % 8:
-                raise ValueError("Buffer Length has to be multiple of 8!")
+                _logger.error(
+                    "Buffer Length has to be multiple of 8!",
+                    _logger.ExceptionTypes.ValueError,
+                )
         return (
             f"wave w{i + 1}_1 = placeholder({length});\n"
             f"wave w{i + 1}_2 = placeholder({length});\n"
@@ -258,13 +317,25 @@ class SequenceCommand(object):
     def init_gauss(gauss_params):
         length, pos, width = gauss_params
         if length < 16:
-            raise ValueError("Invalid Value for length!")
+            _logger.error(
+                "Invalid Value for length!",
+                _logger.ExceptionTypes.ValueError,
+            )
         if length % 16:
-            raise ValueError("Length has to be multiple of 16!")
+            _logger.error(
+                "Length has to be multiple of 16!",
+                _logger.ExceptionTypes.ValueError,
+            )
         if not (length > pos and length > width):
-            raise ValueError("Length has to be larger than position and width!")
+            _logger.error(
+                "Length has to be larger than position and width!",
+                _logger.ExceptionTypes.ValueError,
+            )
         if not (width > 0):
-            raise ValueError("Values cannot be negative!")
+            _logger.error(
+                "Values cannot be negative!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return (
             f"wave w_1 = gauss({length}, {pos}, {width});\n"
             f"wave w_2 = gauss({length}, {pos}, {width});\n"
@@ -274,15 +345,30 @@ class SequenceCommand(object):
     def init_gauss_scaled(amp, gauss_params):
         length, pos, width = gauss_params
         if abs(amp) > 1:
-            raise ValueError("Amplitude cannot be larger than 1.0!")
+            _logger.error(
+                "Amplitude cannot be larger than 1.0!",
+                _logger.ExceptionTypes.ValueError,
+            )
         if length < 16:
-            raise ValueError("Invalid Value for length!")
+            _logger.error(
+                "Invalid Value for length!",
+                _logger.ExceptionTypes.ValueError,
+            )
         if length % 16:
-            raise ValueError("Length has to be multiple of 16!")
+            _logger.error(
+                "Length has to be multiple of 16!",
+                _logger.ExceptionTypes.ValueError,
+            )
         if not (length > pos and length > width):
-            raise ValueError("Length has to be larger than position and width!")
+            _logger.error(
+                "Length has to be larger than position and width!",
+                _logger.ExceptionTypes.ValueError,
+            )
         if not (width > 0):
-            raise ValueError("Values cannot be negative!")
+            _logger.error(
+                "Values cannot be negative!",
+                _logger.ExceptionTypes.ValueError,
+            )
         return (
             f"wave w_1 = {amp} * gauss({length}, {pos}, {width});\n"
             f"wave w_2 = {amp} * drag({length}, {pos}, {width});\n"
@@ -339,7 +425,10 @@ class SequenceCommand(object):
         """
 
         if index not in [1, 2]:
-            raise ValueError("Invalid Trigger Index!")
+            _logger.error(
+                "Invalid Trigger Index!",
+                _logger.ExceptionTypes.ValueError,
+            )
         if target in [DeviceTypes.HDAWG, DeviceTypes.SHFQA]:
             return f"waitDigTrigger({index});\n"
         elif target in [DeviceTypes.UHFQA, DeviceTypes.UHFLI]:

--- a/src/zhinst/toolkit/helpers/shf_waveform.py
+++ b/src/zhinst/toolkit/helpers/shf_waveform.py
@@ -5,6 +5,10 @@
 
 import numpy as np
 
+from zhinst.toolkit.interface import LoggerModule
+
+_logger = LoggerModule(__name__)
+
 
 class SHFWaveform(object):
     """Implements a waveform for single channel.
@@ -53,7 +57,10 @@ class SHFWaveform(object):
             self._wave = wave
             self._update()
         else:
-            raise Exception("Waveform lengths don't match!")
+            _logger.error(
+                "Waveform lengths don't match!",
+                _logger.ExceptionTypes.ToolkitError,
+            )
 
     @property
     def data(self):

--- a/src/zhinst/toolkit/helpers/waveform.py
+++ b/src/zhinst/toolkit/helpers/waveform.py
@@ -5,6 +5,10 @@
 
 import numpy as np
 
+from zhinst.toolkit.interface import LoggerModule
+
+_logger = LoggerModule(__name__)
+
 
 class Waveform(object):
     """Implements a waveform for two channels.
@@ -50,7 +54,10 @@ class Waveform(object):
             self._waves = [wave1, wave2]
             self._update()
         else:
-            raise Exception("Waveform lengths don't match!")
+            _logger.error(
+                "Waveform lengths don't match!",
+                _logger.ExceptionTypes.ToolkitError,
+            )
 
     @property
     def data(self):

--- a/src/zhinst/toolkit/interface/__init__.py
+++ b/src/zhinst/toolkit/interface/__init__.py
@@ -1,1 +1,1 @@
-from .interface import InstrumentConfiguration, DeviceTypes
+from .interface import InstrumentConfiguration, DeviceTypes, LoggerModule

--- a/src/zhinst/toolkit/interface/interface.py
+++ b/src/zhinst/toolkit/interface/interface.py
@@ -4,7 +4,9 @@
 # of the MIT license. See the LICENSE file for details.
 
 import attr
-from enum import Enum
+from enum import Enum, auto
+import logging
+import traceback
 
 
 class DeviceTypes(Enum):
@@ -62,3 +64,134 @@ class InstrumentConfiguration:
     @property
     def instrument(self):
         return self._instrument
+
+
+class LoggerModule:
+    """Implement a custom logging module.
+
+    Arguments:
+        name (str): Name used to instantiate the logger object using
+            the function `logging.getLogger(name)`. When the
+            `LoggerModule` class is imported to another module,
+            `__name__` should be used as argument.  That’s because in a
+             module, `__name__` is the module’s name in the Python
+             package namespace.
+
+    """
+
+    def __init__(self, name):
+        self._name = name
+        self._is_enabled = True
+        self._custom_field = {"callername": ""}
+        self._logger = logging.getLogger(self._name)
+        self._syslog = logging.StreamHandler()
+        self._formatter = logging.Formatter(
+            "%(levelname)s: %(callername)s\n%(message)s"
+        )
+        self._syslog.setFormatter(self._formatter)
+        self._logger.addHandler(self._syslog)
+        self._logger = logging.LoggerAdapter(self._logger, self._custom_field)
+
+    class ExceptionTypes(Enum):
+        """Enum of exception types."""
+
+        ToolkitConnectionError = auto()
+        ToolkitNodeTreeError = auto()
+        ValueError = auto()
+        TypeError = auto()
+        ToolkitError = auto()
+
+    class ToolkitConnectionError(Exception):
+        """Custom Exception class for ToolkitConnectionError"""
+
+        pass
+
+    class ToolkitNodeTreeError(Exception):
+        """Custom Exception class for ToolkitNodeTreeError"""
+
+        pass
+
+    class ToolkitError(Exception):
+        """Custom Exception class for ToolkitError"""
+
+        pass
+
+    def enable_logging(self):
+        self._is_enabled = True
+
+    def disable_logging(self):
+        self._is_enabled = False
+
+    @staticmethod
+    def _get_caller():
+        """Update the caller name.
+
+        This method extracts the line attribute of the FrameSummary object
+        with the name `<module>` . This line attribute corresponds to the line
+        of code in the user notebook that eventually calls this function.
+        """
+        frame_list = traceback.StackSummary.extract(traceback.walk_stack(None))
+        for frame in frame_list:
+            if frame.name == "<module>":
+                return frame.line
+
+    def info(self, msg, *args, **kwargs):
+        """Logs a message with level INFO on the log.
+
+        Updates the caller name before logging the message and passes
+        all arguments and keyword arguments to the underlying `info`
+        method.
+
+        Arguments:
+            msg (str): The message string
+        """
+        if self._is_enabled:
+            self._custom_field["callername"] = LoggerModule._get_caller()
+            self._logger = logging.LoggerAdapter(self._logger, self._custom_field)
+            self._logger.info(msg, *args, **kwargs)
+
+    def warning(self, msg, *args, **kwargs):
+        """Logs a message with level WARNING on the log.
+
+        Updates the caller name before logging the message and passes
+        all arguments and keyword arguments to the underlying `warning`
+        method.
+
+        Arguments:
+            msg (str): The message string
+        """
+        if self._is_enabled:
+            self._custom_field["callername"] = LoggerModule._get_caller()
+            self._logger = logging.LoggerAdapter(self._logger, self._custom_field)
+            self._logger.warning(msg, *args, **kwargs)
+
+    def error(self, msg, exception_type, *args, **kwargs):
+        """Logs a message with level ERROR on the log.
+
+        Updates the caller name before logging the message and passes
+        all arguments and keyword arguments to the underlying `error`
+        method. It eventually raises an exception depending on the
+        exception type specified by the `exception_type` argument.
+
+        Arguments:
+            msg (str): The message string
+            exception_type (class:`ExceptionTypes`): Type enum for the
+                exception to be raised.
+
+        """
+        if self._is_enabled:
+            self._custom_field["callername"] = LoggerModule._get_caller()
+            self._logger = logging.LoggerAdapter(self._logger, self._custom_field)
+            self._logger.error(msg, *args, **kwargs)
+        if exception_type == LoggerModule.ExceptionTypes.ToolkitConnectionError:
+            raise LoggerModule.ToolkitConnectionError(msg)
+        elif exception_type == LoggerModule.ExceptionTypes.ToolkitNodeTreeError:
+            raise LoggerModule.ToolkitNodeTreeError(msg)
+        elif exception_type == LoggerModule.ExceptionTypes.ValueError:
+            raise ValueError(msg)
+        elif exception_type == LoggerModule.ExceptionTypes.TypeError:
+            raise TypeError(msg)
+        elif exception_type == LoggerModule.ExceptionTypes.ToolkitError:
+            raise LoggerModule.ToolkitError(msg)
+        else:
+            raise Exception(msg)

--- a/tests/context.py
+++ b/tests/context.py
@@ -5,7 +5,7 @@
 
 
 from zhinst.ziPython import ziDiscovery
-from zhinst.toolkit import HDAWG, UHFQA, UHFLI, MFLI, PQSC, SHFQA, MultiDeviceConnection
+from zhinst.toolkit import HDAWG, UHFQA, UHFLI, MFLI, PQSC, SHFQA
 from zhinst.toolkit.control.drivers.uhfqa import AWG as UHFQA_AWG, ReadoutChannel
 from zhinst.toolkit.control.drivers.hdawg import AWG as HDAWG_AWG
 from zhinst.toolkit.control.drivers.shfqa import (
@@ -25,7 +25,7 @@ from zhinst.toolkit.control.drivers.uhfli import (
 from zhinst.toolkit.control.connection import (
     ZIConnection,
     DeviceConnection,
-    ToolkitConnectionError,
+    _logger as connection_logger,
 )
 from zhinst.toolkit.control.drivers.base import (
     BaseInstrument,
@@ -39,9 +39,18 @@ from zhinst.toolkit.control.node_tree import (
     Parameter,
     NodeList,
     Node,
-    ToolkitNodeTreeError,
+    _logger as nodetree_logger,
 )
-from zhinst.toolkit.control.parsers import Parse
-from zhinst.toolkit.helpers import Waveform, SequenceCommand, SequenceProgram
+from zhinst.toolkit.control.parsers import Parse, _logger as parser_logger
+from zhinst.toolkit.helpers.sequence_commands import (
+    SequenceCommand,
+    _logger as sequence_command_logger,
+)
+from zhinst.toolkit.helpers.sequences import _logger as sequences_logger
+from zhinst.toolkit.helpers.waveform import Waveform, _logger as waveform_logger
+from zhinst.toolkit.helpers import SequenceProgram
 from zhinst.toolkit import SequenceType, TriggerMode, Alignment
-from zhinst.toolkit.interface import InstrumentConfiguration, DeviceTypes
+from zhinst.toolkit.interface import (
+    InstrumentConfiguration,
+    DeviceTypes,
+)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3,12 +3,9 @@ from hypothesis import given, assume, strategies as st
 from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
 import numpy as np
 
-from .context import (
-    ZIConnection,
-    DeviceConnection,
-    ToolkitConnectionError,
-    DeviceTypes,
-)
+from .context import ZIConnection, DeviceConnection, DeviceTypes, connection_logger
+
+connection_logger.disable_logging()
 
 
 class Details:
@@ -46,15 +43,15 @@ def test_init_zi_connection():
 
 def test_check_connection():
     c = ZIConnection(Details())
-    with pytest.raises(ToolkitConnectionError):
+    with pytest.raises(connection_logger.ToolkitConnectionError):
         c.connect_device()
-    with pytest.raises(ToolkitConnectionError):
+    with pytest.raises(connection_logger.ToolkitConnectionError):
         c.get("tests/test")
-    with pytest.raises(ToolkitConnectionError):
+    with pytest.raises(connection_logger.ToolkitConnectionError):
         c.get_sample("tests/test")
-    with pytest.raises(ToolkitConnectionError):
+    with pytest.raises(connection_logger.ToolkitConnectionError):
         c.set("tests/test", 1)
-    with pytest.raises(ToolkitConnectionError):
+    with pytest.raises(connection_logger.ToolkitConnectionError):
         c.connect()
 
 
@@ -67,17 +64,17 @@ def test_init_device_connection():
 
 def test_device_connection_connect():
     c = DeviceConnection(Device(), DiscoveryMock())
-    with pytest.raises(ToolkitConnectionError):
+    with pytest.raises(connection_logger.ToolkitConnectionError):
         c.setup()
-    with pytest.raises(ToolkitConnectionError):
+    with pytest.raises(connection_logger.ToolkitConnectionError):
         c.setup(connection=ZIConnection(Details()))
-    with pytest.raises(ToolkitConnectionError):
+    with pytest.raises(connection_logger.ToolkitConnectionError):
         c.connect_device()
-    with pytest.raises(ToolkitConnectionError):
+    with pytest.raises(connection_logger.ToolkitConnectionError):
         c.get("tests/test")
-    with pytest.raises(ToolkitConnectionError):
+    with pytest.raises(connection_logger.ToolkitConnectionError):
         c.set("tests/test", 1)
-    with pytest.raises(ToolkitConnectionError):
+    with pytest.raises(connection_logger.ToolkitConnectionError):
         c.get_nodetree("*")
 
 

--- a/tests/test_nodetree.py
+++ b/tests/test_nodetree.py
@@ -3,8 +3,9 @@ from hypothesis import given, assume, strategies as st
 from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
 import numpy as np
 
-from .context import NodeTree, Node, NodeList
+from .context import NodeTree, Node, NodeList, nodetree_logger
 
+nodetree_logger.disable_logging()
 
 DUMMY_PARAMETER = {
     "Node": "test/bla/blub",

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -3,8 +3,9 @@ from hypothesis import given, assume, strategies as st
 from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
 import numpy as np
 
-from .context import Parameter, ToolkitNodeTreeError
+from .context import Parameter, nodetree_logger
 
+nodetree_logger.disable_logging()
 
 DUMMY_PARAMETER = {
     "Node": "test/bla/blub",
@@ -68,7 +69,7 @@ def test_set_get_readonly():
     params["Properties"] = "Read"
     p = Parameter(parent, DUMMY_PARAMETER)
     p()
-    with pytest.raises(ToolkitNodeTreeError):
+    with pytest.raises(nodetree_logger.ToolkitNodeTreeError):
         p(0)
 
 
@@ -80,5 +81,5 @@ def test_set_get_writeonly(v):
     params["Properties"] = "Write"
     p = Parameter(parent, DUMMY_PARAMETER)
     p(v)
-    with pytest.raises(ToolkitNodeTreeError):
+    with pytest.raises(nodetree_logger.ToolkitNodeTreeError):
         p()

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -3,7 +3,9 @@ from hypothesis import given, assume, strategies as st
 from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
 import numpy as np
 
-from .context import Parse
+from .context import Parse, parser_logger
+
+parser_logger.disable_logging()
 
 
 @given(st.integers(0, 5))
@@ -27,6 +29,27 @@ def test_get_on_off(n):
             Parse.get_on_off(n)
 
 
+@given(st.integers(0, 3))
+def test_set_true_false(n):
+    map = {0: False, 1: True, 2: 0, 3: 1}
+    val = Parse.set_true_false(map[n])
+    assert val in [0, 1]
+    with pytest.raises(ValueError):
+        Parse.set_true_false([])
+    with pytest.raises(ValueError):
+        Parse.set_true_false("a;kdhf")
+
+
+@given(st.integers(0, 3))
+def test_get_true_false(n):
+    if n < 2:
+        v = Parse.get_true_false(n)
+        assert v in [True, False]
+    else:
+        with pytest.raises(ValueError):
+            Parse.get_true_false(n)
+
+
 @given(st.integers(0, 4))
 def test_get_locked_status(n):
     if n < 3:
@@ -35,6 +58,24 @@ def test_get_locked_status(n):
     else:
         with pytest.raises(ValueError):
             Parse.get_locked_status(n)
+
+
+@given(v=st.floats(-2.0, 2.0), limit=st.floats(-2.0, 2.0))
+def test_greater(v, limit):
+    if v > limit:
+        assert v == Parse.greater(v, limit)
+    else:
+        with pytest.raises(ValueError):
+            Parse.greater(v, limit)
+
+
+@given(v=st.floats(-2.0, 2.0), limit=st.floats(-2.0, 2.0))
+def test_smaller(v, limit):
+    if v < limit:
+        assert v == Parse.smaller(v, limit)
+    else:
+        with pytest.raises(ValueError):
+            Parse.smaller(v, limit)
 
 
 @given(st.floats(0.0001, 1.0))

--- a/tests/test_sequenceCommands.py
+++ b/tests/test_sequenceCommands.py
@@ -7,7 +7,16 @@ import pytest
 from hypothesis import given, assume, strategies as st
 import numpy as np
 
-from .context import SequenceCommand, DeviceTypes, SequenceType, TriggerMode, Alignment
+from .context import (
+    SequenceCommand,
+    DeviceTypes,
+    SequenceType,
+    TriggerMode,
+    Alignment,
+    sequence_command_logger,
+)
+
+sequence_command_logger.disable_logging()
 
 
 @given(t=st.integers(0, 3))

--- a/tests/test_sequenceProgram.py
+++ b/tests/test_sequenceProgram.py
@@ -8,7 +8,18 @@ from hypothesis import given, assume, strategies as st
 from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
 import numpy as np
 
-from .context import SequenceProgram, SequenceType, TriggerMode, Alignment, DeviceTypes
+from .context import (
+    SequenceProgram,
+    SequenceType,
+    TriggerMode,
+    Alignment,
+    DeviceTypes,
+    sequence_command_logger,
+    sequences_logger,
+)
+
+sequence_command_logger.disable_logging()
+sequences_logger.disable_logging()
 
 
 class SequenceProgramMachine(RuleBasedStateMachine):

--- a/tests/test_waveform.py
+++ b/tests/test_waveform.py
@@ -7,7 +7,9 @@ import pytest
 from hypothesis import given, assume, strategies as st
 import numpy as np
 
-from .context import Waveform
+from .context import Waveform, waveform_logger
+
+waveform_logger.disable_logging()
 
 
 class TestWaveform:


### PR DESCRIPTION
Add centralized logging module

#### **The following changes are made in this update:**
##### **1) `LoggerModule` class is added to `interface.py`:**
This is class implements a customized logging module. It is
imported by the individual modules in zhinst-toolkit by passing
`__name__` as the `name` argument. It formats the log message to display
 the caller information. In case of an error message, it raises an
 exception depending on the `exception_type` argument.
Integrate centralized logger to modules
##### **2) Centralized logger integrated into the following modules:**
* `connection.py`
* `multi_device_connection.py`
* `node_tree.py`
* `parsers.py`
* `sequence_commands.py`
* `sequences.py`
* `shf_waveform.py`
* `waveform.py`
##### **3) Centralized logger integrated into the following tests:**
* `test_connection.py`
* `test_nodetree`
* `test_parsers.py`
* `test_parameter.py`
* `test_sequenceCommands.py`
* `test_sequenceProgram.py`
Note that the logging is disabled during tests.