### PR TITLE
Update AWG module

### DIFF
--- a/src/zhinst/toolkit/control/drivers/hdawg.py
+++ b/src/zhinst/toolkit/control/drivers/hdawg.py
@@ -299,6 +299,7 @@ class AWG(AWGCore):
 
     def __init__(self, parent: BaseInstrument, index: int) -> None:
         super().__init__(parent, index)
+        self._enable = None
         self._ct = None
         self._iq_modulation = False
         self.output1 = None
@@ -316,6 +317,13 @@ class AWG(AWGCore):
         self.zsync_decoder_offset = None
 
     def _init_awg_params(self):
+        self._enable = Parameter(
+            self,
+            self._parent._get_node_dict(f"awgs/{self._index}/enable"),
+            device=self._parent,
+            set_parser=Parse.set_true_false,
+            get_parser=Parse.get_true_false,
+        )
         self.output1 = Parameter(
             self,
             self._parent._get_node_dict(f"sigouts/{2*self._index}/on"),

--- a/src/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/src/zhinst/toolkit/control/drivers/uhfqa.py
@@ -515,6 +515,7 @@ class AWG(AWGCore):
 
     def __init__(self, parent: BaseInstrument, index: int) -> None:
         super().__init__(parent, index)
+        self._enable = None
         self.output1 = None
         self.output2 = None
         self.gain1 = None
@@ -522,6 +523,13 @@ class AWG(AWGCore):
         self.single = None
 
     def _init_awg_params(self):
+        self._enable = Parameter(
+            self,
+            self._parent._get_node_dict(f"awgs/0/enable"),
+            device=self._parent,
+            set_parser=Parse.set_true_false,
+            get_parser=Parse.get_true_false,
+        )
         self.output1 = Parameter(
             self,
             self._parent._get_node_dict("sigouts/0/on"),

--- a/tests/test_awg.py
+++ b/tests/test_awg.py
@@ -14,76 +14,141 @@ from .context import (
     DeviceTypes,
     SequenceType,
     awg_logger,
+    parser_logger,
+    connection_logger,
+    baseinstrument_logger,
 )
 
 awg_logger.disable_logging()
+parser_logger.disable_logging()
+connection_logger.disable_logging()
+baseinstrument_logger.disable_logging()
 
 
-@given(st.integers(0, 3), st.integers(0, 2))
-def test_init_awg(i, j):
-    device_types = {
-        0: HDAWG,
-        1: UHFQA,
-        2: UHFLI,
+@given(device_type=st.sampled_from(DeviceTypes), index=st.integers(0, 3))
+def test_init_awg(device_type, index):
+    allowed_device_types = {
+        DeviceTypes.HDAWG: HDAWG,
+        DeviceTypes.UHFQA: UHFQA,
+        DeviceTypes.UHFLI: UHFLI,
     }
-    device = device_types[j]
-    instr = device("name", "dev1234")
-    awg = AWGCore(instr, i)
-    assert awg._parent == instr
-    assert awg._index == i
-    assert awg.waveforms == []
-    assert awg.name == f"name-awg-{i}"
-    assert awg._program is not None
-    params = awg.sequence_params["sequence_parameters"]
-    if j == 0:
-        assert params["target"] == DeviceTypes.HDAWG
-    elif j == 1:
-        assert params["target"] == DeviceTypes.UHFQA
-    elif j == 2:
-        assert params["target"] == DeviceTypes.UHFLI
-    strings = ["parent", "index", "sequence", "type"]
-    assert any(s in awg.__repr__() for s in strings)
+    if device_type in allowed_device_types.keys():
+        device = allowed_device_types[device_type]
+        instr = device("name", "dev1234")
+        instr._options = ["AWG"]
+        awg = AWGCore(instr, index)
+        assert awg._parent == instr
+        assert awg._index == index
+        assert awg._module is None
+        assert awg._waveforms == []
+        assert awg._program is not None
+        assert awg.index == index
+        assert awg.name == f"name-awg-{index}"
+        assert awg.waveforms == []
+        params = awg.sequence_params["sequence_parameters"]
+        assert params["target"] == device_type
+        strings = ["parent", "index", "sequence", "type"]
+        assert any(s in awg.__repr__() for s in strings)
 
 
-@given(st.integers(0, 3))
-def test_awg_connection(i):
-    instr = HDAWG("name", "dev1234")
-    awg = AWGCore(instr, i)
-    with pytest.raises(awg_logger.ToolkitConnectionError):
-        awg.is_running
-    with pytest.raises(awg_logger.ToolkitConnectionError):
-        awg.run()
-    with pytest.raises(awg_logger.ToolkitConnectionError):
-        awg.stop()
-    with pytest.raises(awg_logger.ToolkitConnectionError):
-        awg.wait_done()
-    with pytest.raises(awg_logger.ToolkitConnectionError):
-        awg.compile()
-    with pytest.raises(awg_logger.ToolkitConnectionError):
-        awg.upload_waveforms()
-    with pytest.raises(awg_logger.ToolkitConnectionError):
-        awg.compile_and_upload_waveforms()
+@given(device_type=st.sampled_from(DeviceTypes), index=st.integers(0, 3))
+def test_awg_connection(device_type, index):
+    allowed_device_types = {
+        DeviceTypes.HDAWG: HDAWG,
+        DeviceTypes.UHFQA: UHFQA,
+        DeviceTypes.UHFLI: UHFLI,
+    }
+    if device_type in allowed_device_types.keys():
+        device = allowed_device_types[device_type]
+        instr = device("name", "dev1234")
+        instr._options = ["AWG"]
+        awg = AWGCore(instr, index)
+        with pytest.raises(awg_logger.ToolkitConnectionError):
+            awg._setup()
+        awg._init_awg_params()
 
 
-@given(sequence_type=st.sampled_from(SequenceType),)
-def test_awg_waveform(sequence_type):
-    instr = HDAWG("name", "dev1234")
-    awg = AWGCore(instr, 0)
-    if sequence_type in instr.allowed_sequences:
-        awg.set_sequence_params(sequence_type=sequence_type)
-        if sequence_type in [SequenceType.SIMPLE, SequenceType.CUSTOM]:
-            awg.queue_waveform([], [])
-            assert len(awg.waveforms) == 1
-            awg.reset_queue()
-            assert awg.waveforms == []
-            for i in range(10):
+@given(device_type=st.sampled_from(DeviceTypes), index=st.integers(0, 3))
+def test_awg_methods(device_type, index):
+    allowed_device_types = {
+        DeviceTypes.HDAWG: HDAWG,
+        DeviceTypes.UHFQA: UHFQA,
+        DeviceTypes.UHFLI: UHFLI,
+    }
+    if device_type in allowed_device_types.keys():
+        device = allowed_device_types[device_type]
+        instr = device("name", "dev1234")
+        instr._options = ["AWG"]
+        awg = AWGCore(instr, index)
+        with pytest.raises(AttributeError):
+            awg.run()
+        with pytest.raises(AttributeError):
+            awg.stop()
+        with pytest.raises(AttributeError):
+            awg.wait_done()
+        with pytest.raises(awg_logger.ToolkitConnectionError):
+            awg.compile()
+        with pytest.raises(awg_logger.ToolkitConnectionError):
+            awg.upload_waveforms()
+        with pytest.raises(awg_logger.ToolkitConnectionError):
+            awg.compile_and_upload_waveforms()
+        with pytest.raises(AttributeError):
+            awg.is_running
+
+
+@given(device_type=st.sampled_from(DeviceTypes), index=st.integers(0, 3))
+def test_awg_set_get(device_type, index):
+    allowed_device_types = {
+        DeviceTypes.HDAWG: HDAWG,
+        DeviceTypes.UHFQA: UHFQA,
+        DeviceTypes.UHFLI: UHFLI,
+    }
+    if device_type in allowed_device_types.keys():
+        device = allowed_device_types[device_type]
+        instr = device("name", "dev1234")
+        instr._options = ["AWG"]
+        awg = AWGCore(instr, index)
+        with pytest.raises(AttributeError):
+            awg.outputs()
+        with pytest.raises(AttributeError):
+            awg.outputs(["on", "on"])
+        with pytest.raises(ValueError):
+            awg.outputs(["on"])
+        with pytest.raises(ValueError):
+            awg.outputs("on")
+
+
+@given(
+    device_type=st.sampled_from(DeviceTypes),
+    sequence_type=st.sampled_from(SequenceType),
+    index=st.integers(0, 3),
+)
+def test_awg_waveform(device_type, sequence_type, index):
+    allowed_device_types = {
+        DeviceTypes.HDAWG: HDAWG,
+        DeviceTypes.UHFQA: UHFQA,
+        DeviceTypes.UHFLI: UHFLI,
+    }
+    if device_type in allowed_device_types.keys():
+        device = allowed_device_types[device_type]
+        instr = device("name", "dev1234")
+        instr._options = ["AWG"]
+        awg = AWGCore(instr, index)
+        if sequence_type in instr.allowed_sequences:
+            awg.set_sequence_params(sequence_type=sequence_type)
+            if sequence_type in [SequenceType.SIMPLE, SequenceType.CUSTOM]:
                 awg.queue_waveform([], [])
-            assert len(awg.waveforms) == 10
-            awg.queue_waveform([-1] * 80, [-1] * 80)
-            awg.replace_waveform([1] * 80, [1] * 80, i=10)
-            wave = awg.waveforms[10].data
-            assert any(w == (2 ** (15) - 1) for w in wave)
-        else:
-            with pytest.raises(awg_logger.ToolkitError):
-                awg.queue_waveform([], [])
-            assert awg.waveforms == []
+                assert len(awg.waveforms) == 1
+                awg.reset_queue()
+                assert awg.waveforms == []
+                for i in range(10):
+                    awg.queue_waveform([], [])
+                assert len(awg.waveforms) == 10
+                awg.queue_waveform([-1] * 80, [-1] * 80)
+                awg.replace_waveform([1] * 80, [1] * 80, i=10)
+                wave = awg.waveforms[10].data
+                assert any(w == (2 ** (15) - 1) for w in wave)
+            else:
+                with pytest.raises(awg_logger.ToolkitError):
+                    awg.queue_waveform([], [])
+                assert awg.waveforms == []


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) `_enable` parameter added to HDAWG's and UHFQA's AWG**
##### **2) `run` method of AWG Core updated:**
This method now uses the newly added `_enable` parameter and it enables
the AWG synchronously by default.
##### **3) `stop` method of AWG Core updated:**
This method now uses the newly added `_enable` parameter and it
disables the AWG synchronously by default.
##### **4) `wait_time` method of AWG Core updated:**
This method now checks if the AWG is running in continuous mode and
raises a `ToolkitError` if this is the case. It also raises a
`TimeoutError` if the AWG is not finished before timeout.
##### **5) Docstring improved**
##### **6) Tests for AWG Core improved**
