### PR TITLE
Fix error handling in child_nodes

### DIFF
--- a/src/zhinst/toolkit/nodetree/node.py
+++ b/src/zhinst/toolkit/nodetree/node.py
@@ -17,6 +17,8 @@ from zhinst.toolkit.nodetree.helper import (
     NodeDict,
 )
 
+from zhinst.core.errors import CoreError
+
 if t.TYPE_CHECKING:  # pragma: no cover
     from zhinst.toolkit.nodetree import NodeTree
 
@@ -1102,8 +1104,8 @@ class Node:
             )
             for node_raw in raw_result:
                 yield self._root.raw_path_to_node(node_raw)
-        except RuntimeError as error:
-            if "Path format invalid" not in error.args[0]:
+        except CoreError as error:
+            if error.code != 32768:  # Replace with correct error in 23.02
                 raise
             if not full_wildcard:
                 raise RuntimeError(

--- a/tests/test_nodetree.py
+++ b/tests/test_nodetree.py
@@ -15,6 +15,8 @@ from zhinst.toolkit.nodetree import Node, NodeTree
 from zhinst.toolkit.nodetree.connection_dict import ConnectionDict
 from zhinst.toolkit.nodetree.node import NodeList
 
+from zhinst.core.errors import CoreError
+
 
 @pytest.fixture()
 def data_dir(request):
@@ -786,7 +788,7 @@ def test_child_nodes(connection):
     with pytest.raises(RuntimeError) as e_info:
         result = list(tree.demods["*"].child_nodes())
     assert e_info.value.args[0] == "Weird fail"
-    connection.listNodes.side_effect = RuntimeError("Path format invalid")
+    connection.listNodes.side_effect = CoreError("Path format invalid", 32768)
     with pytest.raises(RuntimeError) as e_info:
         result = list(tree.demods["[0,1]"].child_nodes())
     assert "full_wildcard" in e_info.value.args[0]


### PR DESCRIPTION
The error message of the LabOne error 32768 was recently changed, so the error handling inside child_nodes was no longer up to date. 
This issue should be fixed in the LabOne error handling, but for the moment we fix it in toolkit by checking the error code. 
We should anyway fix this in the next release of LabOne.