### PR TITLE
Poll before unsubscribing

### DIFF
--- a/examples/nodetree.md
+++ b/examples/nodetree.md
@@ -269,9 +269,8 @@ returns a dictionary of nodes and their corresponding data.
 ```python
 import time
 device.demods[0].sample.subscribe()
-time.sleep(0.01)
-device.demods[0].sample.unsubscribe()
 data = session.poll()
+device.demods[0].sample.unsubscribe()
 data[device.demods[0].sample]
 ```
 


### PR DESCRIPTION
The previous version of the code was unstable on the MFLI devices, because sometimes the data structure resulting from the poll was empty. This was likely due to waiting too little time between the subscribe and the unsubscribe operations: time.sleep(0.01) was not always enough. 
We can solve this by polling directly after subscribing, and unsubscribing just after the poll has ended. This should be stable because the default recording time of the poll function is 0.1s, which empirically is enough to always receive some data. 