### PR TITLE
Add warning to DAQ and Scope module that they not support the `sync` attribute

### DIFF
--- a/examples/example5_SweeperModule.ipynb
+++ b/examples/example5_SweeperModule.ipynb
@@ -157,7 +157,7 @@
     "mfli.sweeper.start(1e3)\n",
     "mfli.sweeper.stop(10e3)\n",
     "mfli.sweeper.samplecount(100)\n",
-    "mfli.sweeper.sweep_parameter(\"frequency\")\n",
+    "mfli.sweeper.sweep_parameter(\"frequency0\")\n",
     "\n",
     "# add a singal source\n",
     "demod = mfli.sweeper.signals_add(\"demod0\")"

--- a/src/zhinst/toolkit/control/drivers/base/daq.py
+++ b/src/zhinst/toolkit/control/drivers/base/daq.py
@@ -167,7 +167,11 @@ class DAQModule:
             setattr(self, name, Parameter(self, v, device=self, mapping=mapping))
         self._init_settings()
 
-    def _set(self, *args):
+    def _set(self, *args, **kwargs):
+        if kwargs.get("sync", False):
+            _logger.warning(
+                "The daq module does not support the `sync` flag."
+            )
         if self._module is None:
             _logger.error(
                 "This DAQ is not connected to a dataAcquisitionModule!",

--- a/src/zhinst/toolkit/control/drivers/base/sweeper.py
+++ b/src/zhinst/toolkit/control/drivers/base/sweeper.py
@@ -173,7 +173,11 @@ class SweeperModule:
             setattr(self, name, Parameter(self, v, device=self, mapping=mapping))
         self._init_settings()
 
-    def _set(self, *args):
+    def _set(self, *args, **kwargs):
+        if kwargs.get("sync", False):
+            _logger.warning(
+                "The sweeper module does not support the `sync` flag."
+            )
         if self._module is None:
             _logger.error(
                 "This DAQ is not connected to a dataAcquisitionModule!",


### PR DESCRIPTION
The last release (0.2.0) added they sync attribute to the set functions. The DAQ and scope module do not support the value. For compatibility reasons they argument should not cause an exception but rather issue a warning in case the `sync` attribute is set to true. 

closes #86 