### PR TITLE
Make `command_to_node` method public

### DIFF
--- a/src/zhinst/toolkit/control/connection.py
+++ b/src/zhinst/toolkit/control/connection.py
@@ -779,10 +779,10 @@ class DeviceConnection(object):
             if isinstance(command, list):
                 paths = []
                 for c in command:
-                    paths.append(self._command_to_node(c))
+                    paths.append(self.command_to_node(c))
                 node_string = ", ".join([p for p in paths])
             elif isinstance(command, str):
-                node_string = self._command_to_node(command)
+                node_string = self.command_to_node(command)
             else:
                 _logger.error(
                     "Invalid argument! It must be either a node path string or "
@@ -934,10 +934,10 @@ class DeviceConnection(object):
                     "node/value must be specified as pairs!",
                     _logger.ExceptionTypes.TypeError,
                 )
-            new_settings.append((self._command_to_node(args[0]), args[1]))
+            new_settings.append((self.command_to_node(args[0]), args[1]))
         return new_settings
 
-    def _command_to_node(self, command):
+    def command_to_node(self, command):
         """Converts a command string to a node path.
 
         Parses a single command into a node string that can be passed

--- a/src/zhinst/toolkit/control/drivers/base/base.py
+++ b/src/zhinst/toolkit/control/drivers/base/base.py
@@ -481,7 +481,7 @@ class BaseInstrument:
         """
         # Add the device serial to the node string if it does not start
         # with '/zi/'.
-        device_node = self._controller._command_to_node(node)
+        device_node = self._controller.command_to_node(node)
         self._check_node_exists(device_node)
         nested_dict = self._get_nodetree(device_node)
         inner_dict = list(nested_dict.values())[0]


### PR DESCRIPTION
`command_to_node` method of `DeviceConnection` is called from outside
the class, i.e. from `BaseInstrument` class. Therefore, it needs to be
public instead of protected