### PR TITLE
Add sphinx-issues to docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 sphinx
+sphinx-issues
 nbsphinx
 nbsphinx_link
 m2r2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,6 +33,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.napoleon",
     "sphinx.ext.autosectionlabel",
+    "sphinx_issues",
     "nbsphinx",
     "nbsphinx_link",
     "IPython.sphinxext.ipython_console_highlighting",
@@ -46,6 +47,9 @@ autodoc_default_options = {"show-inheritance": True}
 
 autosummary_generate = True
 set_type_checking_flag = False
+
+# Sphinx issues
+issues_github_path = "zhinst/zhinst-toolkit"
 
 # Make sure the target is unique
 autosectionlabel_prefix_document = True


### PR DESCRIPTION
Description:

Add sphinx-issues to docs.

[sphinx-issues](https://pypi.org/project/sphinx-issues/) allows easy linking of GitHub issues and PRs to e.g. CHANGELOG.

Fixes issue: #

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [ ] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
