### PR TITLE
Update `node_tree.py`

### DIFF
--- a/src/zhinst/toolkit/control/node_tree.py
+++ b/src/zhinst/toolkit/control/node_tree.py
@@ -2,10 +2,15 @@
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.
+"""Zurich Instruments Toolkit (zhinst-toolkit) Nodes and Parameters.
 
-import numpy as np
+This module implements the Nodetree, Node, Node List and Parameter
+classes necessary for representing the nodetree structure and accessing
+the settings of any Zurich Instruments device.
+"""
+
 import re
-from typing import List, Dict, Callable
+from typing import List, Dict, Callable, Union, Any
 import keyword
 
 from zhinst.toolkit.interface import LoggerModule
@@ -16,11 +21,12 @@ _logger = LoggerModule(__name__)
 class Parameter:
     """Implements a :mod:`zhinst-toolkit` :class:`Parameter`.
 
-    Implements a callable :class:`Parameter` as leaves in the :class:`NodeTree`
-    with a parent :class:`Node` and a device. It holds the information from the
-    `daq.listNodesJSON(...)` method of the Zurich Instruments Python API such as
-    the node path, the description, properties, etc. The `__repr__()` method
-    returns a string with a summary of the :class:`Parameter`.
+    Implements a callable :class:`Parameter` as leaves in the
+    :class:`NodeTree` with a parent :class:`Node` and a device. It
+    holds the information from the `daq.listNodesJSON(...)` method of
+    the Zurich Instruments Python API such as the node path, the
+    description, properties, etc. The `__repr__()` method returns a
+    string with a summary of the :class:`Parameter`.
 
         >>> uhfqa.nodetree.osc.freq
         Node: /DEV2266/OSCS/0/FREQ
@@ -40,30 +46,32 @@ class Parameter:
 
     Arguments:
         parent (:class:`BaseInstrument`, :class:`NodeTree` or :class:`Node`):
-            The parent object that the :class:`Parameter` is associated to.
-        params (dict): Dictionary with a definition of the :class:`Parameter`.
-            It must contain the item *'Node'* corresponding to the node path of
-            the parameter on the device that is used for getting and setting the
-            :class:`Parameter` value. It may contain the items *'Description'*,
-            *'Properties'*, *'Options'*, *'Unit'*, *'Type'*.
-
-    Keyword Arguments:
+            The parent object that the :class:`Parameter` is associated
+            to.
+        params (dict): Dictionary with a definition of the
+            :class:`Parameter`. It must contain the item *'Node'*
+            corresponding to the node path of the parameter on the
+            device that is used for getting and setting the
+            :class:`Parameter` value. It may contain the items
+            *'Description'*, *'Properties'*, *'Options'*, *'Unit'*,
+            *'Type'*.
         device (:class:`BaseInstruemnt`): The device driver that the
-            :class:`Parameter` is associated to. The device is eventually
-            used to `set(...)` and `get(...)` the node. (default: None)
+            :class:`Parameter` is associated to. The device is
+            eventually used to `set(...)` and `get(...)` the node
+            (default: None).
         set_parser (Callable or list): A parser function or a list of
             parser functions that are called with the set value before
             setting the value and return the parsed parameter value
             (default: 'lambda v: v').
-        get_parser (Callable): A parser function that is called with the
-            gotten value from the device before returning it by the
+        get_parser (Callable): A parser function that is called with
+            the gotten value from the device before returning it by the
             getter. It returns the parsed parameter value
             (default: 'lambda v: v').
         auto_mapping (bool): A flag that specifies whether a value
-            mapping should be constructed automatically from the options
-            obtained from the device node.
-        mapping (dict): A value mapping for keyword to integer conversion.
-            (default: None)
+            mapping should be constructed automatically from the
+            options obtained from the device node.
+        mapping (dict): A value mapping for keyword to integer
+            conversion (default: None).
 
     """
 
@@ -72,7 +80,7 @@ class Parameter:
         parent,
         params: Dict,
         device=None,
-        set_parser: Callable = lambda v: v,
+        set_parser: Union[Callable, list] = lambda v: v,
         get_parser: Callable = lambda v: v,
         auto_mapping: bool = False,
         mapping: Dict = None,
