### PR TITLE
Update `ZIConnection` and `DeviceConnection`

### DIFF
--- a/src/zhinst/toolkit/control/drivers/base/awg.py
+++ b/src/zhinst/toolkit/control/drivers/base/awg.py
@@ -105,7 +105,7 @@ class AWGCore:
         self.set_sequence_params(target=self._parent.device_type)
 
     def _setup(self):
-        self._module = self._parent._controller._connection.awg_module
+        self._module = self._parent._controller.connection.awg_module
 
     def _init_awg_params(self):
         """Initialize parameters associated with device AWG nodes.

--- a/src/zhinst/toolkit/control/drivers/base/ct.py
+++ b/src/zhinst/toolkit/control/drivers/base/ct.py
@@ -32,7 +32,7 @@ class CommandTable:
         # Convert the json object
         # Load the command table to the device
         node = f"awgs/{self._index}/commandtable/data"
-        self._device._setVector(node, json.dumps(table_updated))
+        self._device._set_vector(node, json.dumps(table_updated))
 
     def _validate(self, table):
         """ Ensure command table is valid JSON and compliant with schema"""

--- a/src/zhinst/toolkit/control/drivers/base/daq.py
+++ b/src/zhinst/toolkit/control/drivers/base/daq.py
@@ -155,7 +155,7 @@ class DAQModule:
         self._trigger_types = {}
 
     def _setup(self) -> None:
-        self._module = self._parent._controller._connection.daq_module
+        self._module = self._parent._controller.connection.daq_module
         # add all parameters from nodetree
         nodetree = self._module.get_nodetree("*")
         for k, v in nodetree.items():

--- a/src/zhinst/toolkit/control/drivers/base/shf_generator.py
+++ b/src/zhinst/toolkit/control/drivers/base/shf_generator.py
@@ -42,7 +42,7 @@ class SHFGenerator:
         self.set_sequence_params(target=self._device.device_type)
 
     def _setup(self):
-        self._module = self._device._controller._connection.awg_module
+        self._module = self._device._controller.connection.awg_module
 
     def _init_generator_params(self):
         """Initialize parameters associated with device generators.
@@ -192,7 +192,7 @@ class SHFGenerator:
             for i in range(len(waveform_data))
         ]
         tok = time.time()
-        self._device._setVector(zip(nodes, waveform_data))
+        self._device._set_vector(zip(nodes, waveform_data))
         tik = time.time()
         print(f"Upload of {len(waveform_data)} waveforms took {tik - tok:.5} s")
 

--- a/src/zhinst/toolkit/control/drivers/base/shf_sweeper.py
+++ b/src/zhinst/toolkit/control/drivers/base/shf_sweeper.py
@@ -25,7 +25,7 @@ class SHFSweeper:
         self._index = self._parent._index
         self._device = self._parent._parent
         self._module = ShfSweeper(
-            daq=self._device._controller._connection._daq, dev=self._device.serial
+            daq=self._device._controller.connection.daq, dev=self._device.serial
         )
         self._channel_params = RfConfig
         self._trig_config = TriggerConfig

--- a/src/zhinst/toolkit/control/drivers/base/sweeper.py
+++ b/src/zhinst/toolkit/control/drivers/base/sweeper.py
@@ -161,7 +161,7 @@ class SweeperModule:
         self._sweep_params = {}
 
     def _setup(self) -> None:
-        self._module = self._parent._controller._connection.sweeper_module
+        self._module = self._parent._controller.connection.sweeper_module
         # add all parameters from nodetree
         nodetree = self._module.get_nodetree("*")
         for k, v in nodetree.items():

--- a/src/zhinst/toolkit/control/drivers/shfqa.py
+++ b/src/zhinst/toolkit/control/drivers/shfqa.py
@@ -13,12 +13,12 @@ from zhinst.toolkit.control.drivers.base import (
     SHFScope,
     SHFSweeper,
 )
-from zhinst.toolkit.interface import DeviceTypes
+from zhinst.toolkit.interface import DeviceTypes, LoggerModule
 from zhinst.toolkit.control.node_tree import Parameter
 from zhinst.toolkit.control.parsers import Parse
 from zhinst.toolkit.helpers import SequenceType, TriggerMode
 
-_logger = logging.getLogger(__name__)
+_logger = LoggerModule(__name__)
 
 
 class SHFQA(BaseInstrument):
@@ -81,7 +81,7 @@ class SHFQA(BaseInstrument):
     def _num_channels(self):
         """Find the number of channels available in the instrument."""
         serial = self.serial
-        daq = self._controller._connection._daq
+        daq = self._controller.connection.daq
         channels = daq.listNodes(f"{serial}/qachannels/")
         num_channels = len(channels)
         return num_channels

--- a/tests/context.py
+++ b/tests/context.py
@@ -6,6 +6,10 @@
 
 from zhinst.ziPython import ziDiscovery
 from zhinst.toolkit import HDAWG, UHFQA, UHFLI, MFLI, PQSC, SHFQA
