### PR TITLE
Make nodetree generation case insensitive

### DIFF
--- a/src/zhinst/toolkit/control/node_tree.py
+++ b/src/zhinst/toolkit/control/node_tree.py
@@ -582,10 +582,14 @@ class NodeTree(Node):
         :class:`NodeTree`.
 
         """
+        # remove device id form key (case insensitive).
+        device_id_regex = re.compile(
+            re.escape(f"/{self._device.serial.upper()}/"), re.IGNORECASE
+        )
         tree = self._device._get_nodetree(f"{self._device.serial}/*")
         nodetree = {}
         for key, value in tree.items():
-            key = key.replace(f"/{self._device.serial.upper()}/", "")
+            key = device_id_regex.sub("", key)
             hierarchy = key.split("/")
             dictify(nodetree, hierarchy, value)
         return nodetree


### PR DESCRIPTION
With future LabOne Versions we have a strict lower case policy when it comes to node paths. 
This change enables the node tree generation to be case insensitive to support both new and old LabOne versions.