### PR TITLE
Reformat all code with `black`

### DIFF
--- a/src/zhinst/toolkit/control/connection.py
+++ b/src/zhinst/toolkit/control/connection.py
@@ -483,8 +483,7 @@ class DeviceConnection(object):
             self.normalized_serial = self._device.serial
 
         self._connection.connect_device(
-            serial=self.normalized_serial,
-            interface=self._device.interface,
+            serial=self.normalized_serial, interface=self._device.interface,
         )
 
     def set(self, *args):
@@ -568,8 +567,7 @@ class DeviceConnection(object):
                 node_string = self._command_to_node(command)
             else:
                 _logger.error(
-                    "Invalid argument!",
-                    _logger.ExceptionTypes.ToolkitConnectionError,
+                    "Invalid argument!", _logger.ExceptionTypes.ToolkitConnectionError,
                 )
             if (
                 self._device.device_type in [DeviceTypes.UHFLI, DeviceTypes.MFLI]
@@ -589,8 +587,7 @@ class DeviceConnection(object):
                 return data
         else:
             _logger.error(
-                "No device connected!",
-                _logger.ExceptionTypes.ToolkitConnectionError,
+                "No device connected!", _logger.ExceptionTypes.ToolkitConnectionError,
             )
 
     def get_nodetree(self, prefix: str, **kwargs):

--- a/src/zhinst/toolkit/control/drivers/base/base.py
+++ b/src/zhinst/toolkit/control/drivers/base/base.py
@@ -185,14 +185,10 @@ class BaseInstrument:
             get_parser=Parse.version_parser,
         )
         self.firmware_version = Parameter(
-            self,
-            self._get_node_dict(f"/system/fwrevision"),
-            device=self,
+            self, self._get_node_dict(f"/system/fwrevision"), device=self,
         )
         self.fpga_version = Parameter(
-            self,
-            self._get_node_dict(f"/system/fpgarevision"),
-            device=self,
+            self, self._get_node_dict(f"/system/fpgarevision"), device=self,
         )
 
     def _init_settings(self):

