### PR TITLE
Update integration weight generation in `UHFQA`

### DIFF
--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -307,5 +307,7 @@ def test_demod_weights(length, freq, phase):
     else:
         clk_rate = 1.8e9
         x = np.arange(0, length)
-        y = np.sin(2 * np.pi * freq * x / clk_rate + np.deg2rad(phase))
+        y_real = np.cos(2 * np.pi * freq * x / clk_rate + np.deg2rad(phase))
+        y_imag = np.sin(2 * np.pi * freq * x / clk_rate + np.deg2rad(phase))
+        y = y_real + 1j * y_imag
         assert max(abs(y - ch._demod_weights(length, 1.0, freq, phase))) < 1e-3


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) `_demod_weights` updated:**
This method now generates both the real and imaginary part of the
integration weights. The real part corresponds to cosine and the
imaginary part corresponds to sine. Previously, the real part was sine
and the imaginary part was cosine. This method is now a `staticmethod`.
##### **2) `_set_int_weights` updated:**
The integration weights vector is obtained as a complex vector from
`_demod_weights`. Then it is seperated into real and imaginary parts
inside `_set_int_weights`. To send the integration weights to the
instrument `set_vector` is used instead of `set.`