### PR TITLE
Add active_validation parameter to CommandTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Version 0.4.4
 * Added full support for the LabOne Scope module (no need to fallback to zhinst.core)
 * Renamed `zhinst.toolkit.nodetree.nodes.WildcardResult` to `zhinst.toolkit.nodetree.helpers.NodeDict`
+* Added `active_validation` argument to `CommandTable`. By disabling it, `CommandTable` does not actively 
+  validate the inputs and therefore it improves the speed for command table creation.
 
 ## Version 0.4.3
 * Fix issue that prevented correct compilation of sequences for AWG cores other than the first one.

--- a/examples/awg.md
+++ b/examples/awg.md
@@ -425,6 +425,46 @@ ct.table[1].amplitude1.increment = True
 awg_node.commandtable.upload_to_device(ct)
 ```
 
+### Command table ctive validation
+Command table validates the given arguments by default. The feature has overhead and can
+be turned off to improve production code runtimes. Disabling it is good especially when creating a large
+command table with multiple table indexes. The next example shows the effect on active
+validation during a large command table creation (maximum number of table entries in the device).
+
+```python
+from time import perf_counter_ns
+
+ct.clear()
+start = perf_counter_ns()
+ct.active_validation = True
+for i in range(ct.table.range[0], ct.table.range[-1]):
+    ct.table[i].waveform.index = 0
+    ct.table[i].amplitude0.value = 0.0
+    ct.table[i].amplitude0.increment = False
+    ct.table[i].amplitude1.value = -0.0
+    ct.table[i].amplitude1.increment = False
+stop = perf_counter_ns()
+active_validation_on_duration = stop - start
+
+ct.clear()
+ct.active_validation = False
+start = perf_counter_ns()
+for i in range(ct.table.range[0], ct.table.range[-1]):
+    ct.table[i].waveform.index = 0
+    ct.table[i].amplitude0.value = 0.0
+    ct.table[i].amplitude0.increment = False
+    ct.table[i].amplitude1.value = -0.0
+    ct.table[i].amplitude1.increment = False
+stop = perf_counter_ns()
+active_validation_off_duration = stop - start
+
+def diff_percentage(current, previous):
+    return (abs(current - previous) / previous) * 100.0
+
+difference_in_runtime = diff_percentage(active_validation_on_duration, active_validation_off_duration)
+print(f"Speed improvement without active validation: {difference_in_runtime} %")
+```
+
 ## Performance optimzation
 Often the limiting factor for an experiment is the delay of the device communication.
 If this is the case it is best trying to reduce the number of uploads. 

--- a/src/zhinst/toolkit/driver/nodes/command_table_node.py
+++ b/src/zhinst/toolkit/driver/nodes/command_table_node.py
@@ -130,6 +130,6 @@ class CommandTableNode(Node):
         Returns:
             command table.
         """
-        ct = CommandTable(self.load_validation_schema())
+        ct = CommandTable(self.load_validation_schema(), active_validation=True)
         ct.update(self.data())
         return ct

--- a/tests/command_table/test_command_table.py
+++ b/tests/command_table/test_command_table.py
@@ -125,6 +125,53 @@ def test_assert_validate_called_table_index(command_table):
         )
 
 
+@pytest.mark.parametrize("value", [True, False])
+def test_command_table_active_validation(command_table_schema, value):
+    ct = CommandTable(command_table_schema, active_validation=value)
+    assert ct.active_validation is value
+    ct.active_validation = not value
+    assert ct.active_validation is not value
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_command_table_active_validation_change_header_table_true(
+    command_table_schema, value
+):
+    ct = CommandTable(command_table_schema)
+    ct.active_validation = value
+    assert ct.header._active_validation is value
+    assert ct.table._active_validation is value
+
+
+def test_command_table_active_validation_table(command_table_schema):
+    ct = CommandTable(command_table_schema, active_validation=True)
+    ct.table[0]
+    with pytest.raises(ValidationError):
+        ct.table[999999]
+    ct = CommandTable(command_table_schema, active_validation=False)
+    ct.table[999999].amplitude00.value = 1
+    with pytest.raises(ValidationError):
+        ct.as_dict()
+
+
+def test_command_table_active_validation_parent_entry(command_table_schema):
+    ct = CommandTable(command_table_schema, active_validation=True)
+    ct.table[0]
+    with pytest.raises(ValidationError):
+        ct.table[0].amplitude00.value = "abc"
+    ct = CommandTable(command_table_schema, active_validation=False)
+    ct.table[0].amplitude00.value = "abc"
+
+
+def test_command_table_active_validation_header(command_table_schema):
+    ct = CommandTable(command_table_schema, active_validation=True)
+    ct.table[0]
+    with pytest.raises(ValidationError):
+        ct.header.userString = 213
+    ct = CommandTable(command_table_schema, active_validation=False)
+    ct.header.userString = 213
+
+
 @pytest.mark.parametrize("input_, output", [(1, 1), (40, 40), ("foo", "foo"), (-2, -2)])
 def test_assert_validate_called_parent_entry_attribute_set(
     input_, output, command_table


### PR DESCRIPTION
Description:

Add active_validation parameter to CommandTable

By disabling the active validation in large command tables (e.g 1024 table entries), the speed improvements are up to 8x.

Fixes issue: #

Checklist:

- [x] Add tests for the change to show correct behavior.
- [x] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
- [x] Add .. versionchanged:: where necessary.