--- a/src/zhinst/toolkit/control/drivers/base/daq.py
+++ b/src/zhinst/toolkit/control/drivers/base/daq.py
@@ -7,11 +7,7 @@ from zhinst.toolkit.control.node_tree import Parameter
 
 
 MAPPINGS = {
-    "edge": {
-        1: "rising",
-        2: "falling",
-        3: "both",
-    },
+    "edge": {1: "rising", 2: "falling", 3: "both",},
     "eventcount_mode": {0: "sample", 1: "increment"},
     "fft_window": {
         0: "rectangular",
@@ -23,23 +19,9 @@ MAPPINGS = {
         17: "sine",
         18: "cosine_squared",
     },
-    "grid_direction": {
-        0: "forward",
-        1: "reverse",
-        2: "bidirectional",
-    },
-    "grid_mode": {
-        1: "nearest",
-        2: "linear",
-        4: "exact",
-    },
-    "save_fileformat": {
-        0: "matlab",
-        1: "csv",
-        2: "zview",
-        3: "sxm",
-        4: "hdf5",
-    },
+    "grid_direction": {0: "forward", 1: "reverse", 2: "bidirectional",},
+    "grid_mode": {1: "nearest", 2: "linear", 4: "exact",},
+    "save_fileformat": {0: "matlab", 1: "csv", 2: "zview", 3: "sxm", 4: "hdf5",},
     "type": {
         0: "continuous",
         1: "edge",
@@ -145,10 +127,7 @@ class DAQModule:
         # the `streaming_nodes` are used as all available signal sources for the data acquisition
         self._signal_sources = self._parent._get_streamingnodes()
         self._signal_types = {
-            "auxin": {
-                "auxin1": ".Auxin0",
-                "auxin2": ".Auxin1",
-            },
+            "auxin": {"auxin1": ".Auxin0", "auxin2": ".Auxin1",},
             "demod": {
                 "x": ".X",
                 "y": ".Y",

--- a/src/zhinst/toolkit/control/drivers/base/sweeper.py
+++ b/src/zhinst/toolkit/control/drivers/base/sweeper.py
@@ -7,23 +7,10 @@ from zhinst.toolkit.control.node_tree import Parameter
 
 
 MAPPINGS = {
-    "bandwidthcontrol": {
-        0: "manual",
-        1: "fixed",
-        2: "automatic",
-    },
-    "save_fileformat": {
-        0: "matlab",
-        1: "csv",
-        2: "zview",
-        3: "sxm",
-        4: "hdf5",
-    },
+    "bandwidthcontrol": {0: "manual", 1: "fixed", 2: "automatic",},
+    "save_fileformat": {0: "matlab", 1: "csv", 2: "zview", 3: "sxm", 4: "hdf5",},
     "scan": {0: "sequential", 1: "binary", 2: "bidirectional", 3: "reverse"},
-    "xmapping": {
-        0: "linear",
-        1: "logarithmic",
-    },
+    "xmapping": {0: "linear", 1: "logarithmic",},
     "signal_sources": {
         "demod0": "/demods/0/sample",
         "demod1": "/demods/1/sample",

--- a/src/zhinst/toolkit/control/drivers/hdawg.py
+++ b/src/zhinst/toolkit/control/drivers/hdawg.py
@@ -467,10 +467,7 @@ class AWG(AWGCore):
             (f"awgs/{i}/outputs/1/modulation/mode", 2),  # modulation: sine 22
             (f"sines/{2 * i}/oscselect", 4 * i),  # select osc N for awg N
             (f"sines/{2 * i + 1}/oscselect", 4 * i),  # select osc N for awg N
-            (
-                f"sines/{2 * i + 1}/phaseshift",
-                90,
-            ),  # 90 deg phase shift
+            (f"sines/{2 * i + 1}/phaseshift", 90,),  # 90 deg phase shift
         ]
         self._parent._set(settings)
         self.set_sequence_params(reset_phase=True)
@@ -487,10 +484,7 @@ class AWG(AWGCore):
         settings = [
             (f"awgs/{i}/outputs/0/modulation/mode", 0),  # modulation: sine 11
             (f"awgs/{i}/outputs/1/modulation/mode", 0),  # modulation: sine 22
-            (
-                f"sines/{2 * i + 1}/phaseshift",
-                0,
-            ),  # 90 deg phase shift
+            (f"sines/{2 * i + 1}/phaseshift", 0,),  # 90 deg phase shift
         ]
         self._parent._set(settings)
         self.set_sequence_params(reset_phase=False)

--- a/src/zhinst/toolkit/control/drivers/pqsc.py
+++ b/src/zhinst/toolkit/control/drivers/pqsc.py
@@ -226,9 +226,7 @@ class PQSC(BaseInstrument):
             get_parser=Parse.get_locked_status,
         )
         self.progress = Parameter(
-            self,
-            self._get_node_dict(f"execution/progress"),
-            device=self,
+            self, self._get_node_dict(f"execution/progress"), device=self,
         )
         self._enable = Parameter(
             self,

--- a/src/zhinst/toolkit/control/drivers/shfqa.py
+++ b/src/zhinst/toolkit/control/drivers/shfqa.py
@@ -120,9 +120,7 @@ class SHFQA(BaseInstrument):
             get_parser=Parse.get_locked_status,
         )
         self.timebase = Parameter(
-            self,
-            self._get_node_dict(f"system/properties/timebase"),
-            device=self,
+            self, self._get_node_dict(f"system/properties/timebase"), device=self,
         )
 
     def set_trigger_loopback(self):
@@ -576,9 +574,7 @@ class Scope(SHFScope):
 
     def _init_scope_params(self):
         self.enable = Parameter(
-            self,
-            self._parent._get_node_dict(f"scopes/0/enable"),
-            device=self._parent,
+            self, self._parent._get_node_dict(f"scopes/0/enable"), device=self._parent,
         )
         self.channel1 = Parameter(
             self,

--- a/src/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/src/zhinst/toolkit/control/drivers/uhfqa.py
@@ -22,10 +22,7 @@ MAPPINGS = {
         5: "Threshold Correlation",
         7: "Integration",
     },
-    "averaging_mode": {
-        0: "Cyclic",
-        1: "Sequential",
-    },
+    "averaging_mode": {0: "Cyclic", 1: "Sequential",},
 }
 
 
@@ -398,10 +395,7 @@ class UHFQA(BaseInstrument):
             mapping=MAPPINGS["averaging_mode"],
         )
         self.ref_clock = Parameter(
-            self,
-            self._get_node_dict(f"system/extclk"),
-            device=self,
-            auto_mapping=True,
+            self, self._get_node_dict(f"system/extclk"), device=self, auto_mapping=True,
         )
 
     def _init_settings(self):
@@ -673,9 +667,7 @@ class AWG(AWGCore):
                     amps.append(ch.readout_amplitude())
                     phases.append(ch.phase_shift())
             self.set_sequence_params(
-                readout_frequencies=freqs,
-                readout_amplitudes=amps,
-                phase_shifts=phases,
+                readout_frequencies=freqs, readout_amplitudes=amps, phase_shifts=phases,
             )
         else:
             raise ToolkitError("AWG Sequence type needs to be 'Readout'")

--- a/src/zhinst/toolkit/control/multi_device_connection.py
+++ b/src/zhinst/toolkit/control/multi_device_connection.py
@@ -118,8 +118,7 @@ class MultiDeviceConnection:
             self._shfqas[device.name] = device
         else:
             _logger.error(
-                "This device is not recognized!",
-                _logger.ExceptionTypes.ToolkitError,
+                "This device is not recognized!", _logger.ExceptionTypes.ToolkitError,
             )
         device.setup(connection=self._shared_connection)
         device.connect_device()

--- a/src/zhinst/toolkit/helpers/sequence_commands.py
+++ b/src/zhinst/toolkit/helpers/sequence_commands.py
@@ -82,8 +82,7 @@ class SequenceCommand(object):
             return f"while(true){{\n"
         if i < 0:
             _logger.error(
-                "Invalid number of repetitions!",
-                _logger.ExceptionTypes.ValueError,
+                "Invalid number of repetitions!", _logger.ExceptionTypes.ValueError,
             )
         return f"repeat({int(i)}){{\n"
 
@@ -122,8 +121,7 @@ class SequenceCommand(object):
         """
         if i < 0:
             _logger.error(
-                "Wait time cannot be negative!",
-                _logger.ExceptionTypes.ValueError,
+                "Wait time cannot be negative!", _logger.ExceptionTypes.ValueError,
             )
         if i == 0:
             return "//\n"
@@ -176,13 +174,11 @@ class SequenceCommand(object):
     def trigger(value, index=1):
         if value not in [0, 1]:
             _logger.error(
-                "Invalid Trigger Value!",
-                _logger.ExceptionTypes.ValueError,
+                "Invalid Trigger Value!", _logger.ExceptionTypes.ValueError,
             )
         if index not in [1, 2]:
             _logger.error(
-                "Invalid Trigger Index!",
-                _logger.ExceptionTypes.ValueError,
+                "Invalid Trigger Index!", _logger.ExceptionTypes.ValueError,
             )
         return f"setTrigger({value << (index - 1)});\n"
 
@@ -226,8 +222,7 @@ class SequenceCommand(object):
         """
         if i < 0:
             _logger.error(
-                "Waveform Index cannot be negative!",
-                _logger.ExceptionTypes.ValueError,
+                "Waveform Index cannot be negative!", _logger.ExceptionTypes.ValueError,
             )
         return f"assignWaveIndex(w{i + 1}_1, w{i + 1}_2, {i});\n"
 
@@ -248,8 +243,7 @@ class SequenceCommand(object):
     def play_wave_indexed(i):
         if i < 0:
             _logger.error(
-                "Invalid Waveform Index!",
-                _logger.ExceptionTypes.ValueError,
+                "Invalid Waveform Index!", _logger.ExceptionTypes.ValueError,
             )
         return f"playWave(w{i + 1}_1, w{i + 1}_2);\n"
 
@@ -257,8 +251,7 @@ class SequenceCommand(object):
     def play_wave_indexed_scaled(amp1, amp2, i):
         if i < 0:
             _logger.error(
-                "Invalid Waveform Index!",
-                _logger.ExceptionTypes.ValueError,
+                "Invalid Waveform Index!", _logger.ExceptionTypes.ValueError,
             )
         if abs(amp1) > 1 or abs(amp2) > 1:
             _logger.error(
@@ -318,13 +311,11 @@ class SequenceCommand(object):
         length, pos, width = gauss_params
         if length < 16:
             _logger.error(
-                "Invalid Value for length!",
-                _logger.ExceptionTypes.ValueError,
+                "Invalid Value for length!", _logger.ExceptionTypes.ValueError,
             )
         if length % 16:
             _logger.error(
-                "Length has to be multiple of 16!",
-                _logger.ExceptionTypes.ValueError,
+                "Length has to be multiple of 16!", _logger.ExceptionTypes.ValueError,
             )
         if not (length > pos and length > width):
             _logger.error(
@@ -333,8 +324,7 @@ class SequenceCommand(object):
             )
         if not (width > 0):
             _logger.error(
-                "Values cannot be negative!",
-                _logger.ExceptionTypes.ValueError,
+                "Values cannot be negative!", _logger.ExceptionTypes.ValueError,
             )
         return (
             f"wave w_1 = gauss({length}, {pos}, {width});\n"
@@ -351,13 +341,11 @@ class SequenceCommand(object):
             )
         if length < 16:
             _logger.error(
-                "Invalid Value for length!",
-                _logger.ExceptionTypes.ValueError,
+                "Invalid Value for length!", _logger.ExceptionTypes.ValueError,
             )
         if length % 16:
             _logger.error(
-                "Length has to be multiple of 16!",
-                _logger.ExceptionTypes.ValueError,
+                "Length has to be multiple of 16!", _logger.ExceptionTypes.ValueError,
             )
         if not (length > pos and length > width):
             _logger.error(
@@ -366,8 +354,7 @@ class SequenceCommand(object):
             )
         if not (width > 0):
             _logger.error(
-                "Values cannot be negative!",
-                _logger.ExceptionTypes.ValueError,
+                "Values cannot be negative!", _logger.ExceptionTypes.ValueError,
             )
         return (
             f"wave w_1 = {amp} * gauss({length}, {pos}, {width});\n"
@@ -426,8 +413,7 @@ class SequenceCommand(object):
 
         if index not in [1, 2]:
             _logger.error(
-                "Invalid Trigger Index!",
-                _logger.ExceptionTypes.ValueError,
+                "Invalid Trigger Index!", _logger.ExceptionTypes.ValueError,
             )
         if target in [DeviceTypes.HDAWG, DeviceTypes.SHFQA]:
             return f"waitDigTrigger({index});\n"

--- a/src/zhinst/toolkit/helpers/sequences.py
+++ b/src/zhinst/toolkit/helpers/sequences.py
@@ -141,8 +141,7 @@ class Sequence(object):
         converter=lambda m: TriggerMode.NONE if m == "None" else TriggerMode(m),
     )
     trigger_samples = attr.ib(
-        default=32,
-        validator=[is_greater_equal(32), is_multiple(16)],
+        default=32, validator=[is_greater_equal(32), is_multiple(16)],
     )
     repetitions = attr.ib(default=1)
     alignment = attr.ib(
@@ -361,8 +360,7 @@ class Sequence(object):
         """Performs sanity checks on the sequence parameters."""
         if (self.period - self.dead_time - self.latency + self.trigger_delay) < 0:
             _logger.error(
-                "Wait time cannot be negative!",
-                _logger.ExceptionTypes.ValueError,
+                "Wait time cannot be negative!", _logger.ExceptionTypes.ValueError,
             )
 
     def __setattr__(self, name, value) -> None:
@@ -591,8 +589,7 @@ class RabiSequence(Sequence):
     """
 
     pulse_amplitudes = attr.ib(
-        default=[1.0],
-        validator=[is_greater_equal(-1.0), is_smaller_equal(1.0)],
+        default=[1.0], validator=[is_greater_equal(-1.0), is_smaller_equal(1.0)],
     )
     pulse_width = attr.ib(default=50e-9, validator=is_greater_equal(0))
     pulse_truncation = attr.ib(default=3, validator=is_greater_equal(0))
@@ -647,8 +644,7 @@ class RabiSequence(Sequence):
             self.period - self.dead_time - 2 * self.pulse_width * self.pulse_truncation
         ) < 0:
             _logger.error(
-                "Wait time cannot be negative!",
-                _logger.ExceptionTypes.ValueError,
+                "Wait time cannot be negative!", _logger.ExceptionTypes.ValueError,
             )
         if self.n_HW_loop < len(self.pulse_amplitudes):
             _logger.error(
@@ -687,8 +683,7 @@ class T1Sequence(Sequence):
     """
 
     pulse_amplitude = attr.ib(
-        default=1,
-        validator=[is_greater_equal(-1.0), is_smaller_equal(1.0)],
+        default=1, validator=[is_greater_equal(-1.0), is_smaller_equal(1.0)],
     )
     pulse_width = attr.ib(default=50e-9, validator=is_greater_equal(0))
     pulse_truncation = attr.ib(default=3, validator=is_greater_equal(0))
@@ -731,8 +726,7 @@ class T1Sequence(Sequence):
         super().check_attributes()
         if (self.period - self.dead_time - self.gauss_params[0] / self.clock_rate) < 0:
             _logger.error(
-                "Wait time cannot be negative!",
-                _logger.ExceptionTypes.ValueError,
+                "Wait time cannot be negative!", _logger.ExceptionTypes.ValueError,
             )
         if self.n_HW_loop > len(self.delay_times):
             _logger.error(

--- a/src/zhinst/toolkit/helpers/shf_waveform.py
+++ b/src/zhinst/toolkit/helpers/shf_waveform.py
@@ -58,8 +58,7 @@ class SHFWaveform(object):
             self._update()
         else:
             _logger.error(
-                "Waveform lengths don't match!",
-                _logger.ExceptionTypes.ToolkitError,
+                "Waveform lengths don't match!", _logger.ExceptionTypes.ToolkitError,
             )
 
     @property

--- a/src/zhinst/toolkit/helpers/waveform.py
+++ b/src/zhinst/toolkit/helpers/waveform.py
@@ -55,8 +55,7 @@ class Waveform(object):
             self._update()
         else:
             _logger.error(
-                "Waveform lengths don't match!",
-                _logger.ExceptionTypes.ToolkitError,
+                "Waveform lengths don't match!", _logger.ExceptionTypes.ToolkitError,
             )
 
     @property

--- a/tests/test_nodetree.py
+++ b/tests/test_nodetree.py
@@ -17,11 +17,7 @@ DUMMY_DICT = {
         "second": DUMMY_PARAMETER,
         "third": DUMMY_PARAMETER,
     },
-    "second": {
-        1: DUMMY_PARAMETER,
-        2: DUMMY_PARAMETER,
-        3: DUMMY_PARAMETER,
-    },
+    "second": {1: DUMMY_PARAMETER, 2: DUMMY_PARAMETER, 3: DUMMY_PARAMETER,},
     "third": DUMMY_PARAMETER,
     "fourths": {1: DUMMY_PARAMETER},
 }

--- a/tests/test_sequenceCommands.py
+++ b/tests/test_sequenceCommands.py
@@ -27,8 +27,7 @@ def test_header_comment(t):
 
 
 @given(
-    trigger_mode=st.sampled_from(TriggerMode),
-    alignment=st.sampled_from(Alignment),
+    trigger_mode=st.sampled_from(TriggerMode), alignment=st.sampled_from(Alignment),
 )
 def test_header_info(trigger_mode, alignment):
     line = SequenceCommand.header_info(SequenceType.NONE, trigger_mode, alignment)


### PR DESCRIPTION
Python code formatter package `black` is upgraded. Therefore, we run
`black` over the entire project to reformat everything. The most
important change in the upgrade is the correction of max string length
calculation when there are string operators.