### PR TITLE
Introduce WildcardResult class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   The function is able to generated a sequence code snippet that defines and assigns
   the waveforms for this object. Additional meta information like an optional name 
   or the output configuration can be specified through a newly added `Wave` class from `zhinst.toolkit.Waveforms`.
+* Getting a value by calling a wildcard node now returns `zhinst.toolkit.nodetree.node.WildcardResult`
 
 
 ## Version 0.3.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ sphinx-issues
 nbsphinx
 nbsphinx_link
 m2r2
+docutils<0.19.0
 pydata_sphinx_theme
 sphinx_autodoc_typehints
 jupytext==1.13.7

--- a/docs/source/examples/common_device.rst
+++ b/docs/source/examples/common_device.rst
@@ -27,17 +27,17 @@ access the node specific information.
 .. code-block:: python
 
     >>> list(device.child_nodes())
-    [/dev3036/oscs,
-     /dev3036/demods,
-     /dev3036/extrefs,
-     /dev3036/triggers,
-     /dev3036/status,
+    [/dev1234/oscs,
+     /dev1234/demods,
+     /dev1234/extrefs,
+     /dev1234/triggers,
+     /dev1234/status,
      ...]
     >>> list(device.demods[0].child_nodes(recursive=True))
-    [/dev3036/demods/0/adcselect,
-     /dev3036/demods/0/order,
-     /dev3036/demods/0/rate,
-     /dev3036/demods/0/oscselect,
+    [/dev1234/demods/0/adcselect,
+     /dev1234/demods/0/order,
+     /dev1234/demods/0/rate,
+     /dev1234/demods/0/oscselect,
      ...]
 
 The node tree is automatically generated during the initialization of the device
@@ -103,7 +103,7 @@ loads the default preset.
 .. code-block:: python
 
     >>> device.factory_reset()
-    "Factory preset is loaded to device DEV3036."
+    "Factory preset is loaded to device DEV1234."
 
 .. note::
 

--- a/examples/nodetree.md
+++ b/examples/nodetree.md
@@ -75,7 +75,7 @@ Making a call gets the value(s) for that node. Passing a value to the call
 operator will set that value to the node on the device.
 
 Calling a node that is not a leaf (wildcard or partial node) will return/set the
-value on every node that matches it (the return type will be a dictionary).
+value on every node that matches it (the return type will be a dictionary or a mapping).
 
 > Warning:
 >


### PR DESCRIPTION
Description:

Introduce WildcardResult class

The `Node` class cannot be deepcopied (`copy.deepcopy`). This is problematic when Node values are called with wildcards, returns a `dict`, which has the `Node` objects as keys. This PR modifies the return value with wildcards to enable deepcopying the results.

Fixes issue: #

Checklist:

- [x] Add tests for the change to show correct behavior.
- [x] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
- [x] Add .. versionchanged:: where necessary.
