### PR TITLE
Reformat all code with `black`

### DIFF
--- a/src/zhinst/toolkit/control/connection.py
+++ b/src/zhinst/toolkit/control/connection.py
@@ -651,7 +651,8 @@ class DeviceConnection(object):
         else:
             self._normalized_serial = self._device.serial
         self._connection.connect_device(
-            serial=self._normalized_serial, interface=self._device.interface,
+            serial=self._normalized_serial,
+            interface=self._device.interface,
         )
         self._is_connected = True
 
@@ -707,7 +708,8 @@ class DeviceConnection(object):
                 self.sync()
         else:
             _logger.error(
-                "Invalid number of arguments!", _logger.ExceptionTypes.TypeError,
+                "Invalid number of arguments!",
+                _logger.ExceptionTypes.TypeError,
             )
 
     def set_vector(self, *args):
@@ -730,7 +732,8 @@ class DeviceConnection(object):
             settings = args[0]
         else:
             _logger.error(
-                "Invalid number of arguments!", _logger.ExceptionTypes.TypeError,
+                "Invalid number of arguments!",
+                _logger.ExceptionTypes.TypeError,
             )
         settings = self._commands_to_node(settings)
         self._connection.set_vector(settings)
@@ -804,7 +807,8 @@ class DeviceConnection(object):
                 return data
         else:
             _logger.error(
-                "No device connected!", _logger.ExceptionTypes.ToolkitConnectionError,
+                "No device connected!",
+                _logger.ExceptionTypes.ToolkitConnectionError,
             )
 
     def get_nodetree(self, prefix: str, **kwargs):

--- a/src/zhinst/toolkit/control/drivers/base/awg.py
+++ b/src/zhinst/toolkit/control/drivers/base/awg.py
@@ -214,7 +214,8 @@ class AWGCore:
             time.sleep(sleep_time)
         if self.is_running and start_time + timeout < time.time():
             _logger.error(
-                "AWG Core timed out!", _logger.ExceptionTypes.TimeoutError,
+                "AWG Core timed out!",
+                _logger.ExceptionTypes.TimeoutError,
             )
 
     def compile(self) -> None:
