### PR TITLE
Add `_assert_node_value` to `BaseInstrument`

### DIFF
--- a/tests/test_baseInstrument.py
+++ b/tests/test_baseInstrument.py
@@ -51,14 +51,14 @@ def test_init_instrument():
         discovery=DiscoveryMock(),
     )
     assert instr._nodetree is None
-    assert instr._options is None
     assert instr.nodetree is None
+    assert instr._options is None
+    assert instr.options is None
     assert instr.name == "name"
     assert instr.device_type == DeviceTypes.PQSC
     assert instr.serial == "dev10000"
     assert instr.interface == "1GbE"
     assert instr.is_connected is False
-    assert instr.options is None
 
 
 def test_check_connection():
@@ -76,15 +76,8 @@ def test_check_connection():
     with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
         instr.connect_device()
     with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
-        instr._get("sigouts/0/on")
-    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
-        instr._set("sigouts/0/on", 1)
-    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
-        instr._get_node_dict("sigouts/0/on")
-    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
-        instr._get_node_dict("zi/about/revision")
-    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
-        instr._get_streamingnodes()
+        instr._init_params()
+    instr._init_settings()
 
 
 def test_serials():
@@ -100,13 +93,6 @@ def test_serials():
         "name",
         DeviceTypes.PQSC,
         "dev10000",
-        interface="1GbE",
-        discovery=DiscoveryMock(),
-    )
-    BaseInstrument(
-        "name",
-        DeviceTypes.PQSC,
-        "DEV10000",
         interface="1GbE",
         discovery=DiscoveryMock(),
     )
@@ -128,3 +114,33 @@ def test_serial_normalization():
 def test_default_discovery():
     inst = BaseInstrument("name", DeviceTypes.PQSC, "DEV10000", interface="1GbE")
     assert isinstance(inst._controller.discovery, ziDiscovery)
+
+
+def test_set_get():
+    instr = BaseInstrument(
+        "name",
+        DeviceTypes.PQSC,
+        "dev10000",
+        interface="1GbE",
+        discovery=DiscoveryMock(),
+    )
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
+        instr._set("execution/enable", 1)
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
+        instr._set_vector("/zsyncs/0/connection/alias", "hd1")
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
+        instr.sync()
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
+        instr._assert_node_value("execution/enable", 1, blocking=True)
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
+        instr._assert_node_value("execution/enable", 1, blocking=False)
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
+        instr._assert_node_value([("execution/enable", 1)], blocking=True)
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
+        instr._get("execution/enable")
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
+        instr._get_node_dict("execution/enable")
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
+        instr._get_node_dict("zi/about/revision")
+    with pytest.raises(baseinstrument_logger.ToolkitConnectionError):
+        instr._get_streamingnodes()

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -6,13 +6,31 @@
 import pytest
 from hypothesis import given, strategies as st
 
-from .context import Parameter, nodetree_logger
+from .context import Parse, Parameter, nodetree_logger, parser_logger
 
 nodetree_logger.disable_logging()
+parser_logger.disable_logging()
+
 
 DUMMY_PARAMETER = {
     "Node": "test/bla/blub",
 }
+
+DUMMY_OPTIONS = {
+    "1": '"result_of_integration": Complex-valued integration results of the Weighted '
+    "Integration in Qubit Readout mode.",
+    "3": '"result_of_discrimination": The results after state discrimination.',
+}
+
+DUMMY_OPTIONS2 = {
+    "0": '"chan0trigin0", "channel0_trigger_input0": Channel 1, Trigger Input A.',
+    "1024": '"swtrig0", "software_trigger0": Software Trigger 0.',
+}
+
+DUMMY_SET_PARSER = [
+    lambda v: Parse.greater_equal(v, 4),
+    lambda v: Parse.multiple_of(v, 4, "down"),
+]
 
 
 class Device:
@@ -26,6 +44,13 @@ class Device:
     def _set(self, path, v, sync):
         self._value = v
         return self._value
+
+    def _assert_node_value(self, path, v, blocking, timeout, sleep_time):
+        print(v, self._get(path))
+        if v == self._get(path):
+            return True
+        else:
+            return False
 
 
 class Parent:
@@ -48,10 +73,26 @@ def test_parameter_details():
     params["Description"] = "TEST"
     params["Type"] = "TEST"
     params["Properties"] = "Read, Write"
-    params["Options"] = "TEST"
+    params["Options"] = DUMMY_OPTIONS
     params["Unit"] = "TEST"
     p = Parameter(parent, DUMMY_PARAMETER)
     assert p.__repr__() != ""
+    p = Parameter(parent, DUMMY_PARAMETER, auto_mapping=True)
+    assert p._map == {1: "result_of_integration", 3: "result_of_discrimination"}
+    assert p._display_mapping is False
+    params["Options"] = DUMMY_OPTIONS2
+    p = Parameter(parent, DUMMY_PARAMETER, auto_mapping=True)
+    assert p._map == {
+        0: ["chan0trigin0", "channel0_trigger_input0"],
+        1024: ["swtrig0", "software_trigger0"],
+    }
+    assert p._display_mapping is False
+    p = Parameter(parent, DUMMY_PARAMETER, mapping={0: "key"})
+    assert p._map == {0: "key"}
+    assert p._display_mapping is True
+    params["Options"] = None
+    with pytest.raises(nodetree_logger.ToolkitNodeTreeError):
+        Parameter(parent, DUMMY_PARAMETER, auto_mapping=True)
 
 
 @given(st.integers())
@@ -63,6 +104,37 @@ def test_set_get(v):
     p = Parameter(parent, DUMMY_PARAMETER)
     p(v)
     assert p() == v
+    assert p.assert_value(v) is True
+    p = Parameter(parent, DUMMY_PARAMETER, set_parser=DUMMY_SET_PARSER)
+    p(5)
+    assert p() == 4
+    assert p.assert_value(4) is True
+    p = Parameter(parent, DUMMY_PARAMETER, mapping={0: "key"})
+    p("key")
+    assert p() == "key"
+    assert p.assert_value("key") is True
+    p(0)
+    assert p() == "key"
+    assert p.assert_value("key") is True
+    with pytest.raises(ValueError):
+        p(1)
+    with pytest.raises(ValueError):
+        p("key2")
+    params["Options"] = DUMMY_OPTIONS
+    p = Parameter(parent, DUMMY_PARAMETER, auto_mapping=True)
+    p(1)
+    assert p() == "result_of_integration"
+    assert p.assert_value("result_of_integration") is True
+    with pytest.raises(ValueError):
+        p(2)
+    params["Options"] = DUMMY_OPTIONS2
+    p = Parameter(parent, DUMMY_PARAMETER, auto_mapping=True)
+    p(0)
+    assert p() == "chan0trigin0"
+    assert p.assert_value("chan0trigin0") is True
+    with pytest.raises(ValueError):
+        p(1)
+
 
 
 def test_set_get_readonly():


### PR DESCRIPTION
* A function named `assert_value` is also added to `node_tree.py` which
calls `_assert_node_value` from `BaseInstrument` to assert the value of
a parameter.
* Tests for `BaseInstrument` and `Parameter` classes are updated