### PR TITLE
Update PQSC drivers

### DIFF
--- a/src/zhinst/toolkit/control/drivers/base/base.py
+++ b/src/zhinst/toolkit/control/drivers/base/base.py
@@ -125,9 +125,15 @@ class BaseInstrument:
         self._init_params()
         self._init_settings()
 
-    def factory_reset(self) -> None:
-        """Loads the factory default settings."""
-        self._set(f"/system/preset/load", 1)
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
+        self._set(f"/system/preset/load", 1, sync=sync)
         _logger.info(f"Factory preset is loaded to device {self.serial.upper()}.")
 
     def _check_ref_clock(self, blocking=True, timeout=30) -> None:

--- a/src/zhinst/toolkit/control/drivers/hdawg.py
+++ b/src/zhinst/toolkit/control/drivers/hdawg.py
@@ -111,9 +111,15 @@ class HDAWG(BaseInstrument):
         super().connect_device(nodetree=nodetree)
         self._init_awg_cores()
 
-    def factory_reset(self) -> None:
-        """Loads the factory default settings."""
-        super().factory_reset()
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
+        super().factory_reset(sync=sync)
 
     def enable_qccs_mode(self) -> None:
         """Configure the instrument to work with PQSC

--- a/src/zhinst/toolkit/control/drivers/mfli.py
+++ b/src/zhinst/toolkit/control/drivers/mfli.py
@@ -77,9 +77,15 @@ class MFLI(BaseInstrument):
         self._sweeper_module = SweeperModule(self)
         self._sweeper_module._setup()
 
-    def factory_reset(self) -> None:
-        """Loads the factory default settings."""
-        super().factory_reset()
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
+        super().factory_reset(sync=sync)
 
     def _init_settings(self):
         pass

--- a/src/zhinst/toolkit/control/drivers/pqsc.py
+++ b/src/zhinst/toolkit/control/drivers/pqsc.py
@@ -78,7 +78,7 @@ class PQSC(BaseInstrument):
     def connect_device(self, nodetree: bool = True) -> None:
         """Connects the device to the data server.
 
-        Keyword Arguments:
+        Arguments:
             nodetree (bool): A flag that specifies if all the parameters from
                 the device's nodetree should be added to the object's attributes
                 as `zhinst-toolkit` Parameters. (default: True)
@@ -96,7 +96,7 @@ class PQSC(BaseInstrument):
         """
         super().factory_reset(sync=sync)
 
-    def arm(self, repetitions=None, holdoff=None) -> None:
+    def arm(self, sync=True, repetitions: int = None, holdoff: float = None) -> None:
         """Prepare PQSC for triggering the instruments.
 
         This method configures the execution engine of the PQSC and
@@ -109,51 +109,100 @@ class PQSC(BaseInstrument):
         should be long enough such that the PQSC is still enabled when
         the feedback arrives. Otherwise, the feedback cannot be processed.
 
-        Keyword Arguments:
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after stopping the PQSC and clearing the
+                register bank (default: True).
             repetitions (int): If specified, the number of triggers sent
-                over ZSync ports will be set. (default: None)
+                over ZSync ports will be set (default: None).
             holdoff (double): If specified, the time between repeated
                 triggers sent over ZSync ports will be set. It has a
-                minimum value and a granularity of 100 ns. (default: None)
+                minimum value and a granularity of 100 ns
+                (default: None).
 
         """
         # Stop the PQSC if it is already running
-        self.stop()
+        self.stop(sync=sync)
         if repetitions is not None:
-            self.repetitions(int(repetitions))
+            self.repetitions(repetitions)
         if holdoff is not None:
             self.holdoff(holdoff)
         # Clear register bank
-        self._set("feedback/registerbank/reset", 1)
+        self._set("feedback/registerbank/reset", 1, sync=sync)
 
-    def run(self) -> None:
+    def run(self, sync=True) -> None:
         """Start sending out triggers.
 
         This method activates the trigger generation to trigger all
         connected instruments over ZSync ports.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after enabling the PQSC (default: True).
         """
-        self._enable(True)
+        self._enable(True, sync=sync)
 
-    def stop(self) -> None:
-        """Stops the trigger generation."""
-        self._enable(False)
+    def arm_and_run(
+        self, sync=True, repetitions: int = None, holdoff: float = None
+    ) -> None:
+        """Arm the PQSC and start sending out triggers.
 