@@ -340,7 +341,8 @@ class AWGCore:
         """
         if i not in range(len(self._waveforms)):
             _logger.error(
-                "Index out of range!", _logger.ExceptionTypes.ValueError,
+                "Index out of range!",
+                _logger.ExceptionTypes.ValueError,
             )
         self._waveforms[i].replace_data(wave1, wave2, delay=delay)
 

--- a/src/zhinst/toolkit/control/drivers/base/base.py
+++ b/src/zhinst/toolkit/control/drivers/base/base.py
@@ -194,10 +194,14 @@ class BaseInstrument:
             get_parser=Parse.version_parser,
         )
         self.firmware_version = Parameter(
-            self, self._get_node_dict(f"/system/fwrevision"), device=self,
+            self,
+            self._get_node_dict(f"/system/fwrevision"),
+            device=self,
         )
         self.fpga_version = Parameter(
-            self, self._get_node_dict(f"/system/fpgarevision"), device=self,
+            self,
+            self._get_node_dict(f"/system/fpgarevision"),
+            device=self,
         )
 
     def _init_settings(self):

--- a/src/zhinst/toolkit/control/drivers/base/ct.py
+++ b/src/zhinst/toolkit/control/drivers/base/ct.py
@@ -37,7 +37,7 @@ class CommandTable:
         self._device._set_vector(node, json.dumps(table_updated))
 
     def _validate(self, table):
-        """ Ensure command table is valid JSON and compliant with schema"""
+        """Ensure command table is valid JSON and compliant with schema"""
         # Validation only works if the command table is in dictionary
         # format (json object). Make the encessary conversion
         table_updated = self._to_dict(table)

--- a/src/zhinst/toolkit/control/drivers/base/daq.py
+++ b/src/zhinst/toolkit/control/drivers/base/daq.py
@@ -10,7 +10,7 @@ _logger = LoggerModule(__name__)
 
 
 MAPPINGS = {
-    "edge": {1: "rising", 2: "falling", 3: "both",},
+    "edge": {1: "rising", 2: "falling", 3: "both"},
     "eventcount_mode": {0: "sample", 1: "increment"},
     "fft_window": {
         0: "rectangular",
@@ -22,9 +22,9 @@ MAPPINGS = {
         17: "sine",
         18: "cosine_squared",
     },
-    "grid_direction": {0: "forward", 1: "reverse", 2: "bidirectional",},
-    "grid_mode": {1: "nearest", 2: "linear", 4: "exact",},
-    "save_fileformat": {0: "matlab", 1: "csv", 2: "zview", 3: "sxm", 4: "hdf5",},
+    "grid_direction": {0: "forward", 1: "reverse", 2: "bidirectional"},
+    "grid_mode": {1: "nearest", 2: "linear", 4: "exact"},
+    "save_fileformat": {0: "matlab", 1: "csv", 2: "zview", 3: "sxm", 4: "hdf5"},
     "type": {
         0: "continuous",
         1: "edge",
@@ -130,7 +130,7 @@ class DAQModule:
         # the `streaming_nodes` are used as all available signal sources for the data acquisition
         self._signal_sources = self._parent._get_streamingnodes()
         self._signal_types = {
-            "auxin": {"auxin1": ".Auxin0", "auxin2": ".Auxin1",},
+            "auxin": {"auxin1": ".Auxin0", "auxin2": ".Auxin1"},
             "demod": {
                 "x": ".X",
                 "y": ".Y",

--- a/src/zhinst/toolkit/control/drivers/base/scope.py
+++ b/src/zhinst/toolkit/control/drivers/base/scope.py
@@ -178,7 +178,8 @@ class Scope:
             records < num_records or progress < 1.0
         ) and start_time + timeout < time.time():
             _logger.error(
-                "Scope recording timed out!", _logger.ExceptionTypes.TimeoutError,
+                "Scope recording timed out!",
+                _logger.ExceptionTypes.TimeoutError,
             )
 
     def read(self, channel=None, timeout: float = 10, sleep_time: float = 0.005):

--- a/src/zhinst/toolkit/control/drivers/base/shf_generator.py
+++ b/src/zhinst/toolkit/control/drivers/base/shf_generator.py
@@ -168,7 +168,8 @@ class SHFGenerator:
             time.sleep(0.1)
         if self.is_running and start_time + timeout < time.time():
             _logger.error(
-                "The generator timed out!", _logger.ExceptionTypes.TimeoutError,
+                "The generator timed out!",
+                _logger.ExceptionTypes.TimeoutError,
             )
 
     def compile(self) -> None:

--- a/src/zhinst/toolkit/control/drivers/base/shf_scope.py
+++ b/src/zhinst/toolkit/control/drivers/base/shf_scope.py
@@ -72,7 +72,8 @@ class SHFScope:
             time.sleep(0.1)
         if self.is_running and start_time + timeout < time.time():
             _logger.error(
-                "Scope recording timed out!", _logger.ExceptionTypes.TimeoutError,
+                "Scope recording timed out!",
+                _logger.ExceptionTypes.TimeoutError,
             )
 
     def read(self, channel=None):

--- a/src/zhinst/toolkit/control/drivers/base/sweeper.py
+++ b/src/zhinst/toolkit/control/drivers/base/sweeper.py
@@ -10,10 +10,10 @@ _logger = LoggerModule(__name__)
 
 
 MAPPINGS = {
-    "bandwidthcontrol": {0: "manual", 1: "fixed", 2: "automatic",},
-    "save_fileformat": {0: "matlab", 1: "csv", 2: "zview", 3: "sxm", 4: "hdf5",},
+    "bandwidthcontrol": {0: "manual", 1: "fixed", 2: "automatic"},
+    "save_fileformat": {0: "matlab", 1: "csv", 2: "zview", 3: "sxm", 4: "hdf5"},
     "scan": {0: "sequential", 1: "binary", 2: "bidirectional", 3: "reverse"},
-    "xmapping": {0: "linear", 1: "logarithmic",},
+    "xmapping": {0: "linear", 1: "logarithmic"},
     "signal_sources": {
         "demod0": "/demods/0/sample",
         "demod1": "/demods/1/sample",

--- a/src/zhinst/toolkit/control/drivers/hdawg.py
+++ b/src/zhinst/toolkit/control/drivers/hdawg.py
@@ -457,7 +457,7 @@ class AWG(AWGCore):
             (f"awgs/{i}/outputs/1/modulation/mode", 2),  # modulation: sine 22
             (f"sines/{2 * i}/oscselect", 4 * i),  # select osc N for awg N
             (f"sines/{2 * i + 1}/oscselect", 4 * i),  # select osc N for awg N
-            (f"sines/{2 * i + 1}/phaseshift", 90,),  # 90 deg phase shift
+            (f"sines/{2 * i + 1}/phaseshift", 90),  # 90 deg phase shift
         ]
         self._parent._set(settings)
         self.set_sequence_params(reset_phase=True)
@@ -474,7 +474,7 @@ class AWG(AWGCore):
         settings = [
             (f"awgs/{i}/outputs/0/modulation/mode", 0),  # modulation: sine 11
             (f"awgs/{i}/outputs/1/modulation/mode", 0),  # modulation: sine 22
-            (f"sines/{2 * i + 1}/phaseshift", 0,),  # 90 deg phase shift
+            (f"sines/{2 * i + 1}/phaseshift", 0),  # 0 deg phase shift
         ]
         self._parent._set(settings)
         self.set_sequence_params(reset_phase=False)

--- a/src/zhinst/toolkit/control/drivers/pqsc.py
+++ b/src/zhinst/toolkit/control/drivers/pqsc.py
@@ -144,13 +144,11 @@ class PQSC(BaseInstrument):
         """
         self._enable(True, sync=sync)
 
