### PR TITLE
Load command table JSON schema from device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # zhinst-toolkit Changelog
 
+## Version 0.3.4
+
+* `Commandtable.load_validation_schema` can also get the command table
+  JSON schema from the device.
+
 ## Version 0.3.2
 * Added a helper function ``uhfqa.qas[n].integration.write_integration_weights`` for
   QAS integration weights configuration

--- a/src/zhinst/toolkit/driver/nodes/command_table_node.py
+++ b/src/zhinst/toolkit/driver/nodes/command_table_node.py
@@ -55,16 +55,18 @@ class CommandTableNode(Node):
         return ct_status == 1
 
     @lru_cache()
-    def load_validation_schema(self) -> dict:
+    def load_validation_schema(self) -> t.Dict[str, t.Any]:
         """Load device command table validation schema.
 
         Returns:
             JSON validation schema for the device command tables.
         """
-        # TODO: Load from device once available.
-        device_type_striped = self._device_type.lower().rstrip(string.digits)
-        with open(_CT_FILES[device_type_striped]) as f:
-            return json.load(f)
+        try:
+            return json.loads(self.schema())
+        except KeyError:
+            device_type_striped = self._device_type.lower().rstrip(string.digits)
+            with open(_CT_FILES[device_type_striped], encoding="utf-8") as file_:
+                return json.load(file_)
 
     def upload_to_device(
         self, ct: t.Union[CommandTable, str, dict], *, validate: bool = True

--- a/tests/data/nodedoc_dev1234_shfsg.json
+++ b/tests/data/nodedoc_dev1234_shfsg.json
@@ -4902,6 +4902,13 @@
         "Type": "Integer (64 bit)",
         "Unit": "None"
     },
+    "/dev1234/sgchannels/0/awg/commandtable/schema": {
+        "Node": "/DEV1234/SGCHANNELS/0/AWG/COMMANDTABLE/SCHEMA",
+        "Description": "JSON schema describing the command table JSON format (read-only).",
+        "Properties": "Read",
+        "Type": "ZIVectorData",
+        "Unit": "None"
+    },
     "/dev1234/sgchannels/0/awg/dio/strobe/index": {
         "Node": "/DEV1234/SGCHANNELS/0/AWG/DIO/STROBE/INDEX",
         "Description": "Select the DIO bit to use as the STROBE signal.",


### PR DESCRIPTION
Description:

Load command table JSON schema from device.

If failed, fallback to loading from /resources

Fixes issue: #

Checklist:

- [x] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