@@ -145,8 +153,8 @@ class Parameter:
         """Implements a setter for the :class:`Parameter`.
 
         If 'Write' is in the  :class:`Parameter` properties (from
-        `listNodesJSON`), this will call the '_set' method of the associated
-        device with 'path' and 'value' as attributes.
+        `listNodesJSON`), this will call the '_set' method of the
+        associated device with 'path' and 'value' as attributes.
 
         Arguments:
             value: value to be set
@@ -211,7 +219,7 @@ class Parameter:
 
     def _flatten_mapping_values(self):
         """Combine all dictionary values in a single list."""
-        if self._flat_mapping_values == []:
+        if not self._flat_mapping_values:
             nested_list = self._map.values()
             for sublist in nested_list:
                 if isinstance(sublist, list):
@@ -222,13 +230,14 @@ class Parameter:
                     self._flat_mapping_values.append(value)
         return self._flat_mapping_values
 
-    def _reformat_options_dict(self, options):
+    @staticmethod
+    def _reformat_options_dict(options):
         """Insert a new line character after each option
 
         This method allows the options to be displayed in a more human
         readable way
         """
-        return re.sub(r" '\d+':", "\\n\\g<0>", str(options), 0)
+        return re.sub(r" '\d+':", "\\n\\g<0>", str(options))
 
     def _construct_auto_mapping(self):
         """Generate a automatic mapping from the options
@@ -247,8 +256,8 @@ class Parameter:
             map_from_options = {}
             options = self._options
             for key, value in options.items():
-                value_splitted = value.split(": ")
-                value_options = value_splitted[0].split(", ")
+                value_split = value.split(": ")
+                value_options = value_split[0].split(", ")
                 value_options = [re.sub(r'"', "", option) for option in value_options]
                 if len(value_options) < 2:
                     value_options = value_options[0]
