### PR TITLE
Access public members of `InstrumentConfiguration`

### DIFF
--- a/src/zhinst/toolkit/__init__.py
+++ b/src/zhinst/toolkit/__init__.py
@@ -1,4 +1,29 @@
-from zhinst.toolkit.control.drivers import *
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
+"""The Zurich Instruments Toolkit (zhinst-toolkit)
+
+This package is a collection of Python tools for high level device
+control. Based on the native interface to Zurich Instruments LabOne,
+they offer an easy and user-friendly way to control Zurich Instruments
+devices. It  is tailored to control multiple instruments together,
+especially for device management and multiple AWG distributed control.
+
+The Toolkit forms the basis for instrument drivers used in QCoDeS and
+Labber. It comes in the form of a package compatible with Python 3.6+.
+"""
+
+from zhinst.toolkit.control.drivers import (
+    BaseInstrument,
+    HDAWG,
+    UHFQA,
+    UHFLI,
+    MFLI,
+    PQSC,
+    SHFQA,
+)
+from zhinst.toolkit.interface import DeviceTypes
 from zhinst.toolkit.control.multi_device_connection import MultiDeviceConnection
 from zhinst.toolkit.helpers.utils import SequenceType, TriggerMode, Alignment
 from zhinst.toolkit._version import version as __version__

--- a/src/zhinst/toolkit/control/connection.py
+++ b/src/zhinst/toolkit/control/connection.py
@@ -779,10 +779,10 @@ class DeviceConnection(object):
             if isinstance(command, list):
                 paths = []
                 for c in command:
-                    paths.append(self._command_to_node(c))
+                    paths.append(self.command_to_node(c))
                 node_string = ", ".join([p for p in paths])
             elif isinstance(command, str):
-                node_string = self._command_to_node(command)
+                node_string = self.command_to_node(command)
             else:
                 _logger.error(
                     "Invalid argument! It must be either a node path string or "
@@ -934,10 +934,10 @@ class DeviceConnection(object):
                     "node/value must be specified as pairs!",
                     _logger.ExceptionTypes.TypeError,
                 )
-            new_settings.append((self._command_to_node(args[0]), args[1]))
+            new_settings.append((self.command_to_node(args[0]), args[1]))
         return new_settings
 
-    def _command_to_node(self, command):
+    def command_to_node(self, command):
         """Converts a command string to a node path.
 
         Parses a single command into a node string that can be passed

--- a/src/zhinst/toolkit/control/drivers/__init__.py
+++ b/src/zhinst/toolkit/control/drivers/__init__.py
@@ -1,3 +1,13 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
+"""The Zurich Instruments Toolkit (zhinst-toolkit) Drivers
+
+This package is a collection of high level controllers for Zurich
+Instruments devices.
+"""
+from .base import BaseInstrument
 from .hdawg import HDAWG
 from .uhfqa import UHFQA
 from .uhfli import UHFLI

--- a/src/zhinst/toolkit/control/drivers/base/base.py
+++ b/src/zhinst/toolkit/control/drivers/base/base.py
@@ -75,13 +75,13 @@ class BaseInstrument:
                 f"Serial must be a string", _logger.ExceptionTypes.ToolkitError
             )
         self._config = InstrumentConfiguration()
-        self._config._instrument._name = name
-        self._config._instrument._config._device_type = device_type
-        self._config._instrument._config._serial = serial
-        self._config._instrument._config._interface = kwargs.get("interface", "1GbE")
-        self._config._api_config.host = kwargs.get("host", "localhost")
-        self._config._api_config.port = kwargs.get("port", 8004)
-        self._config._api_config.api = kwargs.get("api", 6)
+        self._config.instrument.name = name
+        self._config.instrument.config.device_type = device_type
+        self._config.instrument.config.serial = serial
+        self._config.instrument.config.interface = kwargs.get("interface", "1GbE")
+        self._config.api_config.host = kwargs.get("host", "localhost")
+        self._config.api_config.port = kwargs.get("port", 8004)
+        self._config.api_config.api = kwargs.get("api", 6)
         self._controller = DeviceConnection(
             self, discovery if discovery is not None else zi.ziDiscovery()
         )
@@ -536,22 +536,22 @@ class BaseInstrument:
 
     @property
     def name(self):
-        return self._config._instrument._name
+        return self._config.instrument.name
 
     @property
     def device_type(self):
-        return self._config._instrument._config._device_type
+        return self._config.instrument.config.device_type
 
     @property
     def serial(self):
         if self.is_connected:
             return self._controller.normalized_serial
         else:
-            return self._config._instrument._config._serial
+            return self._config.instrument.config.serial
 
     @property
     def interface(self):
-        return self._config._instrument._config._interface
+        return self._config.instrument.config.interface
 
     @property
     def options(self):

--- a/src/zhinst/toolkit/control/drivers/base/base.py
+++ b/src/zhinst/toolkit/control/drivers/base/base.py
@@ -481,7 +481,7 @@ class BaseInstrument:
         """
         # Add the device serial to the node string if it does not start
         # with '/zi/'.
-        device_node = self._controller._command_to_node(node)
+        device_node = self._controller.command_to_node(node)
         self._check_node_exists(device_node)
         nested_dict = self._get_nodetree(device_node)
         inner_dict = list(nested_dict.values())[0]


### PR DESCRIPTION
The `BaseInstrument` class tries to access to protected members of 
`InstrumentConfiguration` class such as: `instrument` and `api_config`. 
The `__init__` method and the properties of `BaseInstrument` are updated 
to access the public members instead.