+from zhinst.toolkit.control.drivers.base.base import (
+    BaseInstrument,
+    _logger as baseinstrument_logger,
+)
 from zhinst.toolkit.control.drivers.uhfqa import AWG as UHFQA_AWG, ReadoutChannel
 from zhinst.toolkit.control.drivers.hdawg import AWG as HDAWG_AWG
 from zhinst.toolkit.control.drivers.shfqa import (
@@ -13,6 +17,7 @@ from zhinst.toolkit.control.drivers.shfqa import (
     Generator as SHFQA_Generator,
     Sweeper as SHFQA_Sweeper,
     Scope as SHFQA_Scope,
+    _logger as shfqa_logger,
 )
 from zhinst.toolkit.control.drivers.mfli import (
     DAQModule as DAQModule_MFLI,
@@ -28,7 +33,6 @@ from zhinst.toolkit.control.connection import (
     _logger as connection_logger,
 )
 from zhinst.toolkit.control.drivers.base import (
-    BaseInstrument,
     ToolkitError,
     AWGCore,
     DAQModule,

--- a/tests/test_baseInstrument.py
+++ b/tests/test_baseInstrument.py
@@ -1,15 +1,14 @@
 import pytest
-from hypothesis import given, assume, strategies as st
-from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
-import numpy as np
 
 from .context import (
     BaseInstrument,
     ToolkitError,
     DeviceTypes,
-    ZIConnection,
     ziDiscovery,
+    baseinstrument_logger,
 )
+
+baseinstrument_logger.disable_logging()
 
 
 class DiscoveryMock:
@@ -47,6 +46,8 @@ def test_init_instrument():
         interface="1GbE",
         discovery=DiscoveryMock(),
     )
+    assert instr._nodetree is None
+    assert instr._options is None
     assert instr.nodetree is None
     assert instr.name == "name"
     assert instr.device_type == DeviceTypes.PQSC
@@ -64,21 +65,21 @@ def test_check_connection():
         interface="1GbE",
         discovery=DiscoveryMock(),
     )
-    with pytest.raises(ToolkitError):
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
         instr._check_connected()
-    with pytest.raises(ToolkitError):
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
         instr._check_node_exists("sigouts/0/on")
-    with pytest.raises(ToolkitError):
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
         instr.connect_device()
-    with pytest.raises(ToolkitError):
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
         instr._get("sigouts/0/on")
-    with pytest.raises(ToolkitError):
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
         instr._set("sigouts/0/on", 1)
-    with pytest.raises(TypeError):
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
         instr._get_node_dict("sigouts/0/on")
-    with pytest.raises(ToolkitError):
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
         instr._get_node_dict("zi/about/revision")
-    with pytest.raises(ToolkitError):
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
         instr._get_streamingnodes()
 
 
@@ -91,7 +92,6 @@ def test_serials():
         BaseInstrument(
             "name", DeviceTypes.PQSC, 10000, interface="1GbE", discovery=DiscoveryMock()
         )
-
     BaseInstrument(
         "name",
         DeviceTypes.PQSC,

--- a/tests/test_shfqa.py
+++ b/tests/test_shfqa.py
@@ -10,7 +10,10 @@ from .context import (
     SequenceType,
     TriggerMode,
     ToolkitError,
+    shfqa_logger,
 )
+
+shfqa_logger.disable_logging()
 
 
 def test_init_shfqa():
@@ -31,10 +34,10 @@ def test_init_shfqa():
     assert qa.allowed_trigger_modes == [
         TriggerMode.NONE,
     ]
-    with pytest.raises(AttributeError):
+    with pytest.raises(shfqa_logger.ToolkitConnectionError):
         qa._init_channels()
-    with pytest.raises(TypeError):
+    with pytest.raises(shfqa_logger.ToolkitConnectionError):
         qa._init_scope()
-    with pytest.raises(ToolkitError):
+    with pytest.raises(shfqa_logger.ToolkitConnectionError):
         qa._init_params()
     qa._init_settings()


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) `setVector` method of is renamed to `set_vector`:**
The function names should be lowercase.
##### **2) Attributes of `ZIConnection` updated:**
* `_awg` attribute is removed since it was unused.
* Attributes `_awg_module`, `_daq_module` and `_sweeper_module` are 
initialized as `None`
* Public attribute `daq` is added as it is described in the docstring.
* The modules calling the protected attribute `_daq` are updated 
to call the public attribute `daq`. This public attribute 
performs a connection check before returning the `_daq` 
attribute.
##### **3) Attributes of `DeviceConnection` updated:**
* Attributes `normalized_serial` and `discovery` are initialized and 
used inside the class as protected attributes.
* Public attributes `connection`, `device`, `normalized_serial` and 
`discovery` are added. The attributes `connection` and `device` are 
already described in the docstring. A description is added for 
`normalized_serial` and `discovery` to the docstring.
* The modules calling the protected attribute `_connection` are updated 
to call the public attribute `connection`. This public attribute 
performs a connection check before returning the `_connection` 
attribute.
##### **4) `_check_connected` method of `BaseInstrument` updated:**
If the device is not connected to the data server, a 
`ToolkitConnectionError` is raised instead of `ToolkitError`.
##### **5) Following tests are updated:**
* `test_baseInstrument.py`
* `test_connection.py`
* `test_shfqa.py`