### PR TITLE
Improve docs documentation and requirements

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -44,6 +44,12 @@ Building the documentation
 
 Zhinst-toolkit uses `Sphinx <https://pypi.org/project/Sphinx/>`_ to build the package documentation.
 
+- Install the package in editable mode
+
+    .. code-block:: sh
+
+        $ pip install -e .
+
 Change to docs directory
 
     .. code-block:: sh

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ m2r2
 pydata_sphinx_theme
 sphinx_autodoc_typehints
 jupytext
+ipython


### PR DESCRIPTION
IPython was missing from documentation requirements.