### PR TITLE
Add missing nodes setting for QCCS mode

### DIFF
--- a/src/zhinst/toolkit/driver/devices/hdawg.py
+++ b/src/zhinst/toolkit/driver/devices/hdawg.py
@@ -34,7 +34,7 @@ class HDAWG(BaseInstrument):
             self.dios[0].mode("qccs")
             # Drive the two most significant bytes of the DIO port
             self.dios[0].drive(0b1100)
-            # Disable DIO triggering on the AWGs.
+            # Disable DIO triggering on the AWGs,
             # since it's not needed for ZSync messages
             self.awgs['*'].dio.strobe.slope('off')
             self.awgs['*'].dio.valid.polarity('none')

--- a/src/zhinst/toolkit/driver/devices/hdawg.py
+++ b/src/zhinst/toolkit/driver/devices/hdawg.py
@@ -27,13 +27,17 @@ class HDAWG(BaseInstrument):
             self.system.clocks.referenceclock.source("zsync")
             # Configure DIO
             # Set interface standard to use on the 32-bit DIO to LVCMOS
-            self.dios[0].interface(0),
+            self.dios[0].interface(0)
             # Set DIO output values to ZSync input values.
             # Forward the ZSync input values to the AWG sequencer.
             # Forward the DIO input values to the ZSync output.
-            self.dios[0].mode("qccs"),
+            self.dios[0].mode("qccs")
             # Drive the two most significant bytes of the DIO port
-            self.dios[0].drive(0b1100),
+            self.dios[0].drive(0b1100)
+            # Disable DIO triggering on the AWGs.
+            # since it's not needed for ZSync messages
+            self.awgs['*'].dio.strobe.slope('off')
+            self.awgs['*'].dio.valid.polarity('none')
 
     @lazy_property
     def awgs(self) -> t.Sequence[AWG]:

--- a/src/zhinst/toolkit/driver/devices/uhfqa.py
+++ b/src/zhinst/toolkit/driver/devices/uhfqa.py
@@ -131,6 +131,10 @@ class UHFQA(UHFLI):
             self.dios[0].mode("qa_result_qccs")
             # Drive the two least significant bytes of the DIO port
             self.dios[0].drive(0b0011)
+            # Set correct DIO triggering in the AWG sequencer
+            self.awgs[0].dio.strobe.slope('off')
+            self.awgs[0].dio.valid.index(16)
+            self.awgs[0].dio.valid.polarity('high')
 
     @lazy_property
     def qas(self) -> t.Sequence[QAS]:

--- a/tests/test_hdawg.py
+++ b/tests/test_hdawg.py
@@ -26,6 +26,7 @@ def hdawg(data_dir, mock_connection, session):
 def test_repr(hdawg):
     assert repr(hdawg) == "HDAWG(HDAWG4,DEV1234)"
 
+
 def test_enable_qccs_mode(mock_connection, hdawg):
     hdawg.enable_qccs_mode()
     mock_connection.return_value.set.assert_called_with(
@@ -34,6 +35,14 @@ def test_enable_qccs_mode(mock_connection, hdawg):
             ("/dev1234/dios/0/interface", 0),
             ("/dev1234/dios/0/mode", "qccs"),
             ("/dev1234/dios/0/drive", 12),
+            ("/dev1234/awgs/0/dio/strobe/slope", "off"),
+            ("/dev1234/awgs/1/dio/strobe/slope", "off"),
+            ("/dev1234/awgs/2/dio/strobe/slope", "off"),
+            ("/dev1234/awgs/3/dio/strobe/slope", "off"),
+            ("/dev1234/awgs/0/dio/valid/polarity", "none"),
+            ("/dev1234/awgs/1/dio/valid/polarity", "none"),
+            ("/dev1234/awgs/2/dio/valid/polarity", "none"),
+            ("/dev1234/awgs/3/dio/valid/polarity", "none"),
         ]
     )
     mock_connection.reset_mock()
