### PR TITLE
Utilize zhinst.core.ziDAQServer host, port newly added properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   sequences in toolkit (`#141`).
 * Add support for session wide transactions that bundle set command from all 
   devices connected to the data server. (`#134`)
+* Add `from_existing_connection()` to `zhinst.toolkit.Session` to help reusing the existing DataServer connection.
 * Bugfix: Nodes with nameless options don't raise an exception when their enum attribute is called (`#165`).
 * Bugfix: Values of enumerated nodes can now be pickled (`#129`).
 

--- a/src/zhinst/toolkit/driver/modules/shfqa_sweeper.py
+++ b/src/zhinst/toolkit/driver/modules/shfqa_sweeper.py
@@ -71,8 +71,8 @@ class SHFQASweeper(Node):
         }
         super().__init__(self._create_nodetree(), tuple())
         self._daq_server = ziDAQServer(
-            session._daq_server.host,
-            session._daq_server.port,
+            session.daq_server.host,
+            session.daq_server.port,
             6,
         )
         self._raw_module = CoreSweeper(self._daq_server, "")

--- a/src/zhinst/toolkit/driver/modules/shfqa_sweeper.py
+++ b/src/zhinst/toolkit/driver/modules/shfqa_sweeper.py
@@ -56,7 +56,7 @@ class SHFQASweeper(Node):
         session: Session to the Data Server.
     """
 
-    def __init__(self, daq_server: ziDAQServer, session: "Session"):
+    def __init__(self, session: "Session"):
         self._config_classes = {
             SweepConfig: ("sweep", "sweep_config"),
             RfConfig: ("rf", "rf_config"),
@@ -70,8 +70,12 @@ class SHFQASweeper(Node):
             "force_sw_trigger": "sw_trigger_mode",
         }
         super().__init__(self._create_nodetree(), tuple())
-        self._daq_server = daq_server
-        self._raw_module = CoreSweeper(daq_server, "")
+        self._daq_server = ziDAQServer(
+            session._daq_server.host,
+            session._daq_server.port,
+            6,
+        )
+        self._raw_module = CoreSweeper(self._daq_server, "")
         self._session = session
         self.root.update_nodes(
             {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 
 import pytest
 
@@ -17,6 +17,9 @@ def data_dir(request):
 @pytest.fixture()
 def mock_connection():
     with patch("zhinst.toolkit.session.core.ziDAQServer", autospec=True) as connection:
+        type(connection.return_value).port = PropertyMock(return_value=8004)
+        type(connection.return_value).host = PropertyMock(return_value="localhost")
+        type(connection.return_value).api_level = PropertyMock(return_value=6)
         yield connection
 
 
@@ -36,6 +39,7 @@ def session(nodedoc_zi_json, mock_connection):
 @pytest.fixture()
 def hf2_session(data_dir, mock_connection):
     mock_connection.return_value.getString.return_value = "HF2DataServer"
+    type(mock_connection.return_value).port = PropertyMock(return_value=8005)
     yield Session("localhost", hf2=True)
 
 

--- a/tests/test_shfqa_sweeper.py
+++ b/tests/test_shfqa_sweeper.py
@@ -33,8 +33,16 @@ def mock_TriggerConfig():
 
 
 @pytest.fixture()
-def sweeper_module(mock_connection, mock_shf_sweeper, session):
-    yield SHFQASweeper(mock_connection.return_value, session)
+def mock_sweeper_daq():
+    with patch(
+        "zhinst.toolkit.driver.modules.shfqa_sweeper.ziDAQServer", autospec=True
+    ) as connection:
+        yield connection
+
+
+@pytest.fixture()
+def sweeper_module(session, mock_sweeper_daq, mock_shf_sweeper):
+    yield SHFQASweeper(session)
 
 
 def test_repr(sweeper_module):
@@ -46,15 +54,17 @@ def test_missing_node(mock_connection, mock_shf_sweeper, session):
         "zhinst.toolkit.driver.modules.shfqa_sweeper.SweepConfig",
         make_dataclass("Y", fields=[("s", str, 0)], bases=(SweepConfig,)),
     ) as sweeper_config:
-        sweeper_module = SHFQASweeper(mock_connection.return_value, session)
+        sweeper_module = SHFQASweeper(session)
         assert sweeper_module.sweep.s() == 0
 
 
-def test_device(mock_connection, sweeper_module, session, mock_shf_sweeper):
+def test_device(
+    mock_connection, sweeper_module, session, mock_shf_sweeper, mock_sweeper_daq
+):
     assert sweeper_module.device() == ""
 
     sweeper_module.device("dev1234")
-    mock_shf_sweeper.assert_called_with(mock_connection.return_value, "dev1234")
+    mock_shf_sweeper.assert_called_with(mock_sweeper_daq(), "dev1234")
     assert sweeper_module.device() == "dev1234"
 
     connected_devices = "dev1234"
@@ -71,15 +81,17 @@ def test_device(mock_connection, sweeper_module, session, mock_shf_sweeper):
     assert sweeper_module.device() == session.devices["dev1234"]
 
 
-def test_update_settings(mock_connection, sweeper_module, mock_shf_sweeper):
+def test_update_settings(
+    mock_connection, sweeper_module, mock_shf_sweeper, mock_sweeper_daq
+):
     assert not sweeper_module.envelope.enable()
-    mock_shf_sweeper.assert_called_with(mock_connection.return_value, "")
+    mock_shf_sweeper.assert_called_with(sweeper_module._daq_server, "")
     # device needs to be set first
     with pytest.raises(RuntimeError) as e_info:
         sweeper_module._update_settings()
 
     sweeper_module.device("dev1234")
-    mock_shf_sweeper.assert_called_with(mock_connection.return_value, "dev1234")
+    mock_shf_sweeper.assert_called_with(mock_sweeper_daq(), "dev1234")
     sweeper_module._update_settings()
     mock_shf_sweeper.return_value.configure.assert_called_once()
     assert "sweep_config" in mock_shf_sweeper.return_value.configure.call_args[1]


### PR DESCRIPTION
Description:

Utilize zhinst.core.ziDAQServer host, port

Fixes issue: #

Checklist:

- [x] Add tests for the change to show correct behavior.
- [x] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
- [x] Add .. versionchanged:: where necessary.
