### PR TITLE
#110: Add raise_for_invalid_node-keyword argument to NodeTree update_nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   JSON schema from the device.
 * ``load_sequencer_program`` now raises an ``ValueError`` 
   if empty ``sequencer_program`` string is given. :issue:`138`
+* Added a new `raise_for_invalid_node` keyword-argument to ``NodeTree.update_nodes``. :issue:`110`
+  
+  Now only a warning (instead of ``KeyError``) is issued when trying to initialize device/module object, which does
+  not have nodes defined in node value parsers.
 
 ## Version 0.3.2
 * Added a helper function ``uhfqa.qas[n].integration.write_integration_weights`` for

--- a/src/zhinst/toolkit/driver/devices/__init__.py
+++ b/src/zhinst/toolkit/driver/devices/__init__.py
@@ -8,6 +8,7 @@ from zhinst.toolkit.driver.devices.shfqa import SHFQA
 from zhinst.toolkit.driver.devices.shfsg import SHFSG
 from zhinst.toolkit.driver.devices.uhfli import UHFLI
 from zhinst.toolkit.driver.devices.uhfqa import UHFQA
+
 from zhinst.toolkit.driver.devices.shfqc import SHFQC  # isort:skip
 
 DeviceType = t.Union[BaseInstrument, HDAWG, PQSC, SHFQA, SHFSG, UHFLI, UHFQA, SHFQC]

--- a/src/zhinst/toolkit/driver/devices/base.py
+++ b/src/zhinst/toolkit/driver/devices/base.py
@@ -70,7 +70,9 @@ class BaseInstrument(Node):
             preloaded_json=preloaded_json,
         )
         # Add predefined parseres (in node_parser) to nodetree nodes
-        nodetree.update_nodes(node_parser.get(self.__class__.__name__, {}))
+        nodetree.update_nodes(
+            node_parser.get(self.__class__.__name__, {}), raise_for_invalid_node=False
+        )
 
         super().__init__(nodetree, tuple())
 

--- a/src/zhinst/toolkit/driver/modules/base_module.py
+++ b/src/zhinst/toolkit/driver/modules/base_module.py
@@ -43,7 +43,8 @@ class BaseModule(Node):
                         "GetParser": self._get_device,
                         "SetParser": self._set_device,
                     }
-                }
+                },
+                raise_for_invalid_node=False,
             )
 
     def __repr__(self):

--- a/src/zhinst/toolkit/driver/modules/daq_module.py
+++ b/src/zhinst/toolkit/driver/modules/daq_module.py
@@ -43,7 +43,8 @@ class DAQModule(BaseModule):
                     "GetParser": self._get_node,
                     "SetParser": self._set_node,
                 }
-            }
+            },
+            raise_for_invalid_node=False,
         )
 
     def _get_node(self, node: str) -> t.Union[Node, str]:

--- a/src/zhinst/toolkit/driver/modules/shfqa_sweeper.py
+++ b/src/zhinst/toolkit/driver/modules/shfqa_sweeper.py
@@ -82,7 +82,8 @@ class SHFQASweeper(Node):
                     "GetParser": Parse.get_true_false,
                     "SetParser": Parse.set_true_false,
                 },
-            }
+            },
+            raise_for_invalid_node=False,
         )
 
     def __repr__(self):

--- a/src/zhinst/toolkit/driver/modules/sweeper_module.py
+++ b/src/zhinst/toolkit/driver/modules/sweeper_module.py
@@ -39,7 +39,8 @@ class SweeperModule(BaseModule):
                     "GetParser": self._get_node,
                     "SetParser": self._set_node,
                 }
-            }
+            },
+            raise_for_invalid_node=False,
         )
 
     def execute(self) -> None:

--- a/tests/test_nodetree.py
+++ b/tests/test_nodetree.py
@@ -608,6 +608,13 @@ def test_update_nodes(connection):
         {"demods/0/rate": {"Unit": "test3"}, "test": {"Node": "test4"}}, add=True
     )
     assert tree.test.node_info.path == "test4"
+    assert tree.test.is_valid() is True
+
+    # Test for not raising any errors
+    tree.update_nodes(
+        {"312/123": {"Unit": "test5"}, "testNOtexists": {"Node": "test5"}}, add=False, raise_for_invalid_node=False
+    )
+    assert tree.testNOtexists.is_valid() is False
 
 
 def test_options(connection):

--- a/tests/test_nodetree.py
+++ b/tests/test_nodetree.py
@@ -612,7 +612,9 @@ def test_update_nodes(connection):
 
     # Test for not raising any errors
     tree.update_nodes(
-        {"312/123": {"Unit": "test5"}, "testNOtexists": {"Node": "test5"}}, add=False, raise_for_invalid_node=False
+        {"312/123": {"Unit": "test5"}, "testNOtexists": {"Node": "test5"}},
+        add=False,
+        raise_for_invalid_node=False,
     )
     assert tree.testNOtexists.is_valid() is False
 


### PR DESCRIPTION
Description:

Add raise_for_invalid_node-keyword argument to NodeTree update_nodes

This enables the initialization of devices/module classes, even though modified nodes e.g. with parses does not match
the one in device (due to old firmware, deleted/modified node etc.).

Fixes issue: #110

Checklist:

- [x] Add tests for the change to show correct behavior.
- [x] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
- [x] Add .. versionchanged:: where necessary.
