### PR TITLE
Test regex match in examples

### DIFF
--- a/examples/awg.md
+++ b/examples/awg.md
@@ -37,7 +37,7 @@ Connect devices and access the ``/awg`` node.
 ```python
 from zhinst.toolkit import Session
 
-session = Session('localhost')
+session = Session("localhost")
 device = session.connect_device("DEVXXXX")
 awg_node = device.awgs[0]
 ```

--- a/tests/test_examples_regex_match.py
+++ b/tests/test_examples_regex_match.py
@@ -1,0 +1,53 @@
+import pathlib
+import re
+import pytest
+
+
+EXAMPLES_PATH = pathlib.Path("examples")
+
+
+def match_regex_in_markdown(markdown_file: pathlib.Path, exp_to_match: str) -> bool:
+    """Check if a regex is matched inside a markdown file.
+
+    Args:
+        markdown_file: Path to the markdown file where the regex is to be searched.
+        exp_to_match: Regular expression to be matched.
+
+    Returns:
+        Flag if the regex has been matched.
+    """
+    with open(markdown_file, "r") as f:
+        for line in f:
+            match = re.search(exp_to_match, line)
+            if match is not None:
+                return True
+    return False
+
+
+def get_markdown_files() -> pathlib.Path:
+    """Collect all the markdown files contained in the examples path.
+
+    Yields:
+        The path to a markdown file.
+
+    """
+    md_list = EXAMPLES_PATH.glob("*.md")
+    for md_file in md_list:
+        # README.md should not be checked
+        if md_file.stem == "README":
+            continue
+        else:
+            yield md_file
+
+
+@pytest.mark.parametrize(
+    "input_file", get_markdown_files(), ids=lambda input_file: input_file.stem
+)
+def test_examples_regex_match(input_file: pathlib.Path):
+    assert match_regex_in_markdown(
+        input_file, '"DEVXXXX"'
+    ), f'Expression "DEVXXXX" not found in {input_file.name}'
+
+    assert match_regex_in_markdown(
+        input_file, '"localhost"'
+    ), f'Expression "localhost" not found in {input_file.name}'


### PR DESCRIPTION
Add a test to check regex matching in the toolkit examples 
Correct awg examples from 'localhost' to "localhost" (found thanks to the test)