-    def arm_and_run(
-        self, repetitions: int = None, holdoff: float = None
-    ) -> None:
+    def arm_and_run(self, repetitions: int = None, holdoff: float = None) -> None:
         """Arm the PQSC and start sending out triggers.
 
         Simply combines the methods arm and run. A synchronisation
-        is performed between the device and the data server after 
+        is performed between the device and the data server after
         arming and running the PQSC.
 
         Arguments:
@@ -194,7 +192,8 @@ class PQSC(BaseInstrument):
             time.sleep(sleep_time)
         if self.is_running and start_time + timeout < time.time():
             _logger.error(
-                "PQSC timed out!", _logger.ExceptionTypes.TimeoutError,
+                "PQSC timed out!",
+                _logger.ExceptionTypes.TimeoutError,
             )
 
     def check_ref_clock(
@@ -291,7 +290,9 @@ class PQSC(BaseInstrument):
             get_parser=Parse.get_locked_status,
         )
         self.progress = Parameter(
-            self, self._get_node_dict(f"execution/progress"), device=self,
+            self,
+            self._get_node_dict(f"execution/progress"),
+            device=self,
         )
         self._enable = Parameter(
             self,

--- a/src/zhinst/toolkit/control/drivers/uhfli.py
+++ b/src/zhinst/toolkit/control/drivers/uhfli.py
@@ -127,7 +127,8 @@ class UHFLI(BaseInstrument):
     def awg(self):
         if "AWG" not in self._options:
             _logger.error(
-                "The AWG option is not installed.", _logger.ExceptionTypes.ToolkitError,
+                "The AWG option is not installed.",
+                _logger.ExceptionTypes.ToolkitError,
             )
         return self._awg
 
@@ -143,7 +144,8 @@ class UHFLI(BaseInstrument):
     def allowed_sequences(self):
         if "AWG" not in self._options:
             _logger.error(
-                "The AWG option is not installed.", _logger.ExceptionTypes.ToolkitError,
+                "The AWG option is not installed.",
+                _logger.ExceptionTypes.ToolkitError,
             )
         return self._allowed_sequences
 
@@ -151,7 +153,8 @@ class UHFLI(BaseInstrument):
     def allowed_trigger_modes(self):
         if "AWG" not in self._options:
             _logger.error(
-                "The AWG option is not installed.", _logger.ExceptionTypes.ToolkitError,
+                "The AWG option is not installed.",
+                _logger.ExceptionTypes.ToolkitError,
             )
         return self._allowed_trigger_modes
 

--- a/src/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/src/zhinst/toolkit/control/drivers/uhfqa.py
@@ -27,7 +27,7 @@ MAPPINGS = {
         5: "Threshold Correlation",
         7: "Integration",
     },
-    "averaging_mode": {0: "Cyclic", 1: "Sequential",},
+    "averaging_mode": {0: "Cyclic", 1: "Sequential"},
 }
 
 
@@ -440,7 +440,10 @@ class UHFQA(BaseInstrument):
             mapping=MAPPINGS["averaging_mode"],
         )
         self.ref_clock = Parameter(
-            self, self._get_node_dict(f"system/extclk"), device=self, auto_mapping=True,
+            self,
+            self._get_node_dict(f"system/extclk"),
+            device=self,
+            auto_mapping=True,
         )
 
     def _init_settings(self):
@@ -712,7 +715,9 @@ class AWG(AWGCore):
                     amps.append(ch.readout_amplitude())
                     phases.append(ch.phase_shift())
             self.set_sequence_params(
-                readout_frequencies=freqs, readout_amplitudes=amps, phase_shifts=phases,
+                readout_frequencies=freqs,
+                readout_amplitudes=amps,
+                phase_shifts=phases,
             )
         else:
             _logger.error(
@@ -937,7 +942,8 @@ class ReadoutChannel:
             )
         if freq <= 0:
             _logger.error(
-                "This frequency must be positive.", _logger.ExceptionTypes.ValueError,
+                "This frequency must be positive.",
+                _logger.ExceptionTypes.ValueError,
             )
         clk_rate = 1.8e9
         x = np.arange(0, length, 1)
@@ -1007,7 +1013,9 @@ class UHFScope(Scope):
             ],
         )
         self._channel = Parameter(
-            self, self._parent._get_node_dict(f"scopes/0/channel"), device=self._parent,
+            self,
+            self._parent._get_node_dict(f"scopes/0/channel"),
+            device=self._parent,
         )
         self.trigger_source = Parameter(
             self,

--- a/src/zhinst/toolkit/control/multi_device_connection.py
+++ b/src/zhinst/toolkit/control/multi_device_connection.py
@@ -118,7 +118,8 @@ class MultiDeviceConnection:
             self._shfqas[device.name] = device
         else:
             _logger.error(
-                "This device is not recognized!", _logger.ExceptionTypes.ToolkitError,
+                "This device is not recognized!",
+                _logger.ExceptionTypes.ToolkitError,
             )
         device.setup(connection=self._shared_connection)
         device.connect_device()

--- a/src/zhinst/toolkit/control/parsers.py
+++ b/src/zhinst/toolkit/control/parsers.py
@@ -274,7 +274,7 @@ class Parse:
 
     @staticmethod
     def version_parser(v):
-        """ Convert the obtained data version string to correct format"""
+        """Convert the obtained data version string to correct format"""
         v = str(v)
         year = v[:2]
         month = v[2:4]

--- a/src/zhinst/toolkit/helpers/sequence_commands.py
+++ b/src/zhinst/toolkit/helpers/sequence_commands.py
@@ -82,7 +82,8 @@ class SequenceCommand(object):
             return f"while(true){{\n"
         if i < 0:
             _logger.error(
-                "Invalid number of repetitions!", _logger.ExceptionTypes.ValueError,
+                "Invalid number of repetitions!",
+                _logger.ExceptionTypes.ValueError,
             )
         return f"repeat({int(i)}){{\n"
 
@@ -121,7 +122,8 @@ class SequenceCommand(object):
         """
         if i < 0:
             _logger.error(
-                "Wait time cannot be negative!", _logger.ExceptionTypes.ValueError,
+                "Wait time cannot be negative!",
+                _logger.ExceptionTypes.ValueError,
             )
         if i == 0:
             return "//\n"
