### PR TITLE
Fix sampling_rate lowercase

### DIFF
--- a/examples/hdawg_precomp_curve_fit.md
+++ b/examples/hdawg_precomp_curve_fit.md
@@ -58,7 +58,7 @@ TAU = 100e-9
 AMPL = 0.4
 
 # calculate a and b from amplitude and tau
-alpha = 1 - np.exp(-1 / (SAMPLING_RATE * TAU * (1 + AMPL)))
+alpha = 1 - np.exp(-1 / (sampling_rate * TAU * (1 + AMPL)))
 if AMPL >= 0.0:
     k = AMPL / (1 + AMPL - alpha)
     signal_a = [(1 - k + k * alpha), -(1 - k) * (1 - alpha)]


### PR DESCRIPTION
In a recent change to hdawg_precomp_curve_fit the variable SAMPLING_RATE was modified and its name converted to lower case. The occurrence of the variable on line 61 was still using upper case though, producing an error.