### PR TITLE
Fix issue that prevented correct compilation of sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # zhinst-toolkit Changelog
 
+## Version 0.4.3
+* Fix issue that prevented correct compilation of sequences for AWG cores other than the first one.
+
 ## Version 0.4.2
 * Embed multistate utils for the SHFQA into the node tree
   * shfqa.qachannels[n].readout.multistate.qudits[m].configure(settings)

--- a/src/zhinst/toolkit/driver/nodes/awg.py
+++ b/src/zhinst/toolkit/driver/nodes/awg.py
@@ -137,6 +137,7 @@ class AWG(Node):
             str(sequencer_program),
             self._device_type,
             self._device_options,
+            self._index,
             **kwargs,
         )
 

--- a/tests/test_hdawg.py
+++ b/tests/test_hdawg.py
@@ -83,5 +83,10 @@ def test_awg_compiler(mock_connection, hdawg):
     ) as compile_seqc:
         hdawg.awgs[0].compile_sequencer_program("test")
         compile_seqc.assert_called_once_with(
-            "test", "HDAWG4", "AWG,FOOBAR", samplerate=10000
+            "test", "HDAWG4", "AWG,FOOBAR", 0, samplerate=10000
+        )
+        compile_seqc.reset_mock()
+        hdawg.awgs[1].compile_sequencer_program("test")
+        compile_seqc.assert_called_once_with(
+            "test", "HDAWG4", "AWG,FOOBAR", 1, samplerate=10000
         )

--- a/tests/test_shfqa.py
+++ b/tests/test_shfqa.py
@@ -77,7 +77,7 @@ def test_qa_generator_compiler(mock_connection, shfqa):
         "zhinst.toolkit.driver.nodes.awg.compile_seqc", autospec=True
     ) as compile_seqc:
         shfqa.qachannels[0].generator.compile_sequencer_program("test")
-        compile_seqc.assert_called_once_with("test", "SHFQA4", "AWG,FOOBAR")
+        compile_seqc.assert_called_once_with("test", "SHFQA4", "AWG,FOOBAR", 0)
 
 
 def test_qa_readout(shfqa):

--- a/tests/test_shfqc.py
+++ b/tests/test_shfqc.py
@@ -107,7 +107,7 @@ def test_sg_awg_compiler(mock_connection, shfqc):
     ) as compile_seqc:
         shfqc.sgchannels[0].awg.compile_sequencer_program("test")
         compile_seqc.assert_called_once_with(
-            "test", "SHFQC", "AWG,FOOBAR", sequencer="sg"
+            "test", "SHFQC", "AWG,FOOBAR", 0, sequencer="sg"
         )
 
 
@@ -118,7 +118,7 @@ def test_qa_awg_compiler(mock_connection, shfqc):
     ) as compile_seqc:
         shfqc.qachannels[0].generator.compile_sequencer_program("test")
         compile_seqc.assert_called_once_with(
-            "test", "SHFQC", "AWG,FOOBAR", sequencer="qa"
+            "test", "SHFQC", "AWG,FOOBAR", 0, sequencer="qa"
         )
 
 

--- a/tests/test_shfsg.py
+++ b/tests/test_shfsg.py
@@ -40,7 +40,7 @@ def test_sg_awg_compiler(mock_connection, shfsg):
         "zhinst.toolkit.driver.nodes.awg.compile_seqc", autospec=True
     ) as compile_seqc:
         shfsg.sgchannels[0].awg.compile_sequencer_program("test")
-        compile_seqc.assert_called_once_with("test", "SHFSG8", "AWG,FOOBAR")
+        compile_seqc.assert_called_once_with("test", "SHFSG8", "AWG,FOOBAR", 0)
 
 
 def test_sg_awg_modulation_freq(mock_connection, shfsg, data_dir):

--- a/tests/test_uhfli.py
+++ b/tests/test_uhfli.py
@@ -40,7 +40,7 @@ def test_awg_compiler(mock_connection, uhfli):
         "zhinst.toolkit.driver.nodes.awg.compile_seqc", autospec=True
     ) as compile_seqc:
         uhfli.awgs[0].compile_sequencer_program("test")
-        compile_seqc.assert_called_once_with("test", "UHFLI", "AWG,FOOBAR")
+        compile_seqc.assert_called_once_with("test", "UHFLI", "AWG,FOOBAR", 0)
 
 
 def test_awg_option_not_found(data_dir, mock_connection, uhfli):

--- a/tests/test_uhfqa.py
+++ b/tests/test_uhfqa.py
@@ -150,7 +150,7 @@ def test_awg_compiler(mock_connection, uhfqa):
         "zhinst.toolkit.driver.nodes.awg.compile_seqc", autospec=True
     ) as compile_seqc:
         uhfqa.awgs[0].compile_sequencer_program("test")
-        compile_seqc.assert_called_once_with("test", "UHFQA", "AWG,FOOBAR")
+        compile_seqc.assert_called_once_with("test", "UHFQA", "AWG,FOOBAR", 0)
 
 
 class TestWriteIntegrationWeights:

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,6 @@ commands =
 
 [testenv:typing]
 deps = 
-    mypy
+    mypy==0.981  # TODO (markush): 0.982 reports errors.
 commands = 
     mypy src


### PR DESCRIPTION
Fix issue that prevented correct compilation of sequences for AWG cores other than the first one

Description:
The function compile_sequencer_program() was not passing the core index to the compile_seqc function. Therefore, the default index 0 was used. This produced wrong ELF for cores other than the first one on the HDAWG
