### PR TITLE
Added BaseInstrument.session property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added full support for the following LabOne modules (no need to fallback to zhinst.core):
   * Impedance Module
   * Precompensation Advisor Module
+* Added `session` property to `BaseInstrument`. This enables getting the given `Session` from the instrument.
 * Fix issue with downloading waveforms from the device. This issue prevented indexes larger than 9 to be read from the device.
 
 ## Version 0.5.0

--- a/src/zhinst/toolkit/driver/devices/base.py
+++ b/src/zhinst/toolkit/driver/devices/base.py
@@ -322,6 +322,14 @@ class BaseInstrument(Node):
         return self._serial
 
     @property
+    def session(self) -> "Session":
+        """Underlying session to the data server.
+
+        .. versionadded:: 0.5.1
+        """
+        return self._session
+
+    @property
     def device_type(self) -> str:
         """Type of the instrument (e.g. MFLI)."""
         return self._device_type

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,6 +17,10 @@ def base_instrument(mock_connection, session, nodedoc_dev1234_json):
     yield BaseInstrument("DEV1234", "test_type", session)
 
 
+def test_instrument_session_property(base_instrument, session):
+    assert base_instrument.session == session
+
+
 def test_basic_setup(mock_connection, base_instrument):
     mock_connection.return_value.listNodesJSON.assert_called_with(
         f"/{base_instrument.serial}/*"


### PR DESCRIPTION
Description:

Added BaseInstrument.session property

This PR enabled getting the `Session` from devices without using the private attribute `_session`.

Fixes issue: #

Checklist:

- [x] Add tests for the change to show correct behavior.
- [x] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
- [x] Add .. versionchanged:: where necessary.