-    def wait_done(self, timeout: float = 10) -> None:
+        Simply combines the methods arm and run.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after arming and running the PQSC 
+                (default: True).
+            repetitions (int): If specified, the number of triggers sent
+                over ZSync ports will be set (default: None).
+            holdoff (double): If specified, the time between repeated
+                triggers sent over ZSync ports will be set. It has a
+                minimum value and a granularity of 100 ns
+                (default: None).
+
+        """
+        self.arm(sync=sync, repetitions=repetitions, holdoff=holdoff)
+        self.run(sync=sync)
+
+    def stop(self, sync=True) -> None:
+        """Stop the trigger generation.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after disabling the PQSC (default: True).
+        """
+        self._enable(False, sync=sync)
+
+    def wait_done(self, timeout: float = 10, sleep_time: float = 0.005) -> None:
         """Wait until trigger generation and feedback processing is done.
 
-        Keyword Arguments:
-            timeout (int): The maximum waiting time in seconds for the
+        Arguments:
+            timeout (float): The maximum waiting time in seconds for the
                 PQSC (default: 10).
+            sleep_time (float): Time in seconds to wait between
+                requesting PQSC state
+
+        Raises:
+            TimeoutError: If the PQSC is not done sending out all
+                triggers and processing feedback before the timeout.
 
         """
         start_time = time.time()
         while self.is_running and start_time + timeout >= time.time():
-            time.sleep(0.1)
+            time.sleep(sleep_time)
+        if self.is_running and start_time + timeout < time.time():
+            _logger.error(
+                "PQSC timed out!", _logger.ExceptionTypes.TimeoutError,
+            )
 
     def check_ref_clock(self, blocking=True, timeout=30) -> None:
         """Check if reference clock is locked successfully.
 
-        Keyword Arguments:
+        Arguments:
             blocking (bool): A flag that specifies if the program should
                 be blocked until the reference clock is 'locked'.
                 (default: True)
@@ -169,7 +218,7 @@ class PQSC(BaseInstrument):
         This function checks the current status of the instrument
         connected to the given port.
 
-        Keyword Arguments:
+        Arguments:
             ports (list) or (int): The port numbers to check the ZSync
                 connection for. It can either be a single port number given
                 as integer or a list of several port numbers. (default: 0)

--- a/src/zhinst/toolkit/control/drivers/pqsc.py
+++ b/src/zhinst/toolkit/control/drivers/pqsc.py
@@ -86,9 +86,15 @@ class PQSC(BaseInstrument):
         """
         super().connect_device(nodetree=nodetree)
 
-    def factory_reset(self) -> None:
-        """Loads the factory default settings."""
-        super().factory_reset()
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
+        super().factory_reset(sync=sync)
 
     def arm(self, repetitions=None, holdoff=None) -> None:
         """Prepare PQSC for triggering the instruments.

--- a/src/zhinst/toolkit/control/drivers/shfqa.py
+++ b/src/zhinst/toolkit/control/drivers/shfqa.py
@@ -113,8 +113,14 @@ class SHFQA(BaseInstrument):
         self._init_qachannels()
         self._init_scope()
 
-    def factory_reset(self) -> None:
-        """Loads the factory default settings."""
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
         _logger.warning(
             f"Factory preset is not yet supported in SHFQA " f"{self.serial.upper()}."
         )

--- a/src/zhinst/toolkit/control/drivers/uhfli.py
+++ b/src/zhinst/toolkit/control/drivers/uhfli.py
@@ -90,9 +90,15 @@ class UHFLI(BaseInstrument):
         self._init_daq()
         self._init_sweeper()
 
-    def factory_reset(self) -> None:
-        """Loads the factory default settings."""
-        super().factory_reset()
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
+        super().factory_reset(sync=sync)
 
     def _init_awg_cores(self):
         """Initialize the AWGs cores of the device."""

--- a/src/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/src/zhinst/toolkit/control/drivers/uhfqa.py
@@ -169,9 +169,15 @@ class UHFQA(BaseInstrument):
         self._init_scope()
         self._init_readout_channels()
 
-    def factory_reset(self) -> None:
-        """Loads the factory default settings."""
-        super().factory_reset()
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
+        super().factory_reset(sync=sync)
         # Set the AWG to single shot mode manually since the firmware
         # is not programmed to do this automatically when factory
         # preset is loaded


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) `arm` method of PQSC updated:**
* `sync` argument is added and set to `True` by default. The `stop`
function and clear the register bank command are called synchronously
if this argument is set to `True`
* Type hints are added for the arguments `repetitions` and `holdoff`
##### **2) `run` method of PQSC updated:**
`sync` argument is added and set to `True` by default. The `_enable`
parameter is set to `True` synchronously if this argument
is set to `True`
##### **3) `arm_and_run` method added to PQSC:**
This method simply combines the methods `arm` and `run`
##### **4) `stop` method of PQSC updated:**
`sync` argument is added and set to `True` by default. The `_enable`
parameter is set to `False` synchronously if this argument
is set to `True`
##### **5) `wait_done` method of PQSC updated:**
This method now raises a `TimeoutError` if the PQSC is not finished
before timeout.
##### **6) Docstring improved**