@@ -174,11 +176,13 @@ class SequenceCommand(object):
     def trigger(value, index=1):
         if value not in [0, 1]:
             _logger.error(
-                "Invalid Trigger Value!", _logger.ExceptionTypes.ValueError,
+                "Invalid Trigger Value!",
+                _logger.ExceptionTypes.ValueError,
             )
         if index not in [1, 2]:
             _logger.error(
-                "Invalid Trigger Index!", _logger.ExceptionTypes.ValueError,
+                "Invalid Trigger Index!",
+                _logger.ExceptionTypes.ValueError,
             )
         return f"setTrigger({value << (index - 1)});\n"
 
@@ -222,7 +226,8 @@ class SequenceCommand(object):
         """
         if i < 0:
             _logger.error(
-                "Waveform Index cannot be negative!", _logger.ExceptionTypes.ValueError,
+                "Waveform Index cannot be negative!",
+                _logger.ExceptionTypes.ValueError,
             )
         return f"assignWaveIndex(w{i + 1}_1, w{i + 1}_2, {i});\n"
 
@@ -243,7 +248,8 @@ class SequenceCommand(object):
     def play_wave_indexed(i):
         if i < 0:
             _logger.error(
-                "Invalid Waveform Index!", _logger.ExceptionTypes.ValueError,
+                "Invalid Waveform Index!",
+                _logger.ExceptionTypes.ValueError,
             )
         return f"playWave(w{i + 1}_1, w{i + 1}_2);\n"
 
@@ -251,7 +257,8 @@ class SequenceCommand(object):
     def play_wave_indexed_scaled(amp1, amp2, i):
         if i < 0:
             _logger.error(
-                "Invalid Waveform Index!", _logger.ExceptionTypes.ValueError,
+                "Invalid Waveform Index!",
+                _logger.ExceptionTypes.ValueError,
             )
         if abs(amp1) > 1 or abs(amp2) > 1:
             _logger.error(
@@ -311,11 +318,13 @@ class SequenceCommand(object):
         length, pos, width = gauss_params
         if length < 16:
             _logger.error(
-                "Invalid Value for length!", _logger.ExceptionTypes.ValueError,
+                "Invalid Value for length!",
+                _logger.ExceptionTypes.ValueError,
             )
         if length % 16:
             _logger.error(
-                "Length has to be multiple of 16!", _logger.ExceptionTypes.ValueError,
+                "Length has to be multiple of 16!",
+                _logger.ExceptionTypes.ValueError,
             )
         if not (length > pos and length > width):
             _logger.error(
@@ -324,7 +333,8 @@ class SequenceCommand(object):
             )
         if not (width > 0):
             _logger.error(
-                "Values cannot be negative!", _logger.ExceptionTypes.ValueError,
+                "Values cannot be negative!",
+                _logger.ExceptionTypes.ValueError,
             )
         return (
             f"wave w_1 = gauss({length}, {pos}, {width});\n"
@@ -341,11 +351,13 @@ class SequenceCommand(object):
             )
         if length < 16:
             _logger.error(
-                "Invalid Value for length!", _logger.ExceptionTypes.ValueError,
+                "Invalid Value for length!",
+                _logger.ExceptionTypes.ValueError,
             )
         if length % 16:
             _logger.error(
-                "Length has to be multiple of 16!", _logger.ExceptionTypes.ValueError,
+                "Length has to be multiple of 16!",
+                _logger.ExceptionTypes.ValueError,
             )
         if not (length > pos and length > width):
             _logger.error(
@@ -354,7 +366,8 @@ class SequenceCommand(object):
             )
         if not (width > 0):
             _logger.error(
-                "Values cannot be negative!", _logger.ExceptionTypes.ValueError,
+                "Values cannot be negative!",
+                _logger.ExceptionTypes.ValueError,
             )
         return (
             f"wave w_1 = {amp} * gauss({length}, {pos}, {width});\n"
@@ -413,7 +426,8 @@ class SequenceCommand(object):
 
         if index not in [1, 2]:
             _logger.error(
-                "Invalid Trigger Index!", _logger.ExceptionTypes.ValueError,
+                "Invalid Trigger Index!",
+                _logger.ExceptionTypes.ValueError,
             )
         if target in [DeviceTypes.HDAWG, DeviceTypes.SHFQA]:
             return f"waitDigTrigger({index});\n"

--- a/src/zhinst/toolkit/helpers/sequences.py
+++ b/src/zhinst/toolkit/helpers/sequences.py
@@ -141,7 +141,8 @@ class Sequence(object):
         converter=lambda m: TriggerMode.NONE if m == "None" else TriggerMode(m),
     )
     trigger_samples = attr.ib(
-        default=32, validator=[is_greater_equal(32), is_multiple(16)],
+        default=32,
+        validator=[is_greater_equal(32), is_multiple(16)],
     )
     repetitions = attr.ib(default=1)
     alignment = attr.ib(
@@ -362,7 +363,8 @@ class Sequence(object):
         """Performs sanity checks on the sequence parameters."""
         if (self.period - self.dead_time - self.latency + self.trigger_delay) < 0:
             _logger.error(
-                "Wait time cannot be negative!", _logger.ExceptionTypes.ValueError,
+                "Wait time cannot be negative!",
+                _logger.ExceptionTypes.ValueError,
             )
 
     def __setattr__(self, name, value) -> None:
@@ -591,7 +593,8 @@ class RabiSequence(Sequence):
     """
 
     pulse_amplitudes = attr.ib(
-        default=[1.0], validator=[is_greater_equal(-1.0), is_smaller_equal(1.0)],
+        default=[1.0],
+        validator=[is_greater_equal(-1.0), is_smaller_equal(1.0)],
     )
     pulse_width = attr.ib(default=50e-9, validator=is_greater_equal(0))
     pulse_truncation = attr.ib(default=3, validator=is_greater_equal(0))