@@ -45,8 +54,17 @@ def test_enable_qccs_mode(mock_connection, hdawg):
             ("/dev1234/dios/0/interface", 0),
             ("/dev1234/dios/0/mode", "qccs"),
             ("/dev1234/dios/0/drive", 12),
+            ("/dev1234/awgs/0/dio/strobe/slope", "off"),
+            ("/dev1234/awgs/1/dio/strobe/slope", "off"),
+            ("/dev1234/awgs/2/dio/strobe/slope", "off"),
+            ("/dev1234/awgs/3/dio/strobe/slope", "off"),
+            ("/dev1234/awgs/0/dio/valid/polarity", "none"),
+            ("/dev1234/awgs/1/dio/valid/polarity", "none"),
+            ("/dev1234/awgs/2/dio/valid/polarity", "none"),
+            ("/dev1234/awgs/3/dio/valid/polarity", "none"),
         ]
     )
+
 
 def test_awg(data_dir, mock_connection, hdawg):
     json_path = data_dir / "nodedoc_awg_test.json"

--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -38,6 +38,9 @@ def test_enable_qccs_mode(mock_connection, uhfqa):
             ("/dev1234/dios/0/extclk", "internal"),
             ("/dev1234/dios/0/mode", "qa_result_qccs"),
             ("/dev1234/dios/0/drive", 3),
+            ("/dev1234/awgs/0/dio/strobe/slope", "off"),
+            ("/dev1234/awgs/0/dio/valid/index", 16),
+            ("/dev1234/awgs/0/dio/valid/polarity", "high"),
         ]
     )
     mock_connection.reset_mock()
@@ -49,6 +52,9 @@ def test_enable_qccs_mode(mock_connection, uhfqa):
             ("/dev1234/dios/0/extclk", "internal"),
             ("/dev1234/dios/0/mode", "qa_result_qccs"),
             ("/dev1234/dios/0/drive", 3),
+            ("/dev1234/awgs/0/dio/strobe/slope", "off"),
+            ("/dev1234/awgs/0/dio/valid/index", 16),
+            ("/dev1234/awgs/0/dio/valid/polarity", "high"),
         ]
     )
 
@@ -81,20 +87,16 @@ def test_adjusted_delay(uhfqa, mock_connection):
     # set value
     bypass_deskew = 0
     assert uhfqa.qas[0].adjusted_delay(400) == 400
-    mock_connection.return_value.set.assert_called_with(
-        f"/dev1234/qas/0/delay", 600
-    )
+    mock_connection.return_value.set.assert_called_with(f"/dev1234/qas/0/delay", 600)
     bypass_deskew = 1
     assert uhfqa.qas[0].adjusted_delay(400) == 400
-    mock_connection.return_value.set.assert_called_with(
-        f"/dev1234/qas/0/delay", 584
-    )
+    mock_connection.return_value.set.assert_called_with(f"/dev1234/qas/0/delay", 584)
 
     with pytest.raises(ValueError):
         uhfqa.qas[0].adjusted_delay(-185)
 
     with pytest.raises(ValueError):
-        uhfqa.qas[0].adjusted_delay(1025-185)
+        uhfqa.qas[0].adjusted_delay(1025 - 185)
 
 
 def test_qas_crosstalk_matrix(uhfqa, mock_connection):
@@ -133,7 +135,7 @@ def test_awg(data_dir, mock_connection, uhfqa):
     mock_connection.return_value.awgModule.return_value.listNodesJSON.return_value = (
         nodes_json
     )
-    mock_connection.return_value.getString.return_value = 'AWG,FOOBAR'
+    mock_connection.return_value.getString.return_value = "AWG,FOOBAR"
     assert len(uhfqa.awgs) == 1
     assert isinstance(uhfqa.awgs[0], AWG)
     # Wildcards nodes will be converted into normal Nodes


### PR DESCRIPTION
To work properly in QCCS mode, the DIO triggering should be set correctly to some fixed values.
Add such settings in the enable_qccs_mode() function for the HDAWG and UHFQA