### PR TITLE
Elenaa/test examples

### DIFF
--- a/examples/test.spec.yml
+++ b/examples/test.spec.yml
@@ -1,0 +1,63 @@
+awg:
+  device_type: "HDAWG"
+
+daq_module:
+  device_type: ["MFLI", "UHFLI"]
+
+hdawg_awg:
+  device_type: "HDAWG"
+
+hdawg_precomp_curve_fit:
+  device_type: "HDAWG"
+
+hf2:
+  device_type: "HF2LI"
+
+nodetree:
+  device_type: ["MFLI", "UHFLI"]
+
+scope_module:
+  device_type: ["MFLI", "UHFLI"]
+
+shfqa_multistate_discrimination:
+  device_type: "SHFQA2"
+
+shfqa_qubit_readout_measurement:
+  device_type: "SHFQA2"
+
+shfqa_qubit_readout_weights:
+  device_type: "SHFQA2"
+
+shfqa_sweeper:
+  device_type: "SHFQA2"
+
+shfqc_propagation_delay:
+  device_type: "SHFQC"
+
+shfqc_qubit_spectroscopy:
+  device_type: "SHFQC"
+
+shfqc_rabi:
+  device_type: "SHFQC"
+
+shfqc_resonator_spectroscopy_cw_power:
+  device_type: "SHFQC"
+
+shfqc_resonator_spectroscopy_cw:
+  device_type: "SHFQC"
+
+shfsg_rabi:
+  device_type: "SHFSG4"
+
+shfsg_sine:
+  device_type: "SHFSG4"
+
+sweeper_module:
+  device_type: ["MFLI", "UHFLI"]
+
+uhf_boxcar:
+  device_type: "UHFLI"
+
+uhfqa_result_unit:
+  device_type: "UHFQA"
+

--- a/tests/test_example_config.py
+++ b/tests/test_example_config.py
@@ -1,0 +1,37 @@
+import yaml
+import os
+from glob import glob
+from pathlib import Path
+
+EXAMPLES_DIRECTORY = "examples/"
+
+
+def test_config_existence():
+    assert os.path.exists(EXAMPLES_DIRECTORY + "test.spec.yml")
+
+
+def test_example_config():
+    with open(EXAMPLES_DIRECTORY + "test.spec.yml", "rb") as f:
+        test_spec = yaml.load(f, Loader=yaml.Loader)
+
+    examples_list = glob(EXAMPLES_DIRECTORY + "*.md")
+
+    for example in examples_list:
+        example_name = Path(example).name.split(".")[0]
+        if example_name == "README":
+            continue
+
+        # Check that the notebook is in the config file
+        assert (
+            example_name in test_spec
+        ), f'Example "{example_name}" was not included in the configuration file.'
+
+        # Check that it has the device id specified
+        assert (
+            "device_type" in test_spec[example_name]
+        ), f'No device_type was specified for the example "{example_name}".'
+
+        # Check that the device id was written
+        assert (
+            test_spec[example_name]["device_type"] != None
+        ), f'The field "device_type" is empty for the example "{example_name}".'


### PR DESCRIPTION
- Add test.spec.yml
- Test example configuration
- Add variables `device_id` and `host` in the examples to match regex