### PR TITLE
Add logging module to device drivers

### DIFF
--- a/src/zhinst/toolkit/control/drivers/base/__init__.py
+++ b/src/zhinst/toolkit/control/drivers/base/__init__.py
@@ -6,4 +6,4 @@ from .shf_sweeper import SHFSweeper
 from .daq import DAQModule
 from .sweeper import SweeperModule
 from .ct import CommandTable
-from .base import BaseInstrument, ToolkitError
+from .base import BaseInstrument

--- a/src/zhinst/toolkit/control/drivers/base/ct.py
+++ b/src/zhinst/toolkit/control/drivers/base/ct.py
@@ -6,8 +6,10 @@ import json
 import urllib
 import jsonschema
 
-from .base import ToolkitError
 from .awg import AWGCore
+from zhinst.toolkit.interface import LoggerModule
+
+_logger = LoggerModule(__name__)
 
 
 class CommandTable:
@@ -53,15 +55,16 @@ class CommandTable:
             table_updated = json.loads(table)
         elif isinstance(table, list):
             table_updated = {
-                "$schema": "http://docs.zhinst.com/hdawg/commandtable/v2/schema",
+                "$schema": self._ct_schema_url,
                 "header": {"version": "0.2", "partial": False},
                 "table": table,
             }
         elif isinstance(table, dict):
             table_updated = table
         else:
-            raise ToolkitError(
+            _logger.error(
                 "The command table should be specified as either a string, or a list "
-                "of entries without a header, or a valid json as a dictionary."
+                "of entries without a header, or a valid json as a dictionary.",
+                _logger.ExceptionTypes.ToolkitError,
             )
         return table_updated

--- a/src/zhinst/toolkit/control/drivers/base/shf_channel.py
+++ b/src/zhinst/toolkit/control/drivers/base/shf_channel.py
@@ -3,13 +3,7 @@
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.
 
-import numpy as np
-import time
-from typing import List, Union
-
-from zhinst.toolkit.helpers import SequenceProgram, SHFWaveform, SequenceType
-from .base import ToolkitError, BaseInstrument
-from zhinst.utils.shf_sweeper import RfConfig
+from .base import BaseInstrument
 
 
 class SHFChannel:

--- a/src/zhinst/toolkit/control/drivers/base/shf_generator.py
+++ b/src/zhinst/toolkit/control/drivers/base/shf_generator.py
@@ -7,15 +7,12 @@ import numpy as np
 import time
 from typing import List, Union
 import re
-import logging
-import traceback
 
 from zhinst.toolkit.helpers import SequenceProgram, SHFWaveform, SequenceType
-from .base import ToolkitError
+from zhinst.toolkit.interface import DeviceTypes, LoggerModule
 from .shf_channel import SHFChannel
 
-logging.basicConfig(format="%(levelname)s: %(message)s")
-_logger = logging.getLogger(__name__)
+_logger = LoggerModule(__name__)
 
 
 class SHFGenerator:
@@ -107,12 +104,18 @@ class SHFGenerator:
         """Compile the current SequenceProgram and load it to sequencer.
 
         Raises:
-            ToolkitError: If the AWG Core has not been set up yet.
-            ToolkitError: If the compilation has failed.
-            Warning: If the compilation has finished with a warning.
+            ToolkitConnectionError: If the AWG Core has not been set up
+                yet
+            ToolkitError: if the compilation has failed or the ELF
+                upload is not successful.
+            TimeoutError: if the program upload is not completed before
+                timeout.
         """
         if self._module is None:
-            raise ToolkitError("This Generator is not connected to an awgModule!")
+            _logger.error(
+                "This Generator is not connected to an awgModule!",
+                _logger.ExceptionTypes.ToolkitConnectionError,
+            )
         self._module.update(device=self._device.serial)
         self._module.update(index=self._index)
         seqc_program = self._program.get_seqc()
@@ -124,15 +127,15 @@ class SHFGenerator:
         statusstring = self._module.get_string("compiler/statusstring")
         if compiler_status == 1:
             _logger.error(
-                f"{self._caller_name()}\n"
-                f"Please check the sequencer code for {self.name}:\n{self._seqc_error(statusstring)}"
+                f"Please check the sequencer code for {self.name}:\n"
+                f"{self._seqc_error(statusstring)}"
                 f"Compiler status string:\n{statusstring}\n",
+                _logger.ExceptionTypes.ToolkitError,
             )
-            raise ToolkitError("Compilation failed")
         elif compiler_status == 2:
             _logger.warning(
-                f"{self._caller_name()}\n"
-                f"Please check the sequencer code for {self.name}:\n{self._seqc_error(statusstring)}"
+                f"Please check the sequencer code for {self.name}:\n"
+                f"{self._seqc_error(statusstring)}"
                 f"Compiler status string:\n{statusstring}\n",
             )
         elif compiler_status == 0:
@@ -143,16 +146,18 @@ class SHFGenerator:
         ):
             time.sleep(0.1)
             if time.time() - tik >= 100:  # 100s timeout
-                raise ToolkitError(f"{self.name}: Program upload timed out!")
+                _logger.error(
+                    f"{self.name}: Program upload timed out!",
+                    _logger.ExceptionTypes.TimeoutError,
+                )
         elf_status = self._module.get_int("/elf/status")
         if elf_status == 0:
             _logger.info(f"{self.name}: Sequencer status: ELF file uploaded!")
         else:
             _logger.error(
-                f"{self._caller_name()}\n"
                 f"{self.name}: Sequencer status: ELF upload failed!",
+                _logger.ExceptionTypes.ToolkitError,
             )
-            raise ToolkitError(f"{self.name}: ELF upload failed!")
 
     def reset_queue(self) -> None:
         """Resets the waveform queue to an empty list."""
