### PR TITLE
Fix issue with "None" trigger mode and sequence type

### DIFF
--- a/src/zhinst/toolkit/control/drivers/hdawg.py
+++ b/src/zhinst/toolkit/control/drivers/hdawg.py
@@ -483,7 +483,7 @@ class AWG(AWGCore):
 
     def _apply_sequence_settings(self, **kwargs) -> None:
         super()._apply_sequence_settings(**kwargs)
-        if "trigger_mode" in kwargs.keys():
+        if "trigger_mode" in kwargs.keys() and kwargs["trigger_mode"] != "None":
             t = TriggerMode(kwargs["trigger_mode"])
             # apply settings depending on trigger mode
             if t in [TriggerMode.EXTERNAL_TRIGGER, TriggerMode.RECEIVE_TRIGGER]:

--- a/src/zhinst/toolkit/control/drivers/uhfqa.py
+++ b/src/zhinst/toolkit/control/drivers/uhfqa.py
@@ -597,7 +597,7 @@ class AWG(AWGCore):
 
     def _apply_sequence_settings(self, **kwargs) -> None:
         super()._apply_sequence_settings(**kwargs)
-        if "sequence_type" in kwargs.keys():
+        if "sequence_type" in kwargs.keys() and kwargs["sequence_type"] != "None":
             t = SequenceType(kwargs["sequence_type"])
             # apply settings depending on the sequence type
             if t == SequenceType.CW_SPEC:
@@ -608,7 +608,7 @@ class AWG(AWGCore):
                 self._apply_readout_settings()
             else:
                 self._apply_base_settings()
-        if "trigger_mode" in kwargs.keys():
+        if "trigger_mode" in kwargs.keys() and kwargs["trigger_mode"] != "None":
             t = TriggerMode(kwargs["trigger_mode"])
             # apply settings depending on trigger mode
             if t in [TriggerMode.EXTERNAL_TRIGGER, TriggerMode.RECEIVE_TRIGGER]:


### PR DESCRIPTION
Settings depending on trigger mode or sequence type of HDAWG and
UHFQA should not be applied if these are selected as "None".