### PR TITLE
Fix aliasing problem in scope read function

### DIFF
--- a/src/zhinst/toolkit/control/drivers/base/scope.py
+++ b/src/zhinst/toolkit/control/drivers/base/scope.py
@@ -222,11 +222,11 @@ class Scope:
         self.stop()
         # read and post-process the recorded data
         result = []
-        recorded_data = [[], []]
         # generate the wave data
         channel_states = self.channels()
         data = self._module.read()
         for j in range(num_records):
+            recorded_data = [[], []]
             wave_data = data[wave_nodepath][j][0]["wave"]
             dt = data[wave_nodepath][j][0]["dt"]
             for i in range(2):


### PR DESCRIPTION
In the original code, when no channels are specified for the scope's `read` method, the entire `recorded_data` list is added to the `result` array. But in each iteration of the for loop over the records, the contents of `recorded_data` is modified to reflect the current record being handled. As a result, *all* entries in `result` reflect the contents of the final record. By moving the assignment to `recorded_data` into the for-loop this problem is solved, because now a fresh copy of `recorded_data` is created for each iteration.