### PR TITLE
typing: Make toolkit/waveform.py pass typing checks [#136]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,6 @@ ignore_missing_imports = True
 exclude = (?x)(
     src/zhinst/toolkit/nodetree/helper\.py$
     | src/zhinst/toolkit/session\.py$
-    | src/zhinst/toolkit/waveform\.py$
     | src/zhinst/toolkit/command_table\.py$
     | src/zhinst/toolkit/nodetree/nodetree\.py$
     | src/zhinst/toolkit/nodetree/node\.py$

--- a/src/zhinst/toolkit/waveform.py
+++ b/src/zhinst/toolkit/waveform.py
@@ -7,6 +7,9 @@ import numpy as np
 from zhinst.utils import convert_awg_waveform, parse_awg_waveform
 
 
+Waveform = t.Tuple[np.ndarray, t.Optional[np.ndarray], t.Optional[np.ndarray]]
+
+
 class Waveforms(MutableMapping):
     """Waveform dictionary
 
@@ -49,14 +52,13 @@ class Waveforms(MutableMapping):
       specified they are combined into a single complex waveform, where the
       imaginary part defined by the second wave.
     """
-
     def __init__(self):
         self._waveforms = {}
 
-    def __getitem__(self, slot: int) -> t.Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def __getitem__(self, slot: int) -> Waveform:
         return self._waveforms[slot]
 
-    def __setitem__(self, slot: int, value: t.Tuple[np.ndarray, ...]):
+    def __setitem__(self, slot: int, value: t.Union[np.ndarray, Waveform]):
         if isinstance(value, np.ndarray):
             self._set_waveform(slot, (value, None, None))
         else:
@@ -124,7 +126,7 @@ class Waveforms(MutableMapping):
     def _set_waveform(
         self,
         slot: int,
-        value: t.Tuple[np.ndarray, t.Optional[np.ndarray], t.Optional[np.ndarray]],
+        value: Waveform,
     ) -> None:
         """Assigns a tuple of waves to the slot.
 

--- a/src/zhinst/toolkit/waveform.py
+++ b/src/zhinst/toolkit/waveform.py
@@ -52,6 +52,7 @@ class Waveforms(MutableMapping):
       specified they are combined into a single complex waveform, where the
       imaginary part defined by the second wave.
     """
+
     def __init__(self):
         self._waveforms = {}
 


### PR DESCRIPTION
Issues #136

As numpy.typing `NumpyArray` is not supported for `numpy` versions <1.20, a `numpy.ndarray` typehinting should be sufficient at this time.

Included minor typo fixes