### PR TITLE
Correct HDAWG8 instead of HDAWG in test.spec

### DIFF
--- a/examples/test.spec.yml
+++ b/examples/test.spec.yml
@@ -1,14 +1,14 @@
 awg:
-  device_type: "HDAWG"
+  device_type: "HDAWG8"
 
 daq_module:
   device_type: ["MFLI", "UHFLI"]
 
 hdawg_awg:
-  device_type: "HDAWG"
+  device_type: "HDAWG8"
 
 hdawg_precomp_curve_fit:
-  device_type: "HDAWG"
+  device_type: "HDAWG8"
 
 hf2:
   device_type: "HF2LI"


### PR DESCRIPTION
Fix incorrect device_type in the examples test.spec for awg devices.
The correct device_type should be HDAWG8.
