### PR TITLE
Check sequence and trigger mode in `AWG` class

### DIFF
--- a/src/zhinst/toolkit/control/drivers/base/awg.py
+++ b/src/zhinst/toolkit/control/drivers/base/awg.py
@@ -8,7 +8,7 @@ import time
 from typing import List, Union
 import re
 
-from zhinst.toolkit.helpers import SequenceProgram, Waveform, SequenceType
+from zhinst.toolkit.helpers import SequenceProgram, Waveform, SequenceType, TriggerMode
 from .base import BaseInstrument
 from zhinst.toolkit.interface import LoggerModule
 from ...parsers import Parse
@@ -408,13 +408,38 @@ class AWGCore:
         self._program.set_params(**kwargs)
         self._apply_sequence_settings(**kwargs)
 
-    def _apply_sequence_settings(self, **kwargs):
-        pass
+    def _apply_sequence_settings(self, **kwargs) -> None:
+        if "sequence_type" in kwargs.keys():
+            if kwargs["sequence_type"] == "None":
+                # If sequence type is given as string `None`, return
+                # enumeration for `None` from the SequenceType class
+                t = SequenceType(None)
+            else:
+                t = SequenceType(kwargs["sequence_type"])
+            if t not in self._parent.allowed_sequences:
+                _logger.error(
+                    f"Sequence type {t} must be one of "
+                    f"{[s.value for s in self._parent.allowed_sequences]}!",
+                    _logger.ExceptionTypes.ToolkitError,
+                )
+        if "trigger_mode" in kwargs.keys():
+            if kwargs["trigger_mode"] == "None":
+                # If trigger mode is given as string `None`, return
+                # enumeration for `None` from the TriggerMode class
+                t = TriggerMode(None)
+            else:
+                t = TriggerMode(kwargs["trigger_mode"])
+            if t not in self._parent.allowed_trigger_modes:
+                _logger.error(
+                    f"Trigger mode {t} must be one of "
+                    f"{[s.value for s in self._parent.allowed_trigger_modes]}!",
+                    _logger.ExceptionTypes.ToolkitError,
+                )
 
     def _seqc_error(self, statusstring):
         """Extract the relevant lines from seqc program in case of error.
 
-        Ihis method extracts the line number from the compiler status
+        This method extracts the line number from the compiler status
         and then finds the relevant lines in the seqc program to guide
         the user. It works both for errors and warnings.
         """

--- a/src/zhinst/toolkit/control/drivers/hdawg.py
+++ b/src/zhinst/toolkit/control/drivers/hdawg.py
@@ -480,26 +480,12 @@ class AWG(AWGCore):
         self.set_sequence_params(reset_phase=False)
         self._parent._set("system/awg/oscillatorcontrol", 0)
 
-    def _apply_sequence_settings(self, **kwargs):
-        # check sequence type
-        if "sequence_type" in kwargs.keys():
-            t = SequenceType(kwargs["sequence_type"])
-            if t not in self._parent.allowed_sequences:
-                _logger.error(
-                    f"Sequence type {t} must be one of "
-                    f"{[s.value for s in self._parent.allowed_sequences]}!",
-                    _logger.ExceptionTypes.ToolkitError,
-                )
-        # apply settings dependent on trigger mode
+    def _apply_sequence_settings(self, **kwargs) -> None:
+        super()._apply_sequence_settings(**kwargs)
         if "trigger_mode" in kwargs.keys():
             t = TriggerMode(kwargs["trigger_mode"])
-            if t not in self._parent.allowed_trigger_modes:
-                _logger.error(
-                    f"Trigger mode {t} must be one of "
-                    f"{[s.value for s in self._parent.allowed_trigger_modes]}!",
-                    _logger.ExceptionTypes.ToolkitError,
-                )
-            elif t in [TriggerMode.EXTERNAL_TRIGGER, TriggerMode.RECEIVE_TRIGGER]:
+            # apply settings depending on trigger mode
+            if t in [TriggerMode.EXTERNAL_TRIGGER, TriggerMode.RECEIVE_TRIGGER]:
                 self._apply_receive_trigger_settings()
             elif t == TriggerMode.ZSYNC_TRIGGER:
                 self._apply_zsync_trigger_settings()

--- a/src/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/src/zhinst/toolkit/control/drivers/uhfqa.py
@@ -579,17 +579,12 @@ class AWG(AWGCore):
             get_parser=Parse.get_true_false,
         )
 
-    def _apply_sequence_settings(self, **kwargs):
-        # apply settings depending on the sequence type
+    def _apply_sequence_settings(self, **kwargs) -> None:
+        super()._apply_sequence_settings(**kwargs)
         if "sequence_type" in kwargs.keys():
             t = SequenceType(kwargs["sequence_type"])
-            if t not in self._parent.allowed_sequences:
-                _logger.error(
-                    f"Sequence type {t} must be one of "
-                    f"{[s.value for s in self._parent.allowed_sequences]}!",
-                    _logger.ExceptionTypes.ToolkitError,
-                )
-            elif t == SequenceType.CW_SPEC:
+            # apply settings depending on the sequence type
+            if t == SequenceType.CW_SPEC:
                 self._apply_cw_settings()
             elif t == SequenceType.PULSED_SPEC:
                 self._apply_pulsed_settings()
@@ -597,16 +592,10 @@ class AWG(AWGCore):
                 self._apply_readout_settings()
             else:
                 self._apply_base_settings()
-        # apply settings dependent on trigger mode
         if "trigger_mode" in kwargs.keys():
             t = TriggerMode(kwargs["trigger_mode"])
-            if t not in self._parent.allowed_trigger_modes:
-                _logger.error(
-                    f"Trigger mode {t} must be one of "
-                    f"{[s.value for s in self._parent.allowed_trigger_modes]}!",
-                    _logger.ExceptionTypes.ToolkitError,
-                )
-            elif t in [TriggerMode.EXTERNAL_TRIGGER, TriggerMode.RECEIVE_TRIGGER]:
+            # apply settings depending on trigger mode
+            if t in [TriggerMode.EXTERNAL_TRIGGER, TriggerMode.RECEIVE_TRIGGER]:
                 self._apply_receive_trigger_settings()
             elif t == TriggerMode.ZSYNC_TRIGGER:
                 self._apply_zsync_trigger_settings()


### PR DESCRIPTION
* The lines that check the sequence type and the trigger mode in 
device specific `AWG` classes of `HDAWG` and `UHFQA` are exactly the 
same. To avoid having duplicate code, move this check into the 
`_apply_sequence_settings` method of the base `AWGCore` class and 
inherit this method in the child classes before applying device 
specific settings.
* The return type hint `None` is also added to the method.