### PR TITLE
Add publish to PyPi workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,15 +53,6 @@ jobs:
         name: source-dist
         path: dist
 
-    - name: Publish to Test PyPI
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: pypa/gh-action-pypi-publish@v1.4.2
-      with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        packages_dir: dist
-
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags/')
       uses: pypa/gh-action-pypi-publish@v1.4.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,71 @@
+name: Publish to PyPi
+on:
+  push:
+    tags: 
+    - "v*.*.*"
+
+jobs:
+  build-distribution:
+    name: "Build distribution"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout tag/branch"
+        uses: "actions/checkout@v3"
+      - name: "Setup Python"
+        uses: "actions/setup-python@v3"
+        with:
+          python-version: "3.9"
+      - name: "Install build dependencies"
+        run: |
+          set -xe
+          python -VV
+          python -m site
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade -r requirements.txt
+          python -m pip install .
+          pip install build
+
+      - name: "Build wheels & source dist"
+        run: |
+          python -m build --sdist --wheel
+
+      - name: "Test wheels"
+        run: |
+          python -m venv build_env --clear
+          source build_env/bin/activate
+          bash build_tools/test_wheels.sh
+
+      - name: Store artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: source-dist
+          path: dist
+
+  PyPi:
+    needs: ["build-distribution"]
+    name: "Publish to PyPi"
+    runs-on: "ubuntu-latest"
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: source-dist
+        path: dist
+
+    - name: Publish to Test PyPI
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI }}
+        repository_url: https://test.pypi.org/legacy/
+        packages_dir: dist
+
+    # - name: Publish to PyPI
+      #   if: startsWith(github.ref, 'refs/tags/')
+      #   uses: pypa/gh-action-pypi-publish@v1.4.2
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.PYPI }}
+      #     repository_url: https://pypi.org/legacy/
+      #     packages_dir: dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
         uses: "actions/setup-python@v3"
         with:
           python-version: "3.9"
+
       - name: "Install build dependencies"
         run: |
           set -xe
@@ -33,7 +34,7 @@ jobs:
         run: |
           python -m venv build_env --clear
           source build_env/bin/activate
-          bash build_tools/test_wheels.sh
+          bash build_tools/test_wheels.sh ${{ github.ref_name }}
 
       - name: Store artifacts
         uses: actions/upload-artifact@v2
@@ -57,15 +58,15 @@ jobs:
       uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         user: __token__
-        password: ${{ secrets.TEST_PYPI }}
+        password: ${{ secrets.TEST_PYPI_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
         packages_dir: dist
 
-    # - name: Publish to PyPI
-      #   if: startsWith(github.ref, 'refs/tags/')
-      #   uses: pypa/gh-action-pypi-publish@v1.4.2
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.PYPI }}
-      #     repository_url: https://pypi.org/legacy/
-      #     packages_dir: dist
+    - name: Publish to PyPI
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}
+        repository_url: https://pypi.org/legacy/
+        packages_dir: dist

--- a/build_tools/test_wheels.sh
+++ b/build_tools/test_wheels.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+wheelPath=$(find dist -type f -name \*.whl)
+pip install --upgrade --force-reinstall $wheelPath
+python3 -c "import zhinst.toolkit; from zhinst.toolkit import __version__; print(__version__)"

--- a/build_tools/test_wheels.sh
+++ b/build_tools/test_wheels.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 wheelPath=$(find dist -type f -name \*.whl)
 pip install --upgrade --force-reinstall $wheelPath
-python3 -c "import zhinst.toolkit; from zhinst.toolkit import __version__; print(__version__)"
+python3 -c "
+import zhinst.toolkit;
+from zhinst.toolkit import __version__;
+print(__version__);
+version = '$1'[1:] if '$1'.startswith('v') else '$1';
+print(version);
+assert __version__ == version
+"


### PR DESCRIPTION
Add Publish to PyPi workflow on tag `v*.*.*` push

* Both source distribution and wheels are built and stored as artifacts
* Wheel is tested by installing it and testing it is working with imports and correct version check
* First publish is done to test PyPi