### PR TITLE
Add try-except block around intended error and split two cells

### DIFF
--- a/examples/awg.md
+++ b/examples/awg.md
@@ -405,8 +405,11 @@ the moment it gets converted the complete structure is validated.
 
 ```python
 ct.clear()
-ct.table[0].amplitude0.increment = True
-ct.as_dict()
+try:
+    ct.table[0].amplitude0.increment = True
+    ct.as_dict()
+except ValidationError as err:
+    print(err)
 ```
 
 Once the command table is finished the upload to the device is taken care of


### PR DESCRIPTION
Add try-except block around intended error at lines 408-409.
Split commands at lines 71-72 in two different cells, otherwise enable_sequencer sometimes results in an error.