### PR TITLE
Adapt read_from_waveform_memory to be able to read indexes larger than 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added full support for the following LabOne modules (no need to fallback to zhinst.core):
   * Impedance Module
   * Precompensation Advisor Module
+* Fix issue with downloading waveforms from the device. This issue prevented indexes larger than 9 to be read from the device.
 
 ## Version 0.5.0
 * Added full support for the following LabOne modules (no need to fallback to zhinst.core):

--- a/src/zhinst/toolkit/driver/nodes/awg.py
+++ b/src/zhinst/toolkit/driver/nodes/awg.py
@@ -249,22 +249,20 @@ class AWG(Node):
         nodes = [
             self.waveform.node_info.path + f"/waves/{index}"
             for index in range(len(waveform_info))
-            if indexes is None or index in indexes
+            if (indexes is None or index in indexes)
+            and "__filler" not in waveform_info[index]["name"]
         ]
         nodes_str = ",".join(nodes)
         waveforms_raw = self._daq_server.get(nodes_str, settingsonly=False, flat=True)
         waveforms = Waveforms()
         for node, waveform in waveforms_raw.items():
-            slot = int(node[-1])
-            if "__filler" not in waveform_info[slot]["name"]:
-                waveforms.assign_native_awg_waveform(
-                    slot,
-                    waveform[0]["vector"],
-                    channels=int(waveform_info[slot].get("channels", 1)),
-                    markers_present=bool(
-                        int(waveform_info[slot].get("marker_bits")[0])
-                    ),
-                )
+            slot = int(node.rsplit("/", 1)[-1])
+            waveforms.assign_native_awg_waveform(
+                slot,
+                waveform[0]["vector"],
+                channels=int(waveform_info[slot].get("channels", 1)),
+                markers_present=bool(int(waveform_info[slot].get("marker_bits")[0])),
+            )
         return waveforms
 
     @lazy_property

--- a/src/zhinst/toolkit/driver/nodes/awg.py
+++ b/src/zhinst/toolkit/driver/nodes/awg.py
@@ -250,7 +250,9 @@ class AWG(Node):
             self.waveform.node_info.path + f"/waves/{index}"
             for index in range(len(waveform_info))
             if (indexes is None or index in indexes)
-            and "__filler" not in waveform_info[index]["name"]
+            # Entries that have a play_config equals to zero ar dummies/fillers
+            # and can therefore be ignored.
+            and int(waveform_info[index]["play_config"])
         ]
         nodes_str = ",".join(nodes)
         waveforms_raw = self._daq_server.get(nodes_str, settingsonly=False, flat=True)

--- a/tests/data/waveform_descriptors_large.json
+++ b/tests/data/waveform_descriptors_large.json
@@ -1,0 +1,124 @@
+{
+    "waveforms": [
+        {
+            "name": "__filler_10_15",
+            "filename": "",
+            "function": "",
+            "channels": "1",
+            "marker_bits": "0",
+            "length": "32",
+            "timestamp": "0001157435705271",
+            "play_config": "0"
+        },
+        {
+            "name": "__filler_10_15",
+            "filename": "",
+            "function": "",
+            "channels": "1",
+            "marker_bits": "0",
+            "length": "32",
+            "timestamp": "0001157435705271",
+            "play_config": "0"
+        },
+        {
+            "name": "__filler_10_15",
+            "filename": "",
+            "function": "",
+            "channels": "1",
+            "marker_bits": "0",
+            "length": "32",
+            "timestamp": "0001157435705271",
+            "play_config": "0"
+        },
+        {
+            "name": "__filler_10_15",
+            "filename": "",
+            "function": "",
+            "channels": "1",
+            "marker_bits": "0",
+            "length": "32",
+            "timestamp": "0001157435705271",
+            "play_config": "0"
+        },
+        {
+            "name": "__filler_10_15",
+            "filename": "",
+            "function": "",
+            "channels": "1",
+            "marker_bits": "0",
+            "length": "32",
+            "timestamp": "0001157435705271",
+            "play_config": "0"
+        },
+        {
+            "name": "__filler_10_15",
+            "filename": "",
+            "function": "",
+            "channels": "1",
+            "marker_bits": "0",
+            "length": "32",
+            "timestamp": "0001157435705271",
+            "play_config": "0"
+        },
+        {
+            "name": "__filler_10_15",
+            "filename": "",
+            "function": "",
+            "channels": "1",
+            "marker_bits": "0",
+            "length": "32",
+            "timestamp": "0001157435705271",
+            "play_config": "0"
+        },
+        {
+            "name": "__filler_10_15",
+            "filename": "",
+            "function": "",
+            "channels": "1",
+            "marker_bits": "0",
+            "length": "32",
+            "timestamp": "0001157435705271",
+            "play_config": "0"
+        },
+        {
+            "name": "__filler_10_15",
+            "filename": "",
+            "function": "",
+            "channels": "1",
+            "marker_bits": "0",
+            "length": "32",
+            "timestamp": "0001157435705271",
+            "play_config": "0"
+        },
+        {
+            "name": "__filler_10_15",
+            "filename": "",
+            "function": "",
+            "channels": "1",
+            "marker_bits": "0",
+            "length": "32",
+            "timestamp": "0001157435705271",
+            "play_config": "0"
+        },
+        {
+            "name": "__filler_10_15",
+            "filename": "",
+            "function": "",
+            "channels": "1",
+            "marker_bits": "0",
+            "length": "32",
+            "timestamp": "0001157435705271",
+            "play_config": "0"
+        },
+        {
+            "name": "__playWave_10_14",
+            "filename": "",
+            "function": "",
+            "channels": "2",
+            "marker_bits": "1;1",
+            "length": "1008",
+            "timestamp": "0001157435705271",
+            "play_config": "5218051"
+        }
+    ]
+}


### PR DESCRIPTION
Description:
The old implementation used `int(node[-1])` to determine the slot. This only works for single digit numbers. 
The correct way of doing this is ` int(node.rsplit("/", 1)[-1])` meaning to use the `/` as a reference point. 

In addition, I optimized the code a bit in a sense that it does not request the waveform indexes which are marked as `filleres`. The old implementation discarded the as well, but only in the last step.

Fixes issue: #

Checklist:

- [x] Add tests for the change to show correct behavior.
- [x] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
- [x] Add .. versionchanged:: where necessary.
