### PR TITLE
Add mypy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
     branches: ["main"]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: [black, lint]
+        tool: [black, lint, typing]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pytest
 # Lint
 black==22.3.0
 isort==5.10.1
+mypy
 
 # Misc
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ pytest
 # Lint
 black==22.3.0
 isort==5.10.1
-mypy
 
 # Misc
 pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,3 +66,27 @@ exclude =
 per-file-ignores =
     # disable unused-imports errors on __init__.py
     __init__.py: F401
+
+[mypy]
+ignore_missing_imports = True
+exclude = (?x)(
+    src/zhinst/toolkit/nodetree/helper\.py$
+    | src/zhinst/toolkit/session\.py$
+    | src/zhinst/toolkit/waveform\.py$
+    | src/zhinst/toolkit/command_table\.py$
+    | src/zhinst/toolkit/nodetree/nodetree\.py$
+    | src/zhinst/toolkit/nodetree/node\.py$
+    | src/zhinst/toolkit/nodetree/connection_dict\.py$
+    | src/zhinst/toolkit/driver/modules/base_module\.py$
+    | src/zhinst/toolkit/driver/modules/shfqa_sweeper\.py$
+    | src/zhinst/toolkit/driver/modules/daq_module\.py$
+    | src/zhinst/toolkit/driver/modules/sweeper_module\.py$
+    | src/zhinst/toolkit/driver/devices/uhfqa\.py$
+    | src/zhinst/toolkit/driver/devices/hdawg\.py$
+    | src/zhinst/toolkit/driver/devices/base\.py$
+    | src/zhinst/toolkit/driver/nodes/readout\.py$
+    | src/zhinst/toolkit/driver/nodes/spectroscopy\.py$
+    | src/zhinst/toolkit/driver/nodes/command_table_node\.py$
+    | src/zhinst/toolkit/driver/nodes/generator\.py$
+    | src/zhinst/toolkit/driver/nodes/awg\.py$
+  )


### PR DESCRIPTION
Add mypy to check code type hints.

The following files are not passing the checks at the time of this PR:

Created an issue for fixing the files and crossing them off once fixed: : https://github.com/zhinst/zhinst-toolkit/issues/136

- [ ] src/zhinst/toolkit/nodetree/helper.py
- [ ] src/zhinst/toolkit/session.py
- [ ] src/zhinst/toolkit/waveform.py
- [ ] src/zhinst/toolkit/command_table.py
- [ ] src/zhinst/toolkit/nodetree/nodetree.py
- [ ] src/zhinst/toolkit/nodetree/node.py
- [ ] src/zhinst/toolkit/nodetree/connection_dict.py
- [ ] src/zhinst/toolkit/driver/modules/base_module.py
- [ ] src/zhinst/toolkit/driver/modules/shfqa_sweeper.py
- [ ] src/zhinst/toolkit/driver/modules/daq_module.py
- [ ] src/zhinst/toolkit/driver/modules/sweeper_module.py
- [ ] src/zhinst/toolkit/driver/devices/uhfqa.py
- [ ] src/zhinst/toolkit/driver/devices/hdawg.py
- [ ] src/zhinst/toolkit/driver/devices/base.py
- [ ] src/zhinst/toolkit/driver/nodes/readout.py
- [ ] src/zhinst/toolkit/driver/nodes/spectroscopy.py
- [ ] src/zhinst/toolkit/driver/nodes/command_table_node.py
- [ ] src/zhinst/toolkit/driver/nodes/generator.py
- [ ] src/zhinst/toolkit/driver/nodes/awg.py