### PR TITLE
Add `sync` argument to `factory_reset`

### DIFF
--- a/src/zhinst/toolkit/control/drivers/base/base.py
+++ b/src/zhinst/toolkit/control/drivers/base/base.py
@@ -125,9 +125,15 @@ class BaseInstrument:
         self._init_params()
         self._init_settings()
 
-    def factory_reset(self) -> None:
-        """Loads the factory default settings."""
-        self._set(f"/system/preset/load", 1)
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
+        self._set(f"/system/preset/load", 1, sync=sync)
         _logger.info(f"Factory preset is loaded to device {self.serial.upper()}.")
 
     def _check_ref_clock(self, blocking=True, timeout=30) -> None:

--- a/src/zhinst/toolkit/control/drivers/hdawg.py
+++ b/src/zhinst/toolkit/control/drivers/hdawg.py
@@ -111,9 +111,15 @@ class HDAWG(BaseInstrument):
         super().connect_device(nodetree=nodetree)
         self._init_awg_cores()
 
-    def factory_reset(self) -> None:
-        """Loads the factory default settings."""
-        super().factory_reset()
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
+        super().factory_reset(sync=sync)
 
     def enable_qccs_mode(self) -> None:
         """Configure the instrument to work with PQSC

--- a/src/zhinst/toolkit/control/drivers/mfli.py
+++ b/src/zhinst/toolkit/control/drivers/mfli.py
@@ -77,9 +77,15 @@ class MFLI(BaseInstrument):
         self._sweeper_module = SweeperModule(self)
         self._sweeper_module._setup()
 
-    def factory_reset(self) -> None:
-        """Loads the factory default settings."""
-        super().factory_reset()
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
+        super().factory_reset(sync=sync)
 
     def _init_settings(self):
         pass

--- a/src/zhinst/toolkit/control/drivers/pqsc.py
+++ b/src/zhinst/toolkit/control/drivers/pqsc.py
@@ -86,9 +86,15 @@ class PQSC(BaseInstrument):
         """
         super().connect_device(nodetree=nodetree)
 
-    def factory_reset(self) -> None:
-        """Loads the factory default settings."""
-        super().factory_reset()
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
+        super().factory_reset(sync=sync)
 
     def arm(self, repetitions=None, holdoff=None) -> None:
         """Prepare PQSC for triggering the instruments.

--- a/src/zhinst/toolkit/control/drivers/shfqa.py
+++ b/src/zhinst/toolkit/control/drivers/shfqa.py
@@ -113,8 +113,14 @@ class SHFQA(BaseInstrument):
         self._init_qachannels()
         self._init_scope()
 
-    def factory_reset(self) -> None:
-        """Loads the factory default settings."""
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
         _logger.warning(
             f"Factory preset is not yet supported in SHFQA " f"{self.serial.upper()}."
         )

--- a/src/zhinst/toolkit/control/drivers/uhfli.py
+++ b/src/zhinst/toolkit/control/drivers/uhfli.py
@@ -90,9 +90,15 @@ class UHFLI(BaseInstrument):
         self._init_daq()
         self._init_sweeper()
 
-    def factory_reset(self) -> None:
-        """Loads the factory default settings."""
-        super().factory_reset()
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
+        super().factory_reset(sync=sync)
 
     def _init_awg_cores(self):
         """Initialize the AWGs cores of the device."""

--- a/src/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/src/zhinst/toolkit/control/drivers/uhfqa.py
@@ -169,9 +169,15 @@ class UHFQA(BaseInstrument):
         self._init_scope()
         self._init_readout_channels()
 
-    def factory_reset(self) -> None:
-        """Loads the factory default settings."""
-        super().factory_reset()
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
+        super().factory_reset(sync=sync)
         # Set the AWG to single shot mode manually since the firmware
         # is not programmed to do this automatically when factory
         # preset is loaded


### PR DESCRIPTION
The argument is set to `True` by default. When the `factory_reset`
function is called, `daq.snycSetInt("/dev.../system/preset/load", 1)`
will be executed.