### PR TITLE
Add write_integration_weight function to UHFQA integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # zhinst-toolkit Changelog
 
+## Version 0.3.2
+
+* Added a helper function ``uhfqa.qas[n].integration.write_integration_weights`` for 
+  QAS integration weights configuration
+
 ## Version 0.3.1
 * Add missing nodes setting for QCCS mode #108
 * pqsc.check_zsync_connection blocks even if nothing is connected

--- a/src/zhinst/toolkit/driver/devices/uhfqa.py
+++ b/src/zhinst/toolkit/driver/devices/uhfqa.py
@@ -48,10 +48,17 @@ class Integration(Node):
 
         note:
 
+            Does not raise an error when sample limit is exceeded, but applies only
+            the maximum number of samples. Please refer to LabOne node documentation
+            for the number of maximum integration weight samples.
+
+        note:
+
             This function calls both `/qas/n/integration/weights/n/real` and
             `/qas/n/integration/weights/n/imag` nodes.
 
-            If only real or imaginary part is defined, the other one is zeroed.
+            If only real or imaginary part is defined, the number of defined samples
+            from the other one is zeroed.
         """
         waveform_dict = {}
         if isinstance(weights, Waveforms):

--- a/src/zhinst/toolkit/driver/devices/uhfqa.py
+++ b/src/zhinst/toolkit/driver/devices/uhfqa.py
@@ -36,7 +36,7 @@ class Integration(Node):
         self,
         weights: t.Union[Waveforms, dict]
     ) -> None:
-        """Configures the weighted integration functions.
+        """Upload complex integration weights.
 
         The weight functions are applied to the real and imaginary part of
         the input signal. In the hardware the weights are implemented as 17-bit integers.

--- a/src/zhinst/toolkit/driver/devices/uhfqa.py
+++ b/src/zhinst/toolkit/driver/devices/uhfqa.py
@@ -21,6 +21,8 @@ class Integration(Node):
     Args:
         root: Underlying node tree.
         tree: tree (node path as tuple) of the coresponding node.
+
+    .. versionadded:: 0.3.2
     """
 
     def __init__(
@@ -34,15 +36,22 @@ class Integration(Node):
         self,
         weights: t.Union[Waveforms, dict]
     ) -> None:
-        """Configures the weighted integration.
+        """Configures the weighted integration functions.
 
-        The weight functions to be applied on the real and imaginary part of 
+        The weight functions are applied to the real and imaginary part of
         the input signal. In the hardware the weights are implemented as 17-bit integers.
 
         Args:
-            weights: Dictionary containing the complex weight vectors, where
-                keys correspond to the indices of the integration units to be
+            weights: Dictionary containing the weight functions, where
+                keys correspond to the indices of the integration weights to be
                 configured.
+
+        note:
+
+            This function calls both `/qas/n/integration/weights/n/real` and
+            `/qas/n/integration/weights/n/imag` nodes.
+
+            If only real or imaginary part is defined, the other one is zeroed.
         """
         waveform_dict = {}
         if isinstance(weights, Waveforms):
@@ -150,7 +159,10 @@ class QAS(Node):
 
     @lazy_property
     def integration(self) -> Integration:
-        """Integration"""
+        """Integration
+        
+        .. versionadded:: 0.3.2
+        """
         return Integration(self.root, self._tree + ("integration",))
 
 


### PR DESCRIPTION
Add write_integration_weight function to UHFQA integration

Also add Integration part of the UHFQA

- This PR should improve and simplify the uploading of integration weights.