@@ -257,7 +266,7 @@ class Parameter:
 
     def assert_value(
         self,
-        value,
+        value: Any,
         blocking: bool = True,
         timeout: float = 2,
         sleep_time: float = 0.005,
@@ -268,6 +277,7 @@ class Parameter:
         :class:`BaseInstrument`.
 
         Arguments:
+            value (Any): Value the parameter is expected to change to.
             blocking (bool): A flag that specifies if the program should
                 be blocked until the node has the expected value
                 (default: True).
@@ -282,7 +292,7 @@ class Parameter:
 
         Returns:
             Either `True` or `False` to indicate whether the node does
-                or does not have the expected value
+            or does not have the expected value
 
         """
         # Process the value if it is a string
@@ -312,8 +322,8 @@ class Parameter:
 
         Keyword Arguments:
             value:  An optional value to call the  :class:`Parameter`
-                with if it is `set`, leaving the argument out `gets` the
-                :class:`Parameter` from the device. (default: None)
+                with if it is `set`, leaving the argument out `gets`
+                the :class:`Parameter` from the device (default: None).
             sync (bool): A flag that specifies if a synchronisation
                 should be performed between the device and the data
                 server after setting the :class:`Parameter` value
@@ -350,16 +360,18 @@ class Parameter:
 class Node:
     """Implements a node in the :class:`NodeTree` of a device.
 
-    A :class:`Node` has a parent node and a device it is associated with. It can
-    hold other :class:`Nodes` as well as :class:`Parameters`. The data structure
-    of the device :class:`NodeTree` is recreated by recursively adding either
-    other :class:`Nodes` or :class:`Parameters` as attributes to the
+    A :class:`Node` has a parent node and a device it is associated
+    with. It can hold other :class:`Nodes` as well as
+    :class:`Parameters`. The data structure of the device
+    :class:`NodeTree` is recreated by recursively adding either other
+    :class:`Nodes` or :class:`Parameters` as attributes to the
     :class:`Node`.
 
-    To make it easier fo the user to navigate the device :class:`NodeTree`, each
-    :class:`Node` has the attributes `nodes` and `parameters` taht holds a list
-    its children. Also the `__repr__()` method is overwritten such that the
-    output in the console is useful:
+    To make it easier fo the user to navigate the device
+    :class:`NodeTree`, each :class:`Node` has the attributes `nodes`
+    and `parameters` that holds a list its children. Also the
+    `__repr__()` method is overwritten such that the output in the
+    console is useful:
 
         >>> hdawg.nodetree.sigouts[0]
         <zhinst.toolkit.tools.nodetree.Node object at 0x0000021E49397470>
@@ -372,12 +384,16 @@ class Node:
         - over
         ...
 
+    Arguments:
+        parent (:class:`Node`): The parent :class:`Node` that the
+            :class:`Nodes` or :class:`Parameters` are added to as
+            attributes.
 
     Attributes:
-        nodes (list): A list of other :class:`Node` s that are children of this
-            :class:`Node`.
-        parameters (list): A list of :class:`Parameters` that are children of
-            this :class:`Node`.
+        nodes (list): A list of other :class:`Node` s that are children
+            of this :class:`Node`.
+        parameters (list): A list of :class:`Parameter` s that are
+            children of this :class:`Node`.
 
     """
 
@@ -394,28 +410,31 @@ class Node:
         return [k for k, v in self.__dict__.items() if isinstance(v, Parameter)]
 
     def _init_subnodes_recursively(self, parent, nodetree_dict: dict):
-        """Recursively adds class:`Nodes` and/or :class:`Parameters` to a parent
-        :class:`Node`.
+        """Recursively adds class:`Nodes` and/or :class:`Parameters`
+        to a parent :class:`Node`.
 
         Recursively goes through a nested nodetree dictionary. Adds a
-        :class:`Node` object as attribute to the parent node if the leave of the
-        :class:`NodeTree` has not yet been reached. Adds a :class:`Parameter` as
-        attribute to the parent node if the leave has been reached (i.e. when
-        'Node' is in keys of the remaining dict and the remaining dict is the s
-        ame as the one return from `listNodesJSON` describing the
-        :class:`Parameter`).
+        :class:`Node` object as attribute to the parent node if the
+        leave of the :class:`NodeTree` has not yet been reached. Adds a
+        :class:`Parameter` as attribute to the parent node if the leave
+        has been reached (i.e. when 'Node' is in keys of the remaining
+        dict and the remaining dict is the same as the one return from
+        `listNodesJSON` describing the :class:`Parameter`).
 
-        If a layer in the :class:`NodeTree` is enumerated and the keys of the
-        dict are integer values (e.g. 'sigouts/0/..', 'sigouts/1/..',
-        'sigouts/2/..', ...) a :class:`NodeList` is created instead. In case the
-        :class:`NodeList` has only one entry (e.g. for 'qas/0/..') only a single
-        :class:`Node` is added and the plural of 'qas' is turned into 'qa'.
+        If a layer in the :class:`NodeTree` is enumerated and the keys
+        of the dict are integer values (e.g. 'sigouts/0/..',
+        'sigouts/1/..', 'sigouts/2/..', ...) a :class:`NodeList` is
+        created instead. In case the :class:`NodeList` has only one
+        entry (e.g. for 'qas/0/..') only a single :class:`Node` is
+        added and the plural of 'qas' is turned into 'qa'.
 
         Arguments:
             parent (:class:`Node`): The parent :class:`Node` that the
-                :class:`Nodes` or :class:`Parameters` are added to as attributes.
-            nodetree_dict (dict): A (sub-)dictionary containing the next
-                :class:`Nodes` and/or :class:`Parameters` as dicts.
+                :class:`Nodes` or :class:`Parameters` are added to as
+                attributes.
+            nodetree_dict (dict): A (sub-)dictionary containing the
+                next :class:`Nodes` and/or :class:`Parameters` as
+                dicts.
 
         """
         for key, value in nodetree_dict.items():
@@ -459,8 +478,8 @@ class Node:
 class NodeList(list):
     """Implements a list of :class:`Nodes`.
 
-    Simply inherits from :class:`List` and overrides the `__repr__()` method to
-    make it look nice in the console or in a notebook.
+    Simply inherits from :class:`List` and overrides the `__repr__()`
+    method to make it look nice in the console or in a notebook.
 
         >>> hdawg.nodetree.sigouts
         Iterable node with 8 items:
@@ -490,19 +509,21 @@ class NodeList(list):
 class NodeTree(Node):
     """Recreates the device's nodetree.
 
-    Implements a :class:`NodeTree` data structure used to access the settings
-    (:class:`Parameter`) of any Zurich Instruments device. A :class:`NodeTree`
-    is created for every instrument when it is connected to the data server. In
-    this way the available settings always directly correspond to the
-    :class:`Nodes` that are available on the device.
+    Implements a :class:`NodeTree` data structure used to access the
+    settings (:class:`Parameter`) of any Zurich Instruments device.
+    A :class:`NodeTree` is created for every instrument when it is
+    connected to the data server. In this way the available settings
+    always directly correspond to the :class:`Nodes` that are available
+    on the device.
 
     Inherits from the :class:`Node` class. On initialization the
-    :class:`NodeTree` retireves a nested dictionary from the device representing
-    its nodetree heirarchy and then recursively adds :class:`Nodes` and
-    :class:`Parameters` as attributes to the :class:`Node`.
+    :class:`NodeTree` retireves a nested dictionary from the device
+    representing its nodetree heirarchy and then recursively adds
+    :class:`Nodes` and :class:`Parameters` as attributes to the
+    :class:`Node`.
 
-    An underscore will be appended to nodes that are identical to reserved keywords
-    in Python (e.g., `in` -> `in_`).
+    An underscore will be appended to nodes that are identical to
+    reserved keywords in Python (e.g., `in` -> `in_`).
 
         >>> hdawg.nodetree
         <zhinst.toolkit.tools.nodetree.NodeTree object at 0x0000021E467D3BA8>
@@ -521,17 +542,16 @@ class NodeTree(Node):
         parameters:
         - clockbase
 
-
     Arguments:
-        device (:class:`BaseInstrument`): A reference to the instrument that
-            the :class:`NodeTree` belongs to. Used for `getting` and `setting`
-            of each :class:`Parameter`.
+        device (:class:`BaseInstrument`): A reference to the instrument
+            that the :class:`NodeTree` belongs to. Used for `getting`
+            and `setting` of each :class:`Parameter`.
 
     Attributes:
         device (:class:`BaseInstrument`): The associated device.
         nodetree_dict (dict): A nested dictionary created from the dict
-            returned by `daq.listNodesJSON(...)` of the :mod:`zhinst.ziPython`
-            Python API.
+            returned by `daq.listNodesJSON(...)` of the
+            :mod:`zhinst.ziPython` Python API.
 
     """
 
@@ -543,11 +563,12 @@ class NodeTree(Node):
     def _get_nodetree_dict(self) -> Dict:
         """Gets the :class:`NodeTree` as a nested dictionary.
 
-        Retrieves the :class:`NodeTree` from the device as a flat dictionary and
-        converts it to a nested dictionary using `dictify()`. For every device
-        node returned from the instrument this method splits the node string
-        into its parts and sorts the value (dict with 'Node', 'Description',
-        'Unit', etc.) into a nested dict that recreates the hierarchy of the
+        Retrieves the :class:`NodeTree` from the device as a flat
+        dictionary and converts it to a nested dictionary using
+        `dictify()`. For every device node returned from the instrument
+        this method splits the node string into its parts and sorts the
+        value (dict with 'Node', 'Description', 'Unit', etc.) into a
+        nested dict that recreates the hierarchy of the
         :class:`NodeTree`.
 
         """
@@ -561,17 +582,19 @@ class NodeTree(Node):
 
 
 def dictify(data, keys: List, val: Dict) -> Dict:
-    """Turns a flat :class:`NodeTree` dictionary into a nested dictionary.
+    """Turns a flat :class:`NodeTree` dictionary into a nested
+    dictionary.
 
-    Helper function to generate nested dictionary from list of keys and value.
-    Calls itself recursively.
+    Helper function to generate nested dictionary from list of keys and
+    value. Calls itself recursively.
 
-    An underscore will be appended to keys that are identical to reserved keywords
-    in Python (e.g., `in` -> `in_`).
+    An underscore will be appended to keys that are identical to
+    reserved keywords in Python (e.g., `in` -> `in_`).
 
     Arguments:
         data (dict): A dictionary to add value to with keys.
-        keys (list): A list of keys to traverse along tree and place value.
+        keys (list): A list of keys to traverse along tree and place
+            value.
         val (dict): A value for innermost layer of nested dict.
 
     """

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -136,7 +136,6 @@ def test_set_get(v):
         p(1)
 
 
-
 def test_set_get_readonly():
     dev = Device()
     parent = Parent(dev)


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) Remove unused import `numpy`.**
##### **2) Correct the type hint error of `set_parser`:**
`set_parser` can be either a `Callable` or `list` of `Callable`s. Change
the type hint to reflect this.
##### **3) Simplify the if clause in `_flatten_mapping_values`.**
##### **4) Change `_reformat_options_dict` to `staticmethod`:**
##### **5) Fix typo in variable name in `_construct_auto_mapping`:**
Name of the local variable `value_splitted` changed to `value_split`
##### **6) Docstring for `value` argument is added to `assert_value`.**
##### **7) Docstring for `parent` argument is added to `Node` class.**
##### **8) Add missing docstring to beginning of the file.**
##### **9) Line length of the docstrings and comments limited to 72.**