### PR TITLE
Spelling output stdout, no artifacts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,11 +45,4 @@ jobs:
 
       - name: "Test spelling docs"
         run: |
-          cd docs && sphinx-build -b spelling -q -W --keep-going source build/spelling
-
-      - name: Store spelling result artifacts
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: docs-spelling-failure-report
-          path: docs/build/spelling
+          cd docs && sphinx-build -b spelling -W --keep-going source build/spelling


### PR DESCRIPTION
Description:

Spelling failures outputted an artifacts, which is cumbersome to download and open to see errors.
Output spelling straight to stdout.

Fixes issue: #

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [ ] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