@@ -646,7 +649,8 @@ class RabiSequence(Sequence):
             self.period - self.dead_time - 2 * self.pulse_width * self.pulse_truncation
         ) < 0:
             _logger.error(
-                "Wait time cannot be negative!", _logger.ExceptionTypes.ValueError,
+                "Wait time cannot be negative!",
+                _logger.ExceptionTypes.ValueError,
             )
         if self.n_HW_loop < len(self.pulse_amplitudes):
             _logger.error(
@@ -685,7 +689,8 @@ class T1Sequence(Sequence):
     """
 
     pulse_amplitude = attr.ib(
-        default=1, validator=[is_greater_equal(-1.0), is_smaller_equal(1.0)],
+        default=1,
+        validator=[is_greater_equal(-1.0), is_smaller_equal(1.0)],
     )
     pulse_width = attr.ib(default=50e-9, validator=is_greater_equal(0))
     pulse_truncation = attr.ib(default=3, validator=is_greater_equal(0))
@@ -728,7 +733,8 @@ class T1Sequence(Sequence):
         super().check_attributes()
         if (self.period - self.dead_time - self.gauss_params[0] / self.clock_rate) < 0:
             _logger.error(
-                "Wait time cannot be negative!", _logger.ExceptionTypes.ValueError,
+                "Wait time cannot be negative!",
+                _logger.ExceptionTypes.ValueError,
             )
         if self.n_HW_loop > len(self.delay_times):
             _logger.error(

--- a/src/zhinst/toolkit/helpers/shf_waveform.py
+++ b/src/zhinst/toolkit/helpers/shf_waveform.py
@@ -58,7 +58,8 @@ class SHFWaveform(object):
             self._update()
         else:
             _logger.error(
-                "Waveform lengths don't match!", _logger.ExceptionTypes.ToolkitError,
+                "Waveform lengths don't match!",
+                _logger.ExceptionTypes.ToolkitError,
             )
 
     @property

--- a/src/zhinst/toolkit/helpers/waveform.py
+++ b/src/zhinst/toolkit/helpers/waveform.py
@@ -55,7 +55,8 @@ class Waveform(object):
             self._update()
         else:
             _logger.error(
-                "Waveform lengths don't match!", _logger.ExceptionTypes.ToolkitError,
+                "Waveform lengths don't match!",
+                _logger.ExceptionTypes.ToolkitError,
             )
 
     @property

--- a/tests/test_nodetree.py
+++ b/tests/test_nodetree.py
@@ -19,7 +19,7 @@ DUMMY_DICT = {
         "second": DUMMY_PARAMETER,
         "third": DUMMY_PARAMETER,
     },
-    "second": {1: DUMMY_PARAMETER, 2: DUMMY_PARAMETER, 3: DUMMY_PARAMETER,},
+    "second": {1: DUMMY_PARAMETER, 2: DUMMY_PARAMETER, 3: DUMMY_PARAMETER},
     "third": DUMMY_PARAMETER,
     "fourths": {1: DUMMY_PARAMETER},
 }

--- a/tests/test_pqsc.py
+++ b/tests/test_pqsc.py
@@ -50,14 +50,14 @@ def test_methods_pqsc():
         pqsc.check_ref_clock()
 
 
-@given(single_port=st.integers(0, 17),)
+@given(single_port=st.integers(0, 17))
 def test_check_zsync_connection_single_port(single_port):
     pqsc = PQSC("name", "dev10000")
     with pytest.raises(pqsc_logger.ToolkitConnectionError):
         pqsc.check_zsync_connection(ports=single_port)
 
 
-@given(port_list=st.lists(st.integers(0, 17), min_size=1, max_size=18, unique=True),)
+@given(port_list=st.lists(st.integers(0, 17), min_size=1, max_size=18, unique=True))
 def test_check_zsync_connection_port_list(port_list):
     pqsc = PQSC("name", "dev10000")
     with pytest.raises(pqsc_logger.ToolkitConnectionError):

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -22,7 +22,7 @@ parser_logger.disable_logging()
 connection_logger.disable_logging()
 
 
-@given(device_type=st.sampled_from(DeviceTypes),)
+@given(device_type=st.sampled_from(DeviceTypes))
 def test_init_scope(device_type):
     allowed_device_types = {
         DeviceTypes.UHFQA: UHFQA,

--- a/tests/test_sequenceCommands.py
+++ b/tests/test_sequenceCommands.py
@@ -26,7 +26,8 @@ def test_header_comment(t):
 
 
 @given(
-    trigger_mode=st.sampled_from(TriggerMode), alignment=st.sampled_from(Alignment),
+    trigger_mode=st.sampled_from(TriggerMode),
+    alignment=st.sampled_from(Alignment),
 )
 def test_header_info(trigger_mode, alignment):
     line = SequenceCommand.header_info(SequenceType.NONE, trigger_mode, alignment)

--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -275,7 +275,7 @@ def test_set_get_params_channel():
         ch._average_result(1000)
 
 
-@given(single_value=st.floats(-2, 2),)
+@given(single_value=st.floats(-2, 2))
 def test_int_weights_envelope_single_value(single_value):
     ch = ReadoutChannel(UHFQA("name", "dev2000"), 0)
     with pytest.raises(uhfqa_logger.ToolkitConnectionError):
@@ -288,7 +288,7 @@ def test_int_weights_envelope_single_value(single_value):
         assert ch.int_weights_envelope() == single_value
 
 
-@given(value_list=st.lists(st.floats(0, 1), min_size=1, max_size=4096),)
+@given(value_list=st.lists(st.floats(0, 1), min_size=1, max_size=4096))
 def test_int_weights_envelope_value_list(value_list):
     ch = ReadoutChannel(UHFQA("name", "dev2000"), 0)
     with pytest.raises(TypeError):


### PR DESCRIPTION
Python code formatter package `black` is upgraded. Therefore, we run
`black` over the entire project to reformat everything.