### PR TITLE
Improve missing AWG-option handling when calling the awg module

### DIFF
--- a/src/zhinst/toolkit/driver/devices/uhfli.py
+++ b/src/zhinst/toolkit/driver/devices/uhfli.py
@@ -6,7 +6,8 @@ import typing as t
 from zhinst.toolkit.driver.devices.base import BaseInstrument
 from zhinst.toolkit.driver.nodes.awg import AWG
 from zhinst.toolkit.nodetree.helper import lazy_property
-from zhinst.toolkit.nodetree.node import NodeList
+from zhinst.toolkit.nodetree.node import NodeList, Node
+
 
 logger = logging.getLogger(__name__)
 
@@ -15,10 +16,14 @@ class UHFLI(BaseInstrument):
     """High-level driver for the Zurich Instruments UHFLI."""
 
     @lazy_property
-    def awgs(self) -> t.Sequence[AWG]:
-        """A Sequence of AWG Cores"""
+    def awgs(self) -> t.Union[t.Sequence[AWG], Node]:
+        """A Sequence of AWG Cores.
+
+        Device options requirement(s): AWG
+        """
         if "AWG" not in self.features.options():
-            logger.error("The AWG option is not installed.")
+            logger.error("Missing option: AWG")
+            return Node(self._root, self._tree + ("awgs",),)
         return NodeList(
             [
                 AWG(

--- a/src/zhinst/toolkit/driver/devices/uhfqa.py
+++ b/src/zhinst/toolkit/driver/devices/uhfqa.py
@@ -1,17 +1,16 @@
 """UHFQA Instrument Driver."""
 
 import typing as t
-
 import numpy as np
 
-from zhinst.toolkit.driver.devices.base import BaseInstrument
-from zhinst.toolkit.driver.nodes.awg import AWG
+from zhinst.toolkit.driver.devices import UHFLI
 from zhinst.toolkit.nodetree import Node, NodeTree
 from zhinst.toolkit.nodetree.helper import (
     create_or_append_set_transaction,
     lazy_property,
 )
 from zhinst.toolkit.nodetree.node import NodeList
+
 
 Numpy2DArray = t.TypeVar("Numpy2DArray")
 
@@ -68,7 +67,7 @@ class QAS(Node):
                     self.crosstalk.rows[r].cols[c](matrix[r, c])
 
 
-class UHFQA(BaseInstrument):
+class UHFQA(UHFLI):
     """High-level driver for the Zurich Instruments UHFQA."""
 
     def enable_qccs_mode(self) -> None:
@@ -101,24 +100,4 @@ class UHFQA(BaseInstrument):
             ],
             self._root,
             self._tree + ("qas",),
-        )
-
-    @lazy_property
-    def awgs(self) -> t.Sequence[AWG]:
-        """A Sequence of AWG Cores"""
-        return NodeList(
-            [
-                AWG(
-                    self.root,
-                    self._tree + ("awgs", str(i)),
-                    self._session.modules.awg,
-                    self._session.daq_server,
-                    self.serial,
-                    i,
-                    self.device_type,
-                )
-                for i in range(len(self["awgs"]))
-            ],
-            self._root,
-            self._tree + ("awgs",),
         )

--- a/tests/test_uhfli.py
+++ b/tests/test_uhfli.py
@@ -26,6 +26,7 @@ def test_awg(data_dir, mock_connection, uhfli):
     mock_connection.return_value.awgModule.return_value.listNodesJSON.return_value = (
         nodes_json
     )
+    mock_connection.return_value.getString.return_value = 'AWG,FOOBAR'
     assert len(uhfli.awgs) == 1
     assert isinstance(uhfli.awgs[0], AWG)
     # Wildcards nodes will be converted into normal Nodes
@@ -34,3 +35,15 @@ def test_awg(data_dir, mock_connection, uhfli):
 
     # test command table
     assert not uhfli.awgs[0].commandtable
+
+
+def test_awg_option_not_found(data_dir, mock_connection, uhfli):
+    json_path = data_dir / "nodedoc_awg_test.json"
+    with json_path.open("r", encoding="UTF-8") as file:
+        nodes_json = file.read()
+    mock_connection.return_value.awgModule.return_value.listNodesJSON.return_value = (
+        nodes_json
+    )
+    mock_connection.return_value.getString.return_value = 'FOOBAR'
+    assert len(uhfli.awgs) == 1
+    assert isinstance(uhfli.awgs[0], Node)

--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 
-from zhinst.toolkit.driver.devices.uhfqa import AWG, QAS, UHFQA
+from zhinst.toolkit.driver.devices.uhfqa import QAS, UHFQA
+from zhinst.toolkit.driver.nodes.awg import AWG
 from zhinst.toolkit.nodetree import Node
 
 
@@ -77,6 +78,7 @@ def test_qas_crosstalk_matrix(uhfqa, mock_connection):
     with pytest.raises(ValueError):
         uhfqa.qas[0].crosstalk_matrix(matrix2)
 
+
 def test_awg(data_dir, mock_connection, uhfqa):
     json_path = data_dir / "nodedoc_awg_test.json"
     with json_path.open("r", encoding="UTF-8") as file:
@@ -84,6 +86,7 @@ def test_awg(data_dir, mock_connection, uhfqa):
     mock_connection.return_value.awgModule.return_value.listNodesJSON.return_value = (
         nodes_json
     )
+    mock_connection.return_value.getString.return_value = 'AWG,FOOBAR'
     assert len(uhfqa.awgs) == 1
     assert isinstance(uhfqa.awgs[0], AWG)
     # Wildcards nodes will be converted into normal Nodes


### PR DESCRIPTION
Devices without AWG option raised an exception when `awgs` was called. 
This PR gets rid of the exception.

By calling bool on `device.awgs` will return `False` if the AWG option does not exists.

Also as UHFQA extends UHFLI functionality, it is now derived from it.