### PR TITLE
Update device setter

### DIFF
--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -23,7 +23,7 @@ class Device:
     def _get(self, path):
         return self._value
 
-    def _set(self, path, v):
+    def _set(self, path, v, sync):
         self._value = v
         return self._value
 


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) Remove cached value from node tree:**
The cached value is removed from nodetree because it is causing problems
when a parameter is set outside the Python notebook, for example from
LabOne. Since the cached value is not updated in that case, the
parameter cannot be set in the Python notebook anymore without
restarting the kernel or manually getting the parameter to update the
cached value. Since there is no cached value, the setter does not return
the set value anymore
##### **2) Caller and setter in node tree are updated:**
* Added `sync` keyword argument to the caller in node tree
* Added `sync` keyword argument to the setter in node tree
##### **3) `BaseInstrument` class is updated:**
* Add `sync` keyword argument to the `_set` method to specify if a
synchronisation should be performed between the device and the data
server after setting the node
* Add `sync` method to to perform global synchronisation between the
device and the data server
##### **4) `DeviceConnection` class is updated:**
* Add `sync` method to to perform global synchronisation between the
device and the data server. It calls the `sync` method from
`ZIConnection`
* Add `sync` keyword argument to the `set` method to specify if a
synchronisation should be performed between the device and the data
server after setting the node. If the synchronisation is enabled and a
single node/value pair is provided, this  method calls `sync_set` method
from `ZIConnection`. If the synchronisation is enabled and a
list of node/value pairs is provided, this  method calls `set`
method from `ZIConnection` and then calls `sync()`.
##### **5) `DeviceConnection` class is updated:**
* Updated `set` method so that it does not return anything. That is
because `zi.ziDAQServer.set()` method also does not return anything.
* Add `sync` method to to perform global synchronisation between the
device and the data server. It is a wrapper around the
`zi.ziDAQServer.sync()` method of the API of
`zi.ziDAQServer.syncSetInt()`, `zi.ziDAQServer.syncSetDouble()`
or `zi.ziDAQServer.syncSetString()` depending on the passed argument.