@@ -169,11 +174,12 @@ class SHFGenerator:
                 w.r.t. the time origin of the sequence. (default: 0)
 
         Raises:
-            Exception: If the sequence is not of type *'Custom'*.
+            ToolkitError: If the sequence is not of type *'Custom'*.
         """
         if self._program.sequence_type != SequenceType.CUSTOM:
-            raise Exception(
-                "Waveform upload only possible for 'Custom' sequence program!"
+            _logger.error(
+                "Waveform upload only possible for 'Custom' sequence program!",
+                _logger.ExceptionTypes.ToolkitError,
             )
         self._waveforms.append(SHFWaveform(wave, delay=delay))
         print(f"Current length of queue: {len(self._waveforms)}")
@@ -267,15 +273,3 @@ class SHFGenerator:
                 seqc_error += f"   {i + 1: >{number_width}}   {line.strip()}\n"
         seqc_error += "\n"
         return seqc_error
-
-    def _caller_name(self):
-        """Return the caller name.
-
-        This method returns the line that calls a function. It is used
-        to display a logging message to the user and show which line
-        caused an error or warning.
-        """
-        frame_list = traceback.StackSummary.extract(traceback.walk_stack(None))
-        for frame in frame_list:
-            if frame.name == "<module>":
-                return frame.line

--- a/src/zhinst/toolkit/control/drivers/base/shf_scope.py
+++ b/src/zhinst/toolkit/control/drivers/base/shf_scope.py
@@ -6,7 +6,10 @@
 import numpy as np
 import time
 
-from .base import BaseInstrument, ToolkitError
+from .base import BaseInstrument
+from zhinst.toolkit.interface import LoggerModule
+
+_logger = LoggerModule(__name__)
 
 
 class SHFScope:
@@ -46,6 +49,10 @@ class SHFScope:
 
         Returns:
             A dictionary showing the recorded data and scope time.
+
+        Raises:
+            TimeoutError: if the scope recording is not completed before
+                timeout.
         """
 
         # wait until scope has been triggered, 30s timeout
@@ -53,7 +60,9 @@ class SHFScope:
         while self.enable() != 0:
             time.sleep(0.1)
             if time.time() - tik >= 30:
-                raise ToolkitError("Scope recording timed out!")
+                _logger.error(
+                    "Scope recording timed out!", _logger.ExceptionTypes.TimeoutError,
+                )
         # read and post-process the recorded data
         recorded_data = [[], [], [], []]
         num_channels = self._parent._num_channels()
@@ -101,15 +110,20 @@ class SHFScope:
         else:
             if isinstance(value, tuple) or isinstance(value, list):
                 if len(value) != 4:
-                    raise ToolkitError(
-                        "The values should be specified as a tuple or list, e.g. ('on', 'off', 'off', 'off')."
+                    _logger.error(
+                        "The values should be specified as a tuple or list, "
+                        "e.g. ('on', 'off', 'off', 'off').",
+                        _logger.ExceptionTypes.ToolkitError,
                     )
                 self.channel1(value[0])
                 self.channel2(value[1])
                 self.channel3(value[2])
                 self.channel4(value[3])
             else:
-                raise ToolkitError("The value must be a tuple or list of length 4!")
+                _logger.error(
+                    "The value must be a tuple or list of length 4!",
+                    _logger.ExceptionTypes.ToolkitError,
+                )
 
     def input_select(self, value=None):
         """Set all Scope input signals simultaneously.
@@ -134,16 +148,20 @@ class SHFScope:
         else:
             if isinstance(value, tuple) or isinstance(value, list):
                 if len(value) != 4:
-                    raise ToolkitError(
+                    _logger.error(
                         "The values should be specified as a tuple or list, e.g. "
-                        "('chan0sigin', 'chan1sigin', 'chan2sigin', 'chan3sigin')."
+                        "('chan0sigin', 'chan1sigin', 'chan2sigin', 'chan3sigin').",
+                        _logger.ExceptionTypes.ToolkitError,
                     )
                 self.input_select1(value[0])
                 self.input_select2(value[1])
                 self.input_select3(value[2])
                 self.input_select4(value[3])
             else:
-                raise ToolkitError("The value must be a tuple or list of length 4!")
+                _logger.error(
+                    "The value must be a tuple or list of length 4!",
+                    _logger.ExceptionTypes.ToolkitError,
+                )
 
     def segments(self, enable=None, count=None):
         """Configure segmented Scope recording options.

--- a/src/zhinst/toolkit/control/drivers/hdawg.py
+++ b/src/zhinst/toolkit/control/drivers/hdawg.py
@@ -10,12 +10,13 @@ from zhinst.toolkit.control.drivers.base import (
     BaseInstrument,
     AWGCore,
     CommandTable,
-    ToolkitError,
 )
 from zhinst.toolkit.control.node_tree import Parameter
 from zhinst.toolkit.control.parsers import Parse
-from zhinst.toolkit.interface import DeviceTypes
+from zhinst.toolkit.interface import DeviceTypes, LoggerModule
 from zhinst.toolkit.helpers import SequenceType, TriggerMode
+
+_logger = LoggerModule(__name__)
 
 
 class HDAWG(BaseInstrument):
@@ -436,19 +437,28 @@ class AWG(AWGCore):
             A tuple with the states {'on', 'off'} for the two output channels if
             the keyword argument is not given.
 
+        Raises:
+            ToolkitError: If the `value` argument is not a list or tuple
+                of length 2.
+
         """
         if value is None:
             return self.output1(), self.output2()
         else:
             if isinstance(value, tuple) or isinstance(value, list):
                 if len(value) != 2:
-                    raise ToolkitError(
-                        "The values should be specified as a tuple, e.g. ('on', 'off')."
+                    _logger.error(
+                        "The values should be specified as a tuple, e.g. "
+                        "('on', 'off').",
+                        _logger.ExceptionTypes.ToolkitError,
                     )
                 self.output1(value[0])
                 self.output2(value[1])
             else:
-                raise ToolkitError("The value must be a tuple or list of length 2!")
+                _logger.error(
+                    "The value must be a tuple or list of length 2!",
+                    _logger.ExceptionTypes.ToolkitError,
+                )
 
     def enable_iq_modulation(self) -> None:
         """Enables IQ Modulation on the AWG Core.
@@ -495,15 +505,19 @@ class AWG(AWGCore):
         if "sequence_type" in kwargs.keys():
             t = SequenceType(kwargs["sequence_type"])
             if t not in self._parent.allowed_sequences:
-                raise ToolkitError(
-                    f"Sequence type {t} must be one of {[s.value for s in self._parent.allowed_sequences]}!"
+                _logger.error(
+                    f"Sequence type {t} must be one of "
+                    f"{[s.value for s in self._parent.allowed_sequences]}!",
+                    _logger.ExceptionTypes.ToolkitError,
                 )
         # apply settings dependent on trigger mode
         if "trigger_mode" in kwargs.keys():
             t = TriggerMode(kwargs["trigger_mode"])
             if t not in self._parent.allowed_trigger_modes:
-                raise ToolkitError(
-                    f"Trigger mode {t} must be one of {[s.value for s in self._parent.allowed_trigger_modes]}!"
+                _logger.error(
+                    f"Trigger mode {t} must be one of "
+                    f"{[s.value for s in self._parent.allowed_trigger_modes]}!",
+                    _logger.ExceptionTypes.ToolkitError,
                 )
             elif t in [TriggerMode.EXTERNAL_TRIGGER, TriggerMode.RECEIVE_TRIGGER]:
                 self._apply_receive_trigger_settings()

--- a/src/zhinst/toolkit/control/drivers/pqsc.py
+++ b/src/zhinst/toolkit/control/drivers/pqsc.py
@@ -5,14 +5,13 @@
 
 import numpy as np
 import time
-import logging
 
 from zhinst.toolkit.control.drivers.base import BaseInstrument
-from zhinst.toolkit.interface import DeviceTypes
+from zhinst.toolkit.interface import DeviceTypes, LoggerModule
 from zhinst.toolkit.control.node_tree import Parameter
 from zhinst.toolkit.control.parsers import Parse
 
-_logger = logging.getLogger(__name__)
+_logger = LoggerModule(__name__)
 
 
 class PQSC(BaseInstrument):
@@ -174,6 +173,10 @@ class PQSC(BaseInstrument):
             timeout (int): Maximum time in seconds the program waits
                 when `blocking` is set to `True`. (default: 30)
 
+        Raises:
+            ToolkitError: If ZSync connection to the instruments on the
+                specified ports is not established.
+
         """
         if type(ports) is not list:
             ports = [ports]
@@ -190,9 +193,10 @@ class PQSC(BaseInstrument):
                 zsync_connection_status = self._get(f"zsyncs/{port}/connection/status")
             # Throw an exception if the instrument is still not connected after timeout
             if zsync_connection_status != 2:
-                raise Exception(
+                _logger.error(
                     f"Check ZSync connection to the instrument on port {port} "
-                    f"(port {port + 1} on the rear panel) of PQSC."
+                    f"(port {port + 1} on the rear panel) of PQSC.",
+                    _logger.ExceptionTypes.ToolkitError,
                 )
             else:
                 _logger.info(

--- a/src/zhinst/toolkit/control/drivers/shfqa.py
+++ b/src/zhinst/toolkit/control/drivers/shfqa.py
@@ -3,7 +3,6 @@
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.
 
-import logging
 import time
 
 from zhinst.toolkit.control.drivers.base import (
@@ -72,7 +71,9 @@ class SHFQA(BaseInstrument):
 
     def factory_reset(self) -> None:
         """Loads the factory default settings."""
-        _logger.info(f"Factory preset is not supported in {self.serial.upper()}.")
+        _logger.warning(
+            f"Factory preset is not yet supported in SHFQA " f"{self.serial.upper()}."
+        )
 
     def _init_settings(self):
         """Sets initial device settings on startup."""
@@ -323,15 +324,19 @@ class Generator(SHFGenerator):
         if "sequence_type" in kwargs.keys():
             t = SequenceType(kwargs["sequence_type"])
             if t not in self._device.allowed_sequences:
-                raise ToolkitError(
-                    f"Sequence type {t} must be one of {[s.value for s in self._device.allowed_sequences]}!"
+                _logger.error(
+                    f"Sequence type {t} must be one of "
+                    f"{[s.value for s in self._device.allowed_sequences]}!",
+                    _logger.ExceptionTypes.ToolkitError,
                 )
         # check trigger mode
         if "trigger_mode" in kwargs.keys():
             t = TriggerMode(kwargs["trigger_mode"])
             if t not in self._device.allowed_trigger_modes:
-                raise ToolkitError(
-                    f"Trigger mode {t} must be one of {[s.value for s in self._device.allowed_trigger_modes]}!"
+                _logger.error(
+                    f"Trigger mode {t} must be one of "
+                    f"{[s.value for s in self._device.allowed_trigger_modes]}!",
+                    _logger.ExceptionTypes.ToolkitError,
                 )
 
 

--- a/src/zhinst/toolkit/control/drivers/uhfli.py
+++ b/src/zhinst/toolkit/control/drivers/uhfli.py
@@ -9,10 +9,11 @@ from zhinst.toolkit.control.drivers.base import (
     BaseInstrument,
     DAQModule as DAQ,
     SweeperModule as Sweeper,
-    ToolkitError,
 )
 from zhinst.toolkit.control.drivers.uhfqa import AWG
-from zhinst.toolkit.interface import DeviceTypes
+from zhinst.toolkit.interface import DeviceTypes, LoggerModule
+
+_logger = LoggerModule(__name__)
 
 
 class UHFLI(BaseInstrument):
@@ -92,7 +93,9 @@ class UHFLI(BaseInstrument):
     @property
     def awg(self):
         if "AWG" not in self._options:
-            raise ToolkitError("The AWG option is not installed.")
+            _logger.error(
+                "The AWG option is not installed.", _logger.ExceptionTypes.ToolkitError,
+            )
         return self._awg
 
     @property

--- a/src/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/src/zhinst/toolkit/control/drivers/uhfqa.py
@@ -6,12 +6,13 @@
 import numpy as np
 from typing import List
 
-from zhinst.toolkit.control.drivers.base import BaseInstrument, AWGCore, ToolkitError
+from zhinst.toolkit.control.drivers.base import BaseInstrument, AWGCore
 from zhinst.toolkit.control.node_tree import Parameter
 from zhinst.toolkit.control.parsers import Parse
-from zhinst.toolkit.interface import DeviceTypes
+from zhinst.toolkit.interface import DeviceTypes, LoggerModule
 from zhinst.toolkit.helpers import SequenceType, TriggerMode
 
+_logger = LoggerModule(__name__)
 
 MAPPINGS = {
     "result_source": {
@@ -186,6 +187,10 @@ class UHFQA(BaseInstrument):
             If no argument is given the method returns the current crosstalk
             matrix as a 2D numpy array.
 
+        Raises:
+            ValueError: If the matrix size exceeds the maximum size of
+                10 x 10
+
         """
         if matrix is None:
             m = np.zeros((10, 10))
@@ -196,8 +201,10 @@ class UHFQA(BaseInstrument):
         else:
             rows, cols = matrix.shape
             if rows > 10 or cols > 10:
-                raise ValueError(
-                    f"The shape of the given matrix is {rows} x {cols}. The maximum size is 10 x 10."
+                _logger.error(
+                    f"The shape of the given matrix is {rows} x {cols}. "
+                    f"The maximum size is 10 x 10.",
+                    _logger.ExceptionTypes.ValueError,
                 )
             for r in range(rows):
                 for c in range(cols):
@@ -210,10 +217,16 @@ class UHFQA(BaseInstrument):
             channels (list): A list of indices of channels to enable.
                 (default: range(10))
 
+        Raises:
+            ValueError: If the channel list contains an element outside
+                the allowed range.
         """
         for i in channels:
             if i not in range(10):
-                raise ValueError(f"The channel index {i} is out of range!")
+                _logger.error(
+                    f"The channel index {i} is out of range!",
+                    _logger.ExceptionTypes.ValueError,
+                )
             self.channels[i].enable()
 
     def disable_readout_channels(self, channels: List = range(10)) -> None:
@@ -223,10 +236,17 @@ class UHFQA(BaseInstrument):
             channels (list): A list of indices of channels to disable.
                 (default: range(10))
 
+        Raises:
+            ValueError: If the channel list contains an element outside
+                the allowed range.
+
         """
         for i in channels:
             if i not in range(10):
-                raise ValueError(f"The channel index {i} is out of range!")
+                _logger.error(
+                    f"The channel index {i} is out of range!",
+                    _logger.ExceptionTypes.ValueError,
+                )
             self.channels[i].disable()
 
     def enable_qccs_mode(self) -> None:
@@ -302,6 +322,10 @@ class UHFQA(BaseInstrument):
         Returns:
             The adjustment in delay in units of samples.
 
+        Raises:
+            ValueError: If the adjusted quantum analyzer delay is
+                outside the allowed range.
+
         """
         node = f"qas/0/delay"
         # Return the current adjustment if no argument is passed
@@ -314,7 +338,10 @@ class UHFQA(BaseInstrument):
             qa_delay_adjusted = qa_delay_user_temp + self._qa_delay_default()
             # Check if final delay is between 0 and 1020
             if qa_delay_adjusted not in range(0, 1021):
-                raise ValueError("The quantum analyzer delay is out of range!")
+                _logger.error(
+                    "The quantum analyzer delay is out of range!",
+                    _logger.ExceptionTypes.ValueError,
+                )
             else:
                 # Overwrite the previous adjustment if range is correct
                 self._qa_delay_user = qa_delay_user_temp
@@ -524,8 +551,10 @@ class AWG(AWGCore):
         if "sequence_type" in kwargs.keys():
             t = SequenceType(kwargs["sequence_type"])
             if t not in self._parent.allowed_sequences:
-                raise ToolkitError(
-                    f"Sequence type {t} must be one of {[s.value for s in self._parent.allowed_sequences]}!"
+                _logger.error(
+                    f"Sequence type {t} must be one of "
+                    f"{[s.value for s in self._parent.allowed_sequences]}!",
+                    _logger.ExceptionTypes.ToolkitError,
                 )
             elif t == SequenceType.CW_SPEC:
                 self._apply_cw_settings()
@@ -539,8 +568,10 @@ class AWG(AWGCore):
         if "trigger_mode" in kwargs.keys():
             t = TriggerMode(kwargs["trigger_mode"])
             if t not in self._parent.allowed_trigger_modes:
-                raise ToolkitError(
-                    f"Trigger mode {t} must be one of {[s.value for s in self._parent.allowed_trigger_modes]}!"
+                _logger.error(
+                    f"Trigger mode {t} must be one of "
+                    f"{[s.value for s in self._parent.allowed_trigger_modes]}!",
+                    _logger.ExceptionTypes.ToolkitError,
                 )
             elif t in [TriggerMode.EXTERNAL_TRIGGER, TriggerMode.RECEIVE_TRIGGER]:
                 self._apply_receive_trigger_settings()
@@ -642,21 +673,38 @@ class AWG(AWGCore):
             The state {'on', 'off'} for both outputs if the keyword argument is
             not given.
 
+        Raises:
+            ToolkitError: If the `value` argument is not a list or tuple
+                of length 2.
+
         """
         if value is None:
             return self.output1(), self.output2()
         else:
             if isinstance(value, tuple) or isinstance(value, list):
                 if len(value) != 2:
-                    raise ToolkitError(
-                        "The values should be specified as a tuple, e.g. ('on', 'off')."
+                    _logger.error(
+                        "The values should be specified as a tuple, e.g. "
+                        "('on', 'off').",
+                        _logger.ExceptionTypes.ToolkitError,
                     )
                 return self.output1(value[0]), self.output2(value[1])
             else:
-                raise ToolkitError("The value must be a tuple or list of length 2!")
+                _logger.error(
+                    "The value must be a tuple or list of length 2!",
+                    _logger.ExceptionTypes.ToolkitError,
+                )
 
     def update_readout_params(self) -> None:
-        """Updates the sequence parameters for 'Simple' sequence with values from the readout channels."""
+        """Update the readout parameters for 'Readout' sequence
+
+        This method gets the frequency, amplitude and phase shift
+        values from the readout channels and uses them to update the
+        sequence parameters.
+
+        Raises:
+            ToolkitError: If the selected sequence type is not 'Readout'
+        """
         if self.sequence_params["sequence_type"] == SequenceType.READOUT:
             freqs = []
             amps = []
@@ -670,7 +718,10 @@ class AWG(AWGCore):
                 readout_frequencies=freqs, readout_amplitudes=amps, phase_shifts=phases,
             )
         else:
-            raise ToolkitError("AWG Sequence type needs to be 'Readout'")
+            _logger.error(
+                "AWG Sequence type needs to be 'Readout'",
+                _logger.ExceptionTypes.ToolkitError,
+            )
 
     def compile(self) -> None:
         """Wraps the 'compile(...)' method of the parent class `AWGCore`."""
@@ -722,11 +773,17 @@ class ReadoutChannel:
             read-only Parameter holds the result vector for the given readout
             channel as a 1D numpy array.
 
+    Raises:
+        ValueError: If the channel index is not in the allowed range.
+
     """
 
     def __init__(self, parent: BaseInstrument, index: int) -> None:
         if index not in range(10):
-            raise ValueError(f"The channel index {index} is out of range!")
+            _logger.error(
+                f"The channel index {index} is out of range!",
+                _logger.ExceptionTypes.ValueError,
+            )
         self._index = index
         self._parent = parent
         self._enabled = False
@@ -818,9 +875,10 @@ class ReadoutChannel:
                         envelope[i] = Parse.greater_equal(envelope[i], 0)
                         envelope[i] = Parse.smaller_equal(envelope[i], 1.0)
                 else:
-                    raise ToolkitError(
+                    _logger.error(
                         "The length of `int_weights_envelope` list must be equal to "
-                        "integration length."
+                        "integration length.",
+                        _logger.ExceptionTypes.ToolkitError,
                     )
             else:
                 envelope = Parse.greater_equal(envelope, 0)
@@ -876,11 +934,14 @@ class ReadoutChannel:
 
     def _demod_weights(self, length, envelope, freq, phase):
         if length > 4096:
-            raise ValueError(
-                "The maximum length of the integration weights is 4096 samples."
+            _logger.error(
+                "The maximum length of the integration weights is 4096 samples.",
+                _logger.ExceptionTypes.ValueError,
             )
         if freq <= 0:
-            raise ValueError("This frequency must be positive.")
+            _logger.error(
+                "This frequency must be positive.", _logger.ExceptionTypes.ValueError,
+            )
         clk_rate = 1.8e9
         x = np.arange(0, length, 1)
         y = envelope * np.sin(2 * np.pi * freq * x / clk_rate + np.deg2rad(phase))

--- a/src/zhinst/toolkit/interface/interface.py
+++ b/src/zhinst/toolkit/interface/interface.py
@@ -97,9 +97,10 @@ class LoggerModule:
 
         ToolkitConnectionError = auto()
         ToolkitNodeTreeError = auto()
+        ToolkitError = auto()
         ValueError = auto()
         TypeError = auto()
-        ToolkitError = auto()
+        TimeoutError = auto()
 
     class ToolkitConnectionError(Exception):
         """Custom Exception class for ToolkitConnectionError"""
@@ -187,11 +188,13 @@ class LoggerModule:
             raise LoggerModule.ToolkitConnectionError(msg)
         elif exception_type == LoggerModule.ExceptionTypes.ToolkitNodeTreeError:
             raise LoggerModule.ToolkitNodeTreeError(msg)
+        elif exception_type == LoggerModule.ExceptionTypes.ToolkitError:
+            raise LoggerModule.ToolkitError(msg)
         elif exception_type == LoggerModule.ExceptionTypes.ValueError:
             raise ValueError(msg)
         elif exception_type == LoggerModule.ExceptionTypes.TypeError:
             raise TypeError(msg)
-        elif exception_type == LoggerModule.ExceptionTypes.ToolkitError:
-            raise LoggerModule.ToolkitError(msg)
+        elif exception_type == LoggerModule.ExceptionTypes.TimeoutError:
+            raise TimeoutError(msg)
         else:
             raise Exception(msg)

--- a/tests/context.py
+++ b/tests/context.py
@@ -10,8 +10,24 @@ from zhinst.toolkit.control.drivers.base.base import (
     BaseInstrument,
     _logger as baseinstrument_logger,
 )
-from zhinst.toolkit.control.drivers.uhfqa import AWG as UHFQA_AWG, ReadoutChannel
-from zhinst.toolkit.control.drivers.hdawg import AWG as HDAWG_AWG
+from zhinst.toolkit.control.drivers.base.awg import AWGCore, _logger as awg_logger
+from zhinst.toolkit.control.drivers.base.daq import (
+    DAQModule,
+    _logger as daq_logger,
+)
+from zhinst.toolkit.control.drivers.base.sweeper import (
+    SweeperModule,
+    _logger as sweeper_logger,
+)
+from zhinst.toolkit.control.drivers.uhfqa import (
+    AWG as UHFQA_AWG,
+    ReadoutChannel,
+    _logger as uhfqa_logger,
+)
+from zhinst.toolkit.control.drivers.hdawg import (
+    AWG as HDAWG_AWG,
+    _logger as hdawg_logger,
+)
 from zhinst.toolkit.control.drivers.shfqa import (
     Channel as SHFQA_Channel,
     Generator as SHFQA_Generator,
@@ -19,6 +35,7 @@ from zhinst.toolkit.control.drivers.shfqa import (
     Scope as SHFQA_Scope,
     _logger as shfqa_logger,
 )
+from zhinst.toolkit.control.drivers.pqsc import _logger as pqsc_logger
 from zhinst.toolkit.control.drivers.mfli import (
     DAQModule as DAQModule_MFLI,
     SweeperModule as Sweeper_MFLI,
@@ -31,12 +48,6 @@ from zhinst.toolkit.control.connection import (
     ZIConnection,
     DeviceConnection,
     _logger as connection_logger,
-)
-from zhinst.toolkit.control.drivers.base import (
-    ToolkitError,
-    AWGCore,
-    DAQModule,
-    SweeperModule,
 )
 from zhinst.toolkit.control.node_tree import (
     NodeTree,

--- a/tests/test_baseInstrument.py
+++ b/tests/test_baseInstrument.py
@@ -1,8 +1,12 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
+
 import pytest
 
 from .context import (
     BaseInstrument,
-    ToolkitError,
     DeviceTypes,
     ziDiscovery,
     baseinstrument_logger,
@@ -84,11 +88,11 @@ def test_check_connection():
 
 
 def test_serials():
-    with pytest.raises(ToolkitError):
+    with pytest.raises(baseinstrument_logger.ToolkitError):
         BaseInstrument(
             "name", DeviceTypes.PQSC, None, interface="1GbE", discovery=DiscoveryMock()
         )
-    with pytest.raises(ToolkitError):
+    with pytest.raises(baseinstrument_logger.ToolkitError):
         BaseInstrument(
             "name", DeviceTypes.PQSC, 10000, interface="1GbE", discovery=DiscoveryMock()
         )

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -1,9 +1,8 @@
 import pytest
-from hypothesis import given, assume, strategies as st
-from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
-import numpy as np
 
-from .context import DAQModule, ToolkitError
+from .context import DAQModule, daq_logger
+
+daq_logger.disable_logging()
 
 
 class Parent:
@@ -25,9 +24,9 @@ def test_daq_init():
 def test_no_connection():
     p = Parent()
     daq = DAQModule(p)
-    with pytest.raises(ToolkitError):
+    with pytest.raises(daq_logger.ToolkitConnectionError):
         daq._init_settings()
-    with pytest.raises(ToolkitError):
+    with pytest.raises(daq_logger.ToolkitConnectionError):
         daq._set("endless", 0)
-    with pytest.raises(ToolkitError):
+    with pytest.raises(daq_logger.ToolkitConnectionError):
         daq._get("endless")

--- a/tests/test_pqsc.py
+++ b/tests/test_pqsc.py
@@ -1,9 +1,14 @@
+# Copyright (C) 2021 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
+
 import pytest
 from hypothesis import given, assume, strategies as st
-from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
-import numpy as np
 
-from .context import PQSC, DeviceTypes
+from .context import PQSC, DeviceTypes, pqsc_logger
+
+pqsc_logger.disable_logging()
 
 
 def test_init_pqsc():
@@ -16,42 +21,44 @@ def test_init_pqsc():
     assert pqsc._enable is None
     assert pqsc.repetitions is None
     assert pqsc.holdoff is None
-    with pytest.raises(Exception):
+    with pytest.raises(pqsc_logger.ToolkitConnectionError):
         pqsc._init_params()
     pqsc._init_settings()
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.is_running
 
 
 def test_methods_pqsc():
     pqsc = PQSC("name", "dev10000")
-    with pytest.raises(Exception):
+    with pytest.raises(pqsc_logger.ToolkitConnectionError):
         pqsc.connect_device()
-    with pytest.raises(Exception):
+    with pytest.raises(pqsc_logger.ToolkitConnectionError):
         pqsc.factory_reset()
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.arm()
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.arm(repetitions=100)
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.arm(holdoff=2e-6)
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.run()
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.stop()
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.wait_done()
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         pqsc.check_ref_clock()
 
 
-@given(
-    single_port=st.integers(0, 17),
-    port_list=st.lists(st.integers(0, 17), min_size=1, max_size=18, unique=True),
-)
-def test_check_zsync_connection(single_port, port_list):
+@given(single_port=st.integers(0, 17),)
+def test_check_zsync_connection_single_port(single_port):
     pqsc = PQSC("name", "dev10000")
-    with pytest.raises(Exception):
+    with pytest.raises(pqsc_logger.ToolkitConnectionError):
         pqsc.check_zsync_connection(ports=single_port)
-    with pytest.raises(Exception):
+
+
+@given(port_list=st.lists(st.integers(0, 17), min_size=1, max_size=18, unique=True),)
+def test_check_zsync_connection_port_list(port_list):
+    pqsc = PQSC("name", "dev10000")
+    with pytest.raises(pqsc_logger.ToolkitConnectionError):
         pqsc.check_zsync_connection(ports=port_list)

--- a/tests/test_sweeper.py
+++ b/tests/test_sweeper.py
@@ -1,9 +1,13 @@
-import pytest
-from hypothesis import given, assume, strategies as st
-from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
-import numpy as np
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 
-from .context import SweeperModule, ToolkitError
+import pytest
+
+from .context import SweeperModule, sweeper_logger
+
+sweeper_logger.disable_logging()
 
 
 class Parent:
@@ -25,9 +29,9 @@ def test_sweeper_init():
 def test_no_connection():
     p = Parent()
     s = SweeperModule(p)
-    with pytest.raises(ToolkitError):
+    with pytest.raises(sweeper_logger.ToolkitConnectionError):
         s._init_settings()
-    with pytest.raises(ToolkitError):
+    with pytest.raises(sweeper_logger.ToolkitConnectionError):
         s._set("endless", 0)
-    with pytest.raises(ToolkitError):
+    with pytest.raises(sweeper_logger.ToolkitConnectionError):
         s._get("endless")

--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -1,6 +1,10 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
+
 import pytest
-from hypothesis import given, assume, strategies as st
-from hypothesis.stateful import rule, precondition, RuleBasedStateMachine
+from hypothesis import given, strategies as st
 import numpy as np
 
 from .context import (
@@ -10,7 +14,10 @@ from .context import (
     DeviceTypes,
     SequenceType,
     TriggerMode,
+    uhfqa_logger,
 )
+
+uhfqa_logger.disable_logging()
 
 
 def test_init_uhfqa():
@@ -40,31 +47,31 @@ def test_init_uhfqa():
         TriggerMode.RECEIVE_TRIGGER,
         TriggerMode.ZSYNC_TRIGGER,
     ]
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa._init_awg_cores()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa._init_readout_channels()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa._init_params()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa._init_settings()
 
 
 def test_methods_uhfqa():
     qa = UHFQA("name", "dev2000")
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa.connect_device()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa.factory_reset()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa.arm()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa.arm(length=1024)
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa.arm(averages=10)
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa.enable_qccs_mode()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa.enable_manual_mode()
 
 
@@ -72,9 +79,9 @@ def test_methods_uhfqa():
 def test_qa_delay(delay_adj):
     qa = UHFQA("name", "dev2000")
     assert qa.qa_delay() == 0
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa.qa_delay(delay_adj)
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa._qa_delay_default()
 
 
@@ -82,31 +89,67 @@ def test_qa_delay(delay_adj):
 def test_crosstalk_matrix(rows, cols):
     qa = UHFQA("name", "dev2000")
     matrix = np.random.rand(rows, cols)
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa.crosstalk_matrix()
-    with pytest.raises(Exception):
-        qa.crosstalk_matrix(matrix)
+    if rows > 10 or cols > 10:
+        with pytest.raises(ValueError):
+            qa.crosstalk_matrix(matrix)
+    else:
+        with pytest.raises(uhfqa_logger.ToolkitConnectionError):
+            qa.crosstalk_matrix(matrix)
 
 
-@given(channels=st.lists(elements=st.integers(1, 20), min_size=1, max_size=10))
-def test_enable_readout_channels(channels):
+@given(
+    channels=st.lists(elements=st.integers(1, 9), min_size=1, max_size=10, unique=True)
+)
+def test_enable_readout_channels_correct_range(channels):
     qa = UHFQA("name", "dev2000")
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
+        qa._init_readout_channels()
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         qa.enable_readout_channels(channels)
 
 
-@given(channels=st.lists(elements=st.integers(1, 20), min_size=1, max_size=10))
-def test_disable_readout_channels(channels):
+@given(
+    channels=st.lists(
+        elements=st.integers(10, 20), min_size=1, max_size=10, unique=True
+    )
+)
+def test_enable_readout_channels_wrong_range(channels):
     qa = UHFQA("name", "dev2000")
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
+        qa._init_readout_channels()
+    with pytest.raises(ValueError):
+        qa.enable_readout_channels(channels)
+
+
+@given(
+    channels=st.lists(elements=st.integers(1, 9), min_size=1, max_size=10, unique=True)
+)
+def test_disable_readout_channels_correct_range(channels):
+    qa = UHFQA("name", "dev2000")
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
+        qa._init_readout_channels()
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
+        qa.disable_readout_channels(channels)
+
+
+@given(
+    channels=st.lists(
+        elements=st.integers(10, 20), min_size=1, max_size=10, unique=True
+    )
+)
+def test_disable_readout_channels_wrong_range(channels):
+    qa = UHFQA("name", "dev2000")
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
+        qa._init_readout_channels()
+    with pytest.raises(ValueError):
         qa.disable_readout_channels(channels)
 
 
 @given(
     sequence_type=st.sampled_from(SequenceType),
-    trigger_mode=st.sampled_from(
-        [TriggerMode.ZSYNC_TRIGGER, TriggerMode.RECEIVE_TRIGGER]
-    ),
+    trigger_mode=st.sampled_from(TriggerMode),
 )
 def test_init_uhfqa_awg(sequence_type, trigger_mode):
     awg = UHFQA_AWG(UHFQA("name", "dev2000"), 0)
@@ -116,57 +159,73 @@ def test_init_uhfqa_awg(sequence_type, trigger_mode):
     assert awg.gain2 is None
     assert awg.single is None
     assert awg.__repr__() != ""
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         awg.outputs(["on", "on"])
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitError):
         awg.outputs(["on"])
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitError):
         awg.outputs("on")
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         awg.outputs()
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         awg.set_sequence_params(sequence_type="text")
-    with pytest.raises(Exception):
-        awg.set_sequence_params(sequence_type=sequence_type)
-    with pytest.raises(Exception):
+    if sequence_type in awg._parent.allowed_sequences:
+        with pytest.raises(uhfqa_logger.ToolkitConnectionError):
+            awg.set_sequence_params(sequence_type=sequence_type)
+    else:
+        with pytest.raises(uhfqa_logger.ToolkitError):
+            awg.set_sequence_params(sequence_type=sequence_type)
+    with pytest.raises(ValueError):
         awg.set_sequence_params(trigger_mode="text")
-    with pytest.raises(Exception):
-        awg.set_sequence_params(trigger_mode=trigger_mode)
-    with pytest.raises(Exception):
+    if trigger_mode in awg._parent.allowed_trigger_modes:
+        if trigger_mode in [
+            TriggerMode.EXTERNAL_TRIGGER,
+            TriggerMode.RECEIVE_TRIGGER,
+            TriggerMode.ZSYNC_TRIGGER,
+        ]:
+            with pytest.raises(uhfqa_logger.ToolkitConnectionError):
+                awg.set_sequence_params(trigger_mode=trigger_mode)
+        else:
+            awg.set_sequence_params(trigger_mode=trigger_mode)
+    else:
+        with pytest.raises(uhfqa_logger.ToolkitError):
+            awg.set_sequence_params(trigger_mode=trigger_mode)
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         awg.compile()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         awg._apply_receive_trigger_settings()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         awg._apply_zsync_trigger_settings()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         awg._init_awg_params()
 
 
 @given(sequence_type=st.sampled_from(SequenceType))
 def test_update_readout_params(sequence_type):
     uhf = UHFQA("name", "dev2000")
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         uhf._init_awg_cores()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         uhf._init_readout_channels()
-    with pytest.raises(Exception):
-        uhf.awg.set_sequence_params(sequence_type=sequence_type)
-    if sequence_type == SequenceType.READOUT:
-        with pytest.raises(Exception):
-            uhf.channels[0].enable()
-        uhf.awg.update_readout_params()
-    else:
-        with pytest.raises(Exception):
+    if sequence_type in uhf.allowed_sequences:
+        with pytest.raises(uhfqa_logger.ToolkitConnectionError):
+            uhf.awg.set_sequence_params(sequence_type=sequence_type)
+        if sequence_type == SequenceType.READOUT:
+            with pytest.raises(uhfqa_logger.ToolkitConnectionError):
+                uhf.channels[0].enable()
             uhf.awg.update_readout_params()
+        else:
+            with pytest.raises(uhfqa_logger.ToolkitError):
+                uhf.awg.update_readout_params()
 
 
 @given(i=st.integers(1, 20))
 def test_init_readout_channel(i):
     if i not in range(10):
         with pytest.raises(ValueError):
-            ch = ReadoutChannel(UHFQA("name", "dev2000"), i)
+            ReadoutChannel(UHFQA("name", "dev2000"), i)
     else:
-        with pytest.raises(Exception):
+        with pytest.raises(uhfqa_logger.ToolkitConnectionError):
             uhf = UHFQA("name", "dev2000")
             uhf._init_readout_channels()
         ch = uhf.channels[i]
@@ -181,10 +240,10 @@ def test_init_readout_channel(i):
         assert ch.rotation is None
         assert ch.threshold is None
         assert ch.result is None
-        with pytest.raises(Exception):
+        with pytest.raises(TypeError):
             ch.__repr__()
-    with pytest.raises(Exception):
-        ch._init_channel_params()
+        with pytest.raises(uhfqa_logger.ToolkitConnectionError):
+            ch._init_channel_params()
 
 
 def test_set_get_params_channel():
@@ -194,27 +253,24 @@ def test_set_get_params_channel():
     assert ch.readout_amplitude() == 0.5
     ch.phase_shift(10)
     assert ch.phase_shift() == 10
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         ch.enable()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         ch.disable()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         ch.readout_frequency(1)
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         ch._set_int_weights()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         ch._reset_int_weights()
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         ch._average_result(1000)
 
 
-@given(
-    single_value=st.floats(-2, 2),
-    value_list=st.lists(st.floats(0, 1), min_size=1, max_size=4096),
-)
-def test_int_weights_envelope(single_value, value_list):
+@given(single_value=st.floats(-2, 2),)
+def test_int_weights_envelope_single_value(single_value):
     ch = ReadoutChannel(UHFQA("name", "dev2000"), 0)
-    with pytest.raises(Exception):
+    with pytest.raises(uhfqa_logger.ToolkitConnectionError):
         ch.int_weights_envelope(single_value)
     if single_value < 0:
         assert ch.int_weights_envelope() == 0
@@ -222,7 +278,12 @@ def test_int_weights_envelope(single_value, value_list):
         assert ch.int_weights_envelope() == 1
     else:
         assert ch.int_weights_envelope() == single_value
-    with pytest.raises(Exception):
+
+
+@given(value_list=st.lists(st.floats(0, 1), min_size=1, max_size=4096),)
+def test_int_weights_envelope_value_list(value_list):
+    ch = ReadoutChannel(UHFQA("name", "dev2000"), 0)
+    with pytest.raises(TypeError):
         ch.int_weights_envelope(value_list)
 
 


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) Centralized logger integrated into the following modules:**
* `BaseInstrument` module in `base.py`
* `HDAWG` module in `hdawg.py`
* `PQSC` module in `pqsc.py`
* `UHFQA` module in `uhfqa.py`
* `SHFQA` module in `shfqa.py`
* `UHFLI` module in `uhfli.py`
* `AWGCore` module in `awg.py`
* `SHFGenerator` module in `shf_generator.py`
* `SHFScope` module in `shf_scope.py`
* `DAQModule` module in `daq.py`
* `SweeperModule` module in `sweeper.py`
* `CommandTable` module in `ct.py`
##### **2) `TimeoutError` added to centralized logger**
##### **3) Centralized logger integrated into the following tests:**
* `test_baseInstrument.py`
* `test_hdawg.py`
* `test_pqsc.py`
* `test_uhfqa.py`
* `test_awg.py`
* `test_daq.py`
* `test_sweeper.py`