### PR TITLE
Add new features to `SHFQA` driver

### DIFF
--- a/src/zhinst/toolkit/control/drivers/base/shf_generator.py
+++ b/src/zhinst/toolkit/control/drivers/base/shf_generator.py
@@ -8,8 +8,13 @@ import time
 from typing import List, Union
 import re
 
-from zhinst.toolkit.helpers import SequenceProgram, SHFWaveform, SequenceType
-from zhinst.toolkit.interface import DeviceTypes, LoggerModule
+from zhinst.toolkit.helpers import (
+    SequenceProgram,
+    SHFWaveform,
+    SequenceType,
+    TriggerMode,
+)
+from zhinst.toolkit.interface import LoggerModule
 from .shf_qachannel import SHFQAChannel
 
 _logger = LoggerModule(__name__)
@@ -320,13 +325,38 @@ class SHFGenerator:
         self._program.set_params(**kwargs)
         self._apply_sequence_settings(**kwargs)
 
-    def _apply_sequence_settings(self, **kwargs):
-        pass
+    def _apply_sequence_settings(self, **kwargs) -> None:
+        if "sequence_type" in kwargs.keys():
+            if kwargs["sequence_type"] == "None":
+                # If sequence type is given as string `None`, return
+                # enumeration for `None` from the SequenceType class
+                t = SequenceType(None)
+            else:
+                t = SequenceType(kwargs["sequence_type"])
+            if t not in self._device.allowed_sequences:
+                _logger.error(
+                    f"Sequence type {t} must be one of "
+                    f"{[s.value for s in self._device.allowed_sequences]}!",
+                    _logger.ExceptionTypes.ToolkitError,
+                )
+        if "trigger_mode" in kwargs.keys():
+            if kwargs["trigger_mode"] == "None":
+                # If trigger mode is given as string `None`, return
+                # enumeration for `None` from the TriggerMode class
+                t = TriggerMode(None)
+            else:
+                t = TriggerMode(kwargs["trigger_mode"])
+            if t not in self._device.allowed_trigger_modes:
+                _logger.error(
+                    f"Trigger mode {t} must be one of "
+                    f"{[s.value for s in self._device.allowed_trigger_modes]}!",
+                    _logger.ExceptionTypes.ToolkitError,
+                )
 
     def _seqc_error(self, statusstring):
         """Extract the relevant lines from seqc program in case of error.
 
-        Ihis method extracts the line number from the compiler status
+        This method extracts the line number from the compiler status
         and then finds the relevant lines in the seqc program to guide
         the user. It works both for errors and warnings.
         """

--- a/src/zhinst/toolkit/control/drivers/base/shf_sweeper.py
+++ b/src/zhinst/toolkit/control/drivers/base/shf_sweeper.py
@@ -123,7 +123,7 @@ class SHFSweeper:
         self._update_averaging_settings()
         self._module.run()
 
-    def get_result(self):
+    def read(self):
         """Get the measurement data of the last sweep.
 
         This method eventually wraps around the `get_result` method of
@@ -153,7 +153,7 @@ class SHFSweeper:
 
     def _update_trigger_settings(self):
         trig_config = self._trig_config(
-            source=self._trigger_source,
+            source=self.trigger_source(),
             level=self._trigger_level,
             imp50=self._trigger_imp50,
         )

--- a/tests/test_shfqa.py
+++ b/tests/test_shfqa.py
@@ -36,6 +36,8 @@ def test_init_shfqa():
     ]
     assert qa.allowed_trigger_modes == [
         TriggerMode.NONE,
+        TriggerMode.RECEIVE_TRIGGER,
+        TriggerMode.ZSYNC_TRIGGER,
     ]
     with pytest.raises(shfqa_logger.ToolkitConnectionError):
         qa._init_qachannels()


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) Add new parameter `sw_trigger`.**
##### **2) Add new modes to allowed trigger modes:**
* TriggerMode.RECEIVE_TRIGGER
* TriggerMode.ZSYNC_TRIGGER
At the moments, there are no particular settings applied in these
modes. However, they are still added since the Labber drivers of SHFQA
arm the Generator of SHFQA only if one of these trigger modes are
selected.
##### **3) `set_trigger_loopback` updated:**
The test source node is now set synchronously, similar to the API
examples in the repository
##### **4) New method `clear_trigger_loopback` added:**
This method stops the generation of internal trigger loopback pulses.
##### **5) `playback_delay` parameter added to `Generator`:**
##### **6) `Generator` parameter node paths updated:**
The `sequencer` word is removed from the node addresses in SHFQA. This
change is now reflected in zhinst-toolkit as well.
##### **7) `_apply_sequence_settings` moved the base `Generator`:**
Similar to HDAWG and UHFQA, this function is now called from the base
`Generator`. Device specific settings can still be added if desired.
##### **8) New parameters and methods added to `Sweeper`:**
* `oscillator_freq` and `integration_delay` parameters are added.
* `_trigger_source` attribute and `trigger_source` method are removed
and a new parameter with the name `trigger_source` is added.
* `output_freq` method sums the center frequency and offset frequency,
and it returns the output frequency.
* `get_result` method is renamed to `read` to make it consistent with
`Scope`