### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,15 @@
+# Package
 zhinst
 zhinst-deviceutils
 numpy
-pytest
-hypothesis
 jsonschema
 jsonref
+# Tests
+pytest
+
+# Lint
+black==22.3.0
+isort==5.10.1
+
+# Misc
 pre-commit


### PR DESCRIPTION
- Remove `hypothesis` requirements: Not used
- Split requirements.txt into sections for easier reading.
    - requirements can be split into `tests` and `lint` later as `docs` is already separated

- Add hardcoded versions of `black` and `isort` for requirements (keep same versioning as in pre-commit-config.yaml)

