### PR TITLE
Add feedback examples

### DIFF
--- a/examples/bell_state_stabilization.md
+++ b/examples/bell_state_stabilization.md
@@ -1,0 +1,474 @@
+---
+jupyter:
+  jupytext:
+    formats: ipynb,md
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.14.1
+  kernelspec:
+    display_name: toolkit
+    language: python
+    name: python3
+---
+
+# Bell State Stabilization
+
+In this example we illustrate how to perform Bell state stabilization with real-time feedback using Zurich Instruments PQSC, SHFQA and SHFSG.
+
+Requirements:
+- LabOne Version >= 22.08
+- 1 SHFQA
+- 1 SHFSG
+- 1 PQSC
+- ZSync connections between the PQSC and the SHFQA and between the PQSC and the SHFSG
+- Loopback connection between input and output of the first channel of the SHFQA
+
+----
+
+Bell states are the simplest examples of entangled states in a two-qubit system, and they are relevant for a multitude of quantum application. For instance, they can be used as an elementary unit of a complex error correction protocol, or be applied in quantum teleportation and quantum cryptography. There are four Bell states, also called maximally entangled states, but in this example we will use for illustrative purposes only one of them: $$|\psi ^{00} \rangle = \frac{|00 \rangle + |11 \rangle}{\sqrt{2}}$$
+
+When talking about Bell states, the concepts of *bit parity* and *phase parity* play an important role: the bit parity of a Bell state is 0 if the qubits appear in the same state and 1 otherwise, while the phase parity refers to the relative phase appearing in the state superposition, being 0 if the phase is 0 and 1 if the phase is $\pi$. The Bell state written above has both bit parity and phase parity equal to 0, and is therefore called $|\psi ^{00} \rangle$. We can also call the bit parity *Z-Z parity* and the phase parity *X-X parity*.
+
+Bell state stabilization is a procedure to preserve a two-qubit system in a Bell state by detecting and correcting possible errors that might have corrupted the state. Real-time stabilization can be achieved using an active feedback loop, which consists of three steps:
+1. Perform bit and phase parity measurement using ancilla qubits to not make the Bell state collapse.
+2. Apply a feedback operation conditioned on the outcome of the parity measurements.
+3. Reset the ancilla qubits to the initial state to start a new round of stabilization.
+
+We will assume that the ancilla qubits are entangled with the data qubits in a way such that measuring the first ancilla gives the value of the bit parity of the Bell state, and measuring the second ancilla gives the value of the phase parity. For more details about how to entangle ancilla and data qubits to achieve this, please refer to [this blog post](https://www.zhinst.com/ch/en/blogs/bell-state-stabilization-superconducting-qubits-real-time-feedback). We will also call the two ancillas "Z ancilla" and "X ancilla" because they measure respectively the Z-Z parity and the X-X parity. If both the parity and the phase are 0, the state is already stabilized; if the bit parity is 1, then a bit flip on one of the two data qubits has occurred, which can be corrected by applying a Z gate to either of the two qubits; if the phase parity is 1, then a phase flip has occurred, which can be corrected by applying a Z gate on either of the two qubits.
+
+In this notebook we show how to perform the readout of the ancilla qubits with the SHFQA, how to apply the conditional gates with the SHFSG and how to use the PQSC to forward the result of the readout from teh SHFQA to the SHFSG.
+
+----
+
+
+## Connect to the devices
+
+
+Create a session with a running Data Server, and then connect the Data Server with the instruments.
+
+```python
+from zhinst.toolkit import Session, SHFQAChannelMode, Waveforms, Sequence, CommandTable
+import pqsc_helpers
+import numpy as np
+import time, textwrap
+```
+
+```python
+shfqa_serial = "DEVXXXX"
+shfsg_serial = "DEVYYYY"
+pqsc_serial = "DEVZZZZ"
+
+session = Session("localhost")
+
+shfqa = session.connect_device(shfqa_serial)
+shfsg = session.connect_device(shfsg_serial)
+pqsc = session.connect_device(pqsc_serial)
+```
+
+## Basic initial setup
+
+
+### Cocks and communications
+Configure clock resources such that the PQSC receives the reference clock by an external source, and then distributes it to the other devices via ZSync connections.
+
+```python
+# PQSC external reference clock
+pqsc.system.clocks.referenceclock.in_.source("external")
+pqsc.check_ref_clock()
+
+# SHFSG and SHFQA ZSync clock
+shfsg.system.clocks.referenceclock.in_.source("zsync")
+shfqa.system.clocks.referenceclock.in_.source("zsync")
+```
+
+### Inputs and outputs
+
+
+Configure the basic settings for the SHFQA and SHFSG inputs and outputs, such as the range and the center frequency. For the PQSC we configure that the trigger signals sent over ZSync are replicated on the trigger output; the trigger output can then be connected to an oscilloscope to visualize the signals.
+
+```python
+# Channels
+QA_CHANNEL = 0
+SG_CHANNEL = "*"  # Wildcard for "all channels"
+
+with session.set_transaction():
+    # SHFQA
+    shfqa.qachannels[QA_CHANNEL].centerfreq(1e9)  # Hz
+    shfqa.qachannels[QA_CHANNEL].input_range=0  # dBm
+    shfqa.qachannels[QA_CHANNEL].output_range=0.0  # dBm
+    shfqa.qachannels[QA_CHANNEL].mode("readout")
+    shfqa.qachannels[QA_CHANNEL].input.on(True)
+    shfqa.qachannels[QA_CHANNEL].output.on(True)
+
+    # SHFSG
+    shfsg.sgchannels[SG_CHANNEL].awg.diozsyncswitch("zsync")
+    shfsg.synthesizers[SG_CHANNEL].centerfreq(1e09)  # Hz
+    shfsg.sgchannels[SG_CHANNEL].output.range(0.0)  # dBm
+    shfsg.sgchannels[SG_CHANNEL].output.on(True)
+
+    # PQSC - Replicate ZSync triggers on trigger output port
+    pqsc.triggers.out[0].enable(True)
+    pqsc.triggers.out[0].source("start_trigger")
+    pqsc.triggers.out[0].port(pqsc_helpers.find_zsync_worker_port(pqsc, shfsg))
+```
+
+```python
+# Sample rate of the SHFQA and SHFSG waveform generator
+SAMPLE_RATE = 2e9
+```
+
+## Configure ancilla qubit readout
+
+The first thing that we have to do is to configure how to perform the readout of the ancilla qubits. For illustrative purposes, in this example we simulate one readout with no errors, one readout with a bit flip error and one readout with a phase flip error, for a total of 3 simulated readouts.
+
+To perform a simulated qubit readout we connect the signal output of the SHFQA to its signal input in a closed loop. We then mimic the qubit state-dependent resonator response by using two different readout pulses for simulating a qubit in state $|0\rangle$ and in state $|1\rangle$. In particular, the two readout pulses will be both sinusoidal, but with a phase difference of 180 degrees so that the results of the integration will be maximally distant on the complex plane. We also set a common global phase $R$ to the pulses in order to have the complex results of the integration lie on the real axis; the value of $R$ that satisfies this can be measured for example with the Measurement Readout Result Tab in the LabOne Web Interface.
+
+```python
+NUM_READOUTS = 3  # Simulate 3 readouts
+READOUT_REGISTER = 0  # Address of PQSC readout register
+```
+
+Define the readout pulses for the two ancillary qubits.
+
+```python
+# Readout pulses parameters
+PULSE_DURATION = 126e-9
+FREQUENCY_Z = 100e6  # Readout frequency for Z ancilla
+FREQUENCY_X = -97e6  # Readout frequency for X ancilla
+ROTATION_ANGLE_Z = np.deg2rad(55)  # Must be measured beforehand
+ROTATION_ANGLE_X = np.deg2rad(55)  # Must be measured beforehand
+
+pulse_len = int(PULSE_DURATION * SAMPLE_RATE)
+time_vec = np.linspace(0, PULSE_DURATION, pulse_len)
+
+# Define and upload waveforms
+# Z ancilla
+wave_0Z = 0.5 * np.exp(2j * np.pi * (FREQUENCY_Z * time_vec) + 1j * ROTATION_ANGLE_Z)
+wave_1Z = 0.5 * np.exp(
+    2j * np.pi * (FREQUENCY_Z * time_vec + 0.5) + 1j * ROTATION_ANGLE_Z
+)
+# X ancilla
+wave_0X = 0.5 * np.exp(2j * np.pi * (FREQUENCY_X * time_vec) + 1j * ROTATION_ANGLE_X)
+wave_1X = 0.5 * np.exp(
+    2j * np.pi * (FREQUENCY_X * time_vec + 0.5) + 1j * ROTATION_ANGLE_X
+)
+
+readout_pulses = Waveforms()
+readout_pulses = Waveforms()
+readout_pulses[0] = wave_0Z
+readout_pulses[1] = wave_1Z
+readout_pulses[2] = wave_0X
+readout_pulses[3] = wave_1X
+shfqa.qachannels[QA_CHANNEL].generator.write_to_waveform_memory(readout_pulses)
+```
+
+Define the integration weights for the readout.
+
+```python
+weights = Waveforms()
+weights[0] = np.conj(np.exp(2j * np.pi * FREQUENCY_Z * time_vec))
+weights[1] = np.conj(np.exp(2j * np.pi * FREQUENCY_X * time_vec))
+
+shfqa.qachannels[QA_CHANNEL].readout.write_integration_weights(
+    weights=weights,
+    # Compensation for the delay between generator output and input
+    # of the integration unit (short cable). This can be measured
+    # experimentally.
+    integration_delay=234e-9,
+)
+```
+
+Configure the result logger to give us either 0 or 1, i.e. to perform state discrimination.
+
+```python
+shfqa.qachannels[QA_CHANNEL].readout.configure_result_logger(
+    result_length=NUM_READOUTS, result_source="result_of_discrimination"
+)
+
+shfqa.qachannels[QA_CHANNEL].readout.discriminators[0].threshold(0.0)
+shfqa.qachannels[QA_CHANNEL].readout.discriminators[1].threshold(0.0)
+```
+
+Finally, we configure the SHFQA to perform three readouts. The first readout should have result 00, simulating no error; the second readout should have result 10, simulating a bit flip error, and the third readout shoudl have result 01, simulating a phase flip error. Each readout starts after receiving a starting trigger over ZSync from the PQSC, and after each readout the result is forwarded to an address of the Readout Register Bank of the PQSC.
+
+We set up the experiment by writing a sequencer program for the SHFQA. In particular, each readout is configured through the arguments of the function `startQA()`; for this experiment the following parameters are particularly relevant: 
+- the first argument of `startQA()` is in the form `QA_GEN_i|QA_GEN_j`, where `i` and `j` are the indices of the waveforms in the waveform memory to be played on the two ancilla qubits. 
+- the second argument of `startQA()` is in the form `QA_INT_i|QA_INT_j`, where `i` and `j` are the indices of the weights in the integration weights memory to be used during integration;
+- the fourth argument of `startQA()` is the address of the PQSC readout register where the result of the readout is sent.
+
+```python
+seqc_program = Sequence()
+
+seqc_program.constants["num_cycles"] = NUM_READOUTS // 3
+seqc_program.constants["READOUT_REGISTER"] = READOUT_REGISTER
+
+seqc_program.code = textwrap.dedent(
+    """\
+    const NO_ERROR = QA_GEN_0|QA_GEN_2;         // Generator mask to simulate no error (outcome 00)
+    const BIT_ERROR = QA_GEN_1|QA_GEN_2;        // Generator mask to simulate bit error (outcome 10)
+    const PHASE_ERROR = QA_GEN_0|QA_GEN_3;      // Generator mask to simulate phase error (outcome 01)
+    const INT_MASK = QA_INT_0|QA_INT_1;         // Integration mask
+
+    repeat(num_cycles) {
+        waitZSyncTrigger();                                         // Wait for start trigger
+        startQA(NO_ERROR, INT_MASK, true, READOUT_REGISTER, 0);     // Generate a readout with no error
+
+        waitZSyncTrigger();
+        startQA(BIT_ERROR, INT_MASK, true, READOUT_REGISTER, 0);    // Simulate readout with bit error
+
+        waitZSyncTrigger();
+        startQA(PHASE_ERROR, INT_MASK, true, READOUT_REGISTER, 0);  // Simulate readout with phase error
+    }
+"""
+)
+shfqa.qachannels[QA_CHANNEL].generator.load_sequencer_program(seqc_program)
+```
+
+## Configure PQSC feedback
+As metioned at the beginning, the PQSC is used to forward the result of the readout to the SHFSG with minimal latency.
+
+The PQSC has a special memory bank called Readout Register Bank, which can store readout results measured by a Quantum Analyzer such as the SHFQA. Then, the data in the Readout Register Bank goes through a feedback pipeline which ends with signals being sent over ZSync outputs to other devices. This feedback pipeline has two modes of operation:
+- *Register forwarding*: the a portion of the Readout Register Bank is directly forwarded as it is to a ZSync output port, without intermediate processing.
+- *Decoder Unit*: the data from the Readout Register Bank is processed in the so-called Decoder Unit and the output of this processing is send to a ZSync output port. The data processing is programmed by configuring a look-up table (LUT).
+
+<u>Note</u>: regardless of the operation mode of the feedback pipeline, the PQSC always sends on the ZSync outputs 4 bits coming from register forwarding and 8 bits coming from the Decoder Unit. It is our task to program the SHFSG to only consider the bits that are relevant for the experiment.
+
+In this experiment we show how to use the Decoder Unit to send to the SHFSG a processed version of the readout results. In particular, the entries of the Decoder look-up table will correspond to the feedback actions to be applied conditioned on the readout results. Since we have two ancilla qubits, there are $2^2 = 4$ possible outcomes of the readout and therefore the look-up table will have 4 entries.
+
+
+Firstly, program the LUT.
+
+```python
+with pqsc.set_transaction():
+    # Source of bit 0 of LUT
+    pqsc.feedback.decoder.lut.sources[0].register(READOUT_REGISTER)
+    pqsc.feedback.decoder.lut.sources[0].index(0)
+    # Source of bit 1 of LUT
+    pqsc.feedback.decoder.lut.sources[1].register(READOUT_REGISTER)
+    pqsc.feedback.decoder.lut.sources[1].index(1)
+    # Output values of LUT
+    lut = np.array([0, 1, 2, 3], dtype=np.uint32)
+    pqsc.feedback.decoder.lut.tables[0](lut)
+```
+
+Then find the index of the ZSync port connected to the SHFSG.
+
+
+And finally enable the Decoder Unit.
+
+```python
+# Find SHFSG ZSync port ID
+shfsg_zsync_port = pqsc_helpers.find_zsync_worker_port(pqsc, shfsg)
+
+with pqsc.set_transaction():
+    # Enable Decoder Unit
+    pqsc.zsyncs[shfsg_zsync_port].output.registerbank.enable(
+        False
+    )  # Disable direct forwarding
+    pqsc.zsyncs[shfsg_zsync_port].output.decoder.enable(True)  # Enable Decoder Unit
+    pqsc.zsyncs[shfsg_zsync_port].output.decoder.source(
+        0,
+    )  # Index of LUT being forwarded
+```
+
+## Configure the SHFSG
+
+
+### Feedback latency
+
+For the last step of the experiment we configure the SHFSG to acquire the data received by the PQSC over ZSync and play a pulse conditioned on the received data. 
+
+The tricky part here is that we have to tell the SHFSG *when* to read the result of the readout on the ZSync connection, but the we don't know a priori when the PQSC will send the result of the readout to the SHFSG. We need therefore a way to find out the so called *feedback latency*, i.e. the latency between the start trigger and the moment when data is sent over the ZSync connection to the SHFSG. 
+
+Zurich Instruments `zhinst-utils` package provides a routine for calculating the feedback latency of a setup according to a model of the feedback system. The only thing that we have to calculate by ourselves and provide as a parameter to the routine is the latency accumulated in the readout (or "QA") stage, which is experiment-specific and therefore cannot be known in advance by the model. Such QA latency must include the integration length and any other delay defined by the user in the SHFQA seqC program before or after the readout.
+
+```python
+from zhinst.utils.feedback_model import (
+    QCCSFeedbackModel,
+    get_feedback_system_description,
+    SGType,
+    QAType,
+    PQSCMode,
+)
+
+# Instantiate the class for the feedback model
+feedback_model = QCCSFeedbackModel(
+    description=get_feedback_system_description(
+        generator_type=SGType.SHFSG,
+        analyzer_type=QAType.SHFQA,
+        pqsc_mode=PQSCMode.DECODER,
+    )
+)
+
+# Calculate the QA delay
+int_len = shfqa.qachannels[QA_CHANNEL].readout.integration.length()
+int_delay = round(
+    shfqa.qachannels[QA_CHANNEL].readout.integration.delay() * SAMPLE_RATE
+)
+qa_delay = int_len + int_delay
+
+# Get the total feedback latency from the model
+feedback_latency = feedback_model.get_latency(qa_delay)
+```
+
+### Define SeqC program and Command Table
+Finally, we configure the error correction pulses that the SHFSG should apply. We have to apply gates both to the data qubits (to correct the errors) and to the ancilla qubits (to reset them in the initial state), for a total of 4 qubits. Therefore, we use 4 AWG cores.
+
+```python
+data_A_awg = shfsg.sgchannels[0].awg
+data_B_awg = shfsg.sgchannels[1].awg
+ancilla_x_awg = shfsg.sgchannels[2].awg
+ancilla_z_awg = shfsg.sgchannels[3].awg
+```
+
+The output of the Decoder Unit sent over ZSync is always an 8-bit number, but the SHFSG will only need to look at the two least significant bits. Even more precisely, each AWG core will have to look at only one of these two bits: for the first data qubit and the Z ancilla only the second least significant bit is relevant, while for the second data qubit and the X ancilla only the least significant bit is relevant. (You can find very clear pictures in [this blog post](https://www.zhinst.com/ch/en/blogs/bell-state-stabilization-superconducting-qubits-real-time-feedback)).
+
+In the following lines we tell each AWG cores which bits to read. We can configure it by telling:
+- if and how to shift the bits
+- which bits to select after the shift: this is done by specifying a mask
+- if and how to apply ad additive offset to the bits (not needed here)
+
+```python
+with shfsg.set_transaction():
+    data_A_awg.zsync.decoder.shift(1)
+    data_A_awg.zsync.decoder.mask(0b1)
+    data_A_awg.zsync.decoder.offset(0)
+
+    data_B_awg.zsync.decoder.shift(0)
+    data_B_awg.zsync.decoder.mask(0b1)
+    data_B_awg.zsync.decoder.offset(0)
+
+    ancilla_x_awg.zsync.decoder.shift(1)
+    ancilla_x_awg.zsync.decoder.mask(0b1)
+    ancilla_x_awg.zsync.decoder.offset(0)
+
+    ancilla_z_awg.zsync.decoder.shift(0)
+    ancilla_z_awg.zsync.decoder.mask(0b1)
+    ancilla_z_awg.zsync.decoder.offset(0)
+```
+
+Lastly, we write the sequencer program and the command table for the SHFSG. With the following instruction:
+
+`executeTableEntry(ZSYNC_DATA_PQSC_DECODER, feedback_latency);`
+
+The Decoder data will be read after waiting for the feedback latency, and it will be directly forwarded to the command table without going through the sequencer. The command table will then execute the table entry corresponding to the bit read from the Decoder data. For illustrative purposes, to distinguish between X gate and Z gate we define two sequencer programs that differ only for the duration of the pulse. 
+
+```python
+seqc_X = Sequence()
+
+# Contants
+constants = {
+    "NUM_READOUTS": NUM_READOUTS,
+    "feedback_latency": feedback_latency,
+}
+seqc_X.constants = constants
+
+# Waveform
+seqc_X.waveforms = Waveforms()
+seqc_X.waveforms[0] = 1.0 * np.ones(128)  # Short pulse = X gate
+
+# Code
+seqc_X.code = textwrap.dedent(
+    """\
+    repeat(NUM_READOUTS) {
+        waitZSyncTrigger();
+        executeTableEntry(ZSYNC_DATA_PQSC_DECODER, feedback_latency);
+    }
+"""
+)
+```
+
+```python
+seqc_Z = Sequence()
+
+seqc_Z.constants = constants
+
+# Waveform
+seqc_Z.waveforms = Waveforms()
+seqc_Z.waveforms[0] = 1.0 * np.ones(256)  # Long pulse = Z gate
+
+# Code
+seqc_Z.code = textwrap.dedent(
+    """\
+    repeat(NUM_READOUTS) {
+        waitZSyncTrigger();
+        executeTableEntry(ZSYNC_DATA_PQSC_DECODER, feedback_latency);
+    }
+"""
+)
+```
+
+Command Table. Here every qubit will need the same command table, so we only write one command table and we will then upload it to every AWG core.
+
+```python
+ct_schema = shfsg.sgchannels[0].awg.commandtable.load_validation_schema()
+ct = CommandTable(ct_schema)
+
+# Play a zero pulse (here 0.2 just for better visualization)
+ct.table[0].waveform.index = 0
+ct.table[0].amplitude00.value = 0.2
+ct.table[0].amplitude01.value = -0.2
+ct.table[0].amplitude10.value = 0.2
+ct.table[0].amplitude11.value = 0.2
+
+# Play a one pulse (here 0.5 just for better visualization)
+ct.table[1].waveform.index = 0
+ct.table[1].amplitude00.value = 1.0
+ct.table[1].amplitude01.value = -1.0
+ct.table[1].amplitude10.value = 1.0
+ct.table[1].amplitude11.value = 1.0
+```
+
+Upload the sequencer program, the waveform and the command table to each AWG core.
+
+```python
+with shfsg.set_transaction():
+    # Apply X gate on data qubit A and on the ancilla qubits
+    for awg_core in [data_A_awg, ancilla_x_awg, ancilla_z_awg]:
+        awg_core.load_sequencer_program(seqc_X)
+        awg_core.write_to_waveform_memory(seqc_X.waveforms)
+        awg_core.commandtable.upload_to_device(ct)
+
+    # Apply Z gate on data qubit B
+    data_B_awg.load_sequencer_program(seqc_Z)
+    data_B_awg.write_to_waveform_memory(seqc_Z.waveforms)
+    data_B_awg.commandtable.upload_to_device(ct)
+```
+
+## Run experiment
+
+```python
+# Use the RT Logger to print a nice log of all the ZSync signals arriving to the SHFSG
+import rtlogger_helpers
+
+for awg_core in [data_A_awg, data_B_awg, ancilla_x_awg, ancilla_z_awg]:
+    rtlogger_helpers.reset_and_enable_rtlogger(awg_core.rtlogger)
+
+# Enable SHFQA readout
+shfqa.qachannels[QA_CHANNEL].readout.result.enable(True)
+
+# Enable the AWG cores
+for awg_core in [data_A_awg, data_B_awg, ancilla_x_awg, ancilla_z_awg]:
+    awg_core.enable_sequencer(single=True)
+
+shfqa.qachannels[QA_CHANNEL].generator.enable(True, deep=True)
+
+# Send start triggers
+pqsc.arm_and_run(repetitions=NUM_READOUTS, holdoff=4e-6)
+
+for awg_core in [data_A_awg, data_B_awg, ancilla_x_awg, ancilla_z_awg]:
+    awg_core.wait_done()
+```
+
+```python
+print("------------------------------- Data qubit A -------------------------------")
+rtlogger_helpers.print_rtlogger_data(session, data_A_awg)
+print("------------------------------- Data qubit B -------------------------------")
+rtlogger_helpers.print_rtlogger_data(session, data_B_awg)
+print("----------------------------- Ancilla qubit X ------------------------------")
+rtlogger_helpers.print_rtlogger_data(session, ancilla_x_awg)
+print("----------------------------- Ancilla qubit Z ------------------------------")
+rtlogger_helpers.print_rtlogger_data(session, ancilla_z_awg)
+```

--- a/examples/pqsc_helpers.py
+++ b/examples/pqsc_helpers.py
@@ -1,0 +1,32 @@
+import zhinst.toolkit.driver.devices as devices
+from zhinst.toolkit.driver.devices.pqsc import PQSC
+
+
+def find_zsync_worker_port(pqsc: PQSC, device: devices.DeviceType) -> int:
+    """Find the ID of the PQSC ZSync port connected to a given device.
+
+    Args:
+        pqsc: PQSC device over whose ports the research shall be done.
+        device: device for which the connected ZSync port shall be found.
+
+    Returns:
+        Integer value represent the ID of the searched PQSC Zsync port.
+
+    """
+    node_to_serial_dict = pqsc.zsyncs["*"].connection.serial()
+    serial_to_node_dict = {v: k for k, v in node_to_serial_dict.items()}
+    device_serial = device.serial[3:]
+    # Get the node of the ZSync connected to the device
+    # (will have the form "/devXXXX/zsyncs/N/connection/serial")
+    try:
+        device_zsync_node = serial_to_node_dict[device_serial]
+    except KeyError:
+        raise Exception(
+            f"No ZSync connection found between the PQSC {pqsc.serial} and the device {device.serial}."
+        )
+    # Just interested in knowing N: split in
+    # ['', 'devXXXX', 'zsyncs', 'N', 'connection', 'serial']
+    # and take fourth value
+    device_zsync_port = int(device_zsync_node.split("/")[3])
+
+    return device_zsync_port

--- a/examples/repeat_until_success.md
+++ b/examples/repeat_until_success.md
@@ -1,0 +1,486 @@
+---
+jupyter:
+  jupytext:
+    formats: ipynb,md
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.14.1
+  kernelspec:
+    display_name: toolkit
+    language: python
+    name: python3
+---
+
+# Repeat-until-success
+
+This tutorial shows how to perform a repeat-until-success experiment with real-time feedback using Zurich Instruments PQSC, SHFQA and SHFSG devices.
+
+Repeat-until-success is a procedure to obtain a desired quantum state by repeatedly performing a sequence of gates on the qubits and then measuring their state, until the qubits are measured in the desired state. 
+
+In this example we illustrate a very simple case of repeat-until-success, in which we repeatedly measure the state of a qubit until we we find it to be in the 1 state. In particular, we show how to perform real-time feedback of the measurement outcomes and how to engineer the timing of the experiment.
+
+Requirements:
+- LabOne Version >= 22.08
+- 1 SHFQA
+- 1 SHFSG
+- 1 PQSC
+- ZSync connections between the PQSC and the SHFQA and between the PQSC and the SHFSG
+- Loopback connection between input and output of the first channel of the SHFQA
+----
+
+
+```python
+from zhinst.toolkit import Session, SHFQAChannelMode, Waveforms, Sequence, CommandTable
+import pqsc_helpers
+from zhinst.toolkit.waveform import Wave
+import numpy as np
+import time, textwrap
+```
+
+## Connect to the devices
+
+
+Create a session with a running Data Server, and then connect the Data Server with the instruments.
+
+```python
+shfqa_serial = "DEVXXXX"
+shfsg_serial = "DEVYYYY"
+pqsc_serial = "DEVZZZZ"
+
+session = Session("localhost")
+
+shfqa = session.connect_device(shfqa_serial)
+shfsg = session.connect_device(shfsg_serial)
+pqsc = session.connect_device(pqsc_serial)
+```
+
+## Basic initial setup
+
+
+### Cocks and communications
+Configure clock resources such that the PQSC receives the reference clock by an external source, and then distributes it to the other devices via ZSync connections.
+
+```python
+# PQSC external reference clock
+pqsc.system.clocks.referenceclock.in_.source("external")
+pqsc.check_ref_clock()
+
+# SHFSG and SHFQA ZSync clock
+shfsg.system.clocks.referenceclock.in_.source("zsync")
+shfqa.system.clocks.referenceclock.in_.source("zsync")
+```
+
+### Inputs and outputs
+
+
+Configure the basic settings for the SHFQA and SHFSG inputs and outputs, such as the range and the center frequency. For the PQSC we configure that the trigger signals sent over ZSync are replicated on the trigger output; the trigger output can then be connected to an oscilloscope to visualize the signals.
+
+```python
+# Default channels
+QA_CHANNEL = 0
+SG_CHANNEL = 0
+
+with session.set_transaction():
+    # SHFQA
+    shfqa.qachannels[QA_CHANNEL].centerfreq(1e9)  # Hz
+    shfqa.qachannels[QA_CHANNEL].input_range=0  # dBm
+    shfqa.qachannels[QA_CHANNEL].output_range=0.0  # dBm
+    shfqa.qachannels[QA_CHANNEL].mode("readout")
+    shfqa.qachannels[QA_CHANNEL].input.on(True)
+    shfqa.qachannels[QA_CHANNEL].output.on(True)
+
+    # SHFSG
+    shfsg.sgchannels[SG_CHANNEL].awg.diozsyncswitch("zsync")
+    shfsg.synthesizers[SG_CHANNEL].centerfreq(1e09)  # Hz
+    shfsg.sgchannels[SG_CHANNEL].output.range(0.0)  # dBm
+    shfsg.sgchannels[SG_CHANNEL].output.on(True)
+
+    # PQSC - Replicate ZSync triggers on trigger output port
+    pqsc.triggers.out[0].enable(True)
+    pqsc.triggers.out[0].source("start_trigger")
+    pqsc.triggers.out[0].port(pqsc_helpers.find_zsync_worker_port(pqsc, shfsg))
+```
+
+```python
+# Sample rate of the SHFQA and SHFSG waveform generator
+SAMPLE_RATE = 2e9
+
+# Conversion factor from clock cycles to samples for SHFSG
+CLOCK_TO_SAMPLE_SG = 8
+```
+
+## Configure readout pulses and weights
+
+The first thing that we have to do is to configure how to perform the readout of the qubit. For illustrative purposes, in this example we simulate three readouts, of which the first two are failures (readout result 0) and the last one is a success (readout result 1).
+
+To perform a simulated qubit readout we connect the signal output of the SHFQA to its signal input in a closed loop. We then mimic the qubit state-dependent resonator response by using two different readout pulses for simulating a qubit in state $|0\rangle$ and in state $|1\rangle$. In particular, the two readout pulses will be both sinusoidal, but with a phase difference of 180 degrees so that the results of the integration will be maximally distant on the complex plane. We also set a common global phase $R$ to the pulses in order to have the complex results of the integration lie on the real axis; the value of $R$ that satisfies this can be measured for example with the Measurement Readout Result Tab in the LabOne Web Interface.
+
+```python
+SIMULATED_FAILURES = 2
+```
+
+Define the readout pulses for the two ancillary qubits.
+
+```python
+# Readout pulses parameters
+PULSE_DURATION = 126e-9
+FREQUENCY = 100e6  # Readout frequency
+ROTATION_ANGLE = np.deg2rad(55)  # Must be measured beforehand
+
+pulse_len = int(PULSE_DURATION * SAMPLE_RATE)
+time_vec = np.linspace(0, PULSE_DURATION, pulse_len)
+
+# Define and upload waveforms
+wave_0 = 0.5 * np.exp(2j * np.pi * (FREQUENCY * time_vec) + 1j * ROTATION_ANGLE)
+wave_1 = 0.5 * np.exp(2j * np.pi * (FREQUENCY * time_vec + 0.5) + 1j * ROTATION_ANGLE)
+
+readout_pulses = Waveforms()
+readout_pulses[0] = wave_0
+readout_pulses[1] = wave_1
+
+shfqa.qachannels[QA_CHANNEL].generator.write_to_waveform_memory(readout_pulses)
+```
+
+Define the integration weights for the readout.
+
+```python
+# Integration unit of the SHFQA
+INT_UNIT = 0
+
+weights = Waveforms()
+weights[INT_UNIT] = np.conj(np.exp(2j * np.pi * FREQUENCY * time_vec))
+
+shfqa.qachannels[QA_CHANNEL].readout.write_integration_weights(
+    weights=weights,
+    # Compensation for the delay between generator output and input
+    # of the integration unit (short cable). This can be measured
+    # experimentally, for example using the Scope of the SHFQA.
+    integration_delay=234e-9,
+)
+```
+
+Configure the result logger to give us either 0 or 1, i.e. to perform state discrimination.
+
+```python
+shfqa.qachannels[QA_CHANNEL].readout.configure_result_logger(
+    result_length=SIMULATED_FAILURES, result_source="result_of_discrimination"
+)
+
+shfqa.qachannels[QA_CHANNEL].readout.discriminators[INT_UNIT].threshold(0.0)
+```
+
+## Configure the feedback
+
+In the following part of the example we actually describe the steps of the experiment and, most importantly, their timing. 
+
+The experiment will run as follows:
+1. the PQSC sends a start trigger to the instruments to signal the beginning of the experiment;
+2. the SHFSG plays a pulse indicating that a "try" segment is starting. Let us call this `try pulse`;
+3. the SHFQA performs a readout and then sends the result to the PQSC readout register bank via ZSync;
+4. the PQSC forwards the result to the SHFSG via ZSync with minimal latency;
+5. the SHFSG plays a different "success" pulse if the readout result was 1 (success), otherwise it starts again from step 2.
+
+Steps 2-5 are thus repeated until a success event happens. For illustrative purposes, in this example we simulate 2 failures (qubit measured in 0 state) and a final success (qubit measured in 1 state), but of course in a real experiment points 2-4 would be repeated indefinitely until a success happens.
+
+
+### Calculate feedback latency and create timing grid
+
+A crucial aspect of the experiment is the timing of the operations. In particular, there are two timing requirements that we should consider:
+- at each iteration, the SHFQA should wait that the SHFSG has finished playing the try pulse, before starting the readout;
+- after playing the try pulse the SHFSG must that new readout result is available on its ZSync input port, before reading it and doing the following actions;
+
+The first timing requirement is easily fulfillable: given that the try pulse has length `WAVEFORM_TRY_LEN`, we can delay the SHFQA readout by using the seqC instruction `playZero(WAVEFORM_TRY_LEN)` before starting the readout. 
+
+With respect to the second timing requirement, we use the seqC instruction `getFeedback` to read the readout result. This instruction takes as a parameter the delay (measured from the last start trigger) that the instrument should wait before reading the readout result. Our task is hence to estimate how long this delay should be and then provide it to the instrument through `getFeedback`. How do we estimate the right delay?
+
+We call *feedback latency* the amount of time between the initial start trigger and the moment when the readout is available on the SHFSG ZSync input port. This latency depends on the time it takes to the Quantum Analyzer to complete the readout, but also on the time it takes for the result to go to the PQSC, be processed and then be sent to the SHFSG. The package `zhinst-utils` offers the class `QCCSFeedbackModel` which, given a description of the experiment setup, has a method `get_latency()` that calculates the feedback latency based on a model of the feedback system. The only argument that we have to provide to `get_latency()` is the latency accumulated by the operations in the Quantum Analyzer during the readout, which is experiment-specific and therefore cannot be known in advance by the model. We refer to this latency as `qa_delay`, and it includes for example the integration length or any other user-defined delays before the integration. 
+
+So we can calculate the feedback latency with the model and then tell the SHFSG to wait for an amount of time equal to the feedback latency, before reading the readout result on ZSync.
+
+But what about the iterations other than the first one? The delay to be waited that we pass to the seqC instruction `getFeedback` must always be measured starting from the initial start trigger. Hence, we would have to recalculate the feedback latency at each iteration to include the latency of all the previous cycles. However, we can take advantage of a fact regarding the feedback latency calculated by the model: 
+
+`get_latency(qa_delay + N*200 ns) = get_latency(qa_delay) + N*200 ns`
+
+with `N` integer. In other terms, if and only if the duration of one try cycle is an integer multiple of 200 ns (i.e. `N*200 ns`), then the new feedback latency at each iteration will be equal to the old feedback latency of the previous cycle plus the duration of a cycle! What does this imply? If we engineer the cycles in oder to last an integer multiple of 200 ns, we can avoid recalculating the feedback latency with the model at each iteration, and be much faster.
+
+This may sound complicated at first, so let's have a look at the code.
+
+
+As first thing we instantiate `QCCSFeedbackModel`, calculate `qa_delay` and the feedback latency of the first iteration.
+
+```python
+from zhinst.utils.feedback_model import (
+    QCCSFeedbackModel,
+    get_feedback_system_description,
+    SGType,
+    QAType,
+    PQSCMode,
+)
+
+# Instantiate the class
+feedback_model = QCCSFeedbackModel(
+    description=get_feedback_system_description(
+        generator_type=SGType.SHFSG,
+        analyzer_type=QAType.SHFQA,
+        pqsc_mode=PQSCMode.DECODER,
+    )
+)
+
+# Length of the "try" waveform played by the SHFSG
+WAVEFORM_TRY_LEN = 128
+
+# Delay in the QA stage
+# Look at the sequencer code below to match the delays
+int_start = (
+    8 + WAVEFORM_TRY_LEN
+)  # `playZero(waveform_try)` also includes 8 additional clock cycles
+int_len = shfqa.qachannels[QA_CHANNEL].readout.integration.length()
+int_delay = round(
+    shfqa.qachannels[QA_CHANNEL].readout.integration.delay() * SAMPLE_RATE
+)
+
+qa_delay = int_start + int_len + int_delay
+
+# Total feedback latency in the first iteration
+feedback_latency = feedback_model.get_latency(qa_delay)
+```
+
+And now we enforce the duration of one SHFQA iteration to be a multiple of 200 ns. In technical jargon, we say that we create a *timing grid* with a spacing of 200 ns.
+
+```python
+GRID_SPACING = 200e-9
+# Number of samples in 200 ns
+grid_samples = SAMPLE_RATE * GRID_SPACING
+
+# Number of clock cycles needed for evaluating while condition (found empirically)
+LOOP_OVERHEAD = 8
+# Duration of one iteration, expressed in number samples
+cycle_len_samples = (feedback_latency + LOOP_OVERHEAD) * CLOCK_TO_SAMPLE_SG
+
+# Increase the length of one cycle to reach the closest integer multiple of `grid_samples`
+cycle_len_samples = int(np.ceil(cycle_len_samples / grid_samples) * grid_samples)
+# Express the duration in clock cycles again (needed in the seqc program)
+cycle_len_clocks = cycle_len_samples // CLOCK_TO_SAMPLE_SG
+
+# Subtract the length of the `try` waveform to get the length of the `startQA` section
+section_len = cycle_len_samples - WAVEFORM_TRY_LEN
+```
+
+## SHFQA sequencer program
+
+
+Now instruct the SHFQA on what it should do and with which timing, by writing the instructions in a sequencer program. In particular, we tell the SHFQA to:
+1. Stay silent for `WAVEFORM_TRY_LEN` samples, while the SHFSG plays the "try" waveform;
+2. Start a section with a duration `section_len`, previously calculated such that `section_len + WAVEFORM_TRY_LEN` is an integer multiple of 200 ns;
+3. During this section, perform the readout with `startQA` and forward the result of the readout to the PQSC readout register bank address specified by `READOUT_REGISTER`;
+4. Update the feedback time for the next iteration.
+These steps are repeated for `SIMULATED_FAILURES` times simulating a readout with result 0. Then we simulate an additional readout with result 1.
+
+<u>Note 1</u>:
+Instructions about the readout are provided through the arguments of the function `startQA()`; for this experiment the following parameters are particularly relevant: 
+- the first argument of `startQA()` is in the form `QA_GEN_i`, where `i` is the index of the waveform in the waveform memory to be played;
+- the second argument of `startQA()` is in the form `QA_INT_i`, where `i` is the index of the weight in the integration weights memory to be used during integration;
+- the fourth argument of `startQA()` is the address of the PQSC readout register where the result of the readout is sent.
+
+<u>Note 2</u>: the way to force the duration of the readout section to be `section_len` is to execute a `playZero(section_len)` before `startQA`. This may seem confusing at first, but the reason why this works is that `playZero` can run in parallel with a `startQA` and will only block other `playZero`. In practice, this will force the duration of the readout section to be `section_len`.
+
+```python
+READOUT_REGISTER = 0  # Address of PQSC readout register
+
+seqc_program_shfqa = Sequence()
+
+# Assign constants
+constants = {
+    "feedback_latency": feedback_latency,
+    "SIMULATED_FAILURES": SIMULATED_FAILURES,
+    "cycle_len_clocks": cycle_len_clocks,
+    "READOUT_REGISTER": READOUT_REGISTER,
+    "WAVEFORM_TRY_LEN": WAVEFORM_TRY_LEN,
+    "section_len": section_len,
+}
+seqc_program_shfqa.constants = constants
+
+seqc_program_shfqa.code = textwrap.dedent(
+    """\
+    var success;
+    var feedback_time = feedback_latency;
+    var remaining_failures = SIMULATED_FAILURES;
+
+    waitZSyncTrigger();
+
+    // Simulate failures
+    do {
+        playZero(WAVEFORM_TRY_LEN);                                 // Do nothing while SHFSG plays "try" waveform
+        playZero(section_len);                                      // Define the duration of the startQA section
+        startQA(QA_GEN_0, QA_INT_0, true, READOUT_REGISTER, 0);     // Simulate readout = 0
+
+        success = getFeedback(ZSYNC_DATA_RAW, feedback_time);       // Result of the readout
+        feedback_time += cycle_len_clocks;                          // Update feedback time for next iteration
+        remaining_failures -= 1;
+    } while (remaining_failures);
+
+    // Final try (success)
+    playZero(WAVEFORM_TRY_LEN);
+    playZero(section_len);
+    startQA(QA_GEN_1, QA_INT_0, true, READOUT_REGISTER, 0);
+
+    success = getFeedback(ZSYNC_DATA_RAW, feedback_time);
+    feedback_time += cycle_len_clocks;
+"""
+)
+shfqa.qachannels[QA_CHANNEL].generator.load_sequencer_program(seqc_program_shfqa)
+```
+
+## Configure PQSC
+As metioned earlier, the PQSC is used to forward the result of the readout to the SHFSG with minimal latency.
+
+The PQSC has a special memory bank called Readout Register Bank, which can store readout results measured by a Quantum Analyzer such as the SHFQA. Then, the data in the Readout Register Bank goes through a feedback pipeline which ends with signals being sent over ZSync outputs to other devices. This feedback pipeline has two modes of operation:
+- *Register forwarding*: a portion of the Readout Register Bank is directly forwarded as it is to a ZSync output port, without intermediate processing.
+- *Decoder Unit*: the data from the Readout Register Bank is processed in the so-called Decoder Unit and the output of this processing is sent to a ZSync output port. The data processing is programmed by configuring a look-up table.
+
+<u>Note</u>: regardless of the operation mode of the feedback pipeline, the PQSC always sends on the ZSync outputs 4 bits coming from register forwarding and 8 bits coming from the Decoder Unit. It is our task to program the SHFSG to only consider the bits that are relevant for the experiment.
+
+In this experiment we show how to use the Decoder Unit to send to the SHFSG a processed version of the readout results. In particular, we want the PQSC to send to the SHFSG the value 1 if the readout result was 0, and to send the value 0 if the readout result was 1. In this way the ZSync output value represents the happening of a failures rather than a success: let us call this value `failure`, as we will do later in the SHFSG sequencer program. The advantage of having a variable represeting this is that we directly do the loop "repeat-until-success" using this variable as an iterator with `while(failure)`. If we instead did register forwarding we would have a variable (let us imagine calling it `success`) representing whether a success has happened, and we would have to write the loop as `while(!success)`, which takes up more time that `while(failure)` because of the NOT operation. In other words, in this experiment we use the Decoder Unit to optimize the performance.
+
+
+
+Firstly, configure the lookup table. Since we only want to forward one bit, we only configure bit 0 of the LUT.
+
+```python
+# Enable look-up table (LUT)
+with pqsc.set_transaction():
+    pqsc.feedback.decoder.lut.sources[0].register(
+        READOUT_REGISTER
+    )  # Source register for bit 0 of LUT
+    pqsc.feedback.decoder.lut.sources[0].index(
+        INT_UNIT
+    )  # Source bit in READOUT_REGISTER for bit 0 of LUT
+    lut = np.array([1, 0], dtype=np.uint32)  # LUT[0] -> 1 and LUT[1] -> 0
+    pqsc.feedback.decoder.lut.tables[0](lut)
+```
+
+Finally, enable the Decoder.
+
+```python
+# Find SHFSG and SHFQA ZSync port IDs
+import pqsc_helpers
+
+shfsg_zsync_port = pqsc_helpers.find_zsync_worker_port(pqsc, shfsg)
+shfqa_zsync_port = pqsc_helpers.find_zsync_worker_port(pqsc, shfqa)
+
+with pqsc.set_transaction():
+    for zsync_port in [shfsg_zsync_port, shfqa_zsync_port]:
+        pqsc.zsyncs[zsync_port].output.registerbank.enable(
+            False
+        )  # Disable direct forwarding
+        pqsc.zsyncs[zsync_port].output.decoder.enable(True)  # Enable Decoder
+        pqsc.zsyncs[zsync_port].output.decoder.source(0)  # LUT index being forwarded
+```
+
+## SHFSG sequencer program
+
+The only part still missing is the configuration of the SHFSG. In the following sequencer program we tell the SHFSG to:
+1. Play a "try" waveform at the beginning of each iteration
+2. Stay silent for `section_len`, previously calculated such that `section_len + WAVEFORM_TRY_LEN` corresponds to an integer multiple of 200 ns;
+3. Acquire the feedback value sent by the PQSC over ZSync, waiting a time `feedback_time` with respect to the initial start trigger;
+4. Update the feedback time for the next ieration.
+
+We repeat these steps as long as the the feedback value received by the PQSC (which we call `failure`) is 1. When `failure` is 0 the while loop ends and the SHFSG will play a "success" pulse, with half the amplitude and double the duration with respect to the "try" waveform.
+
+```python
+seqc_program_shfsg = Sequence()
+
+constants = {
+    "feedback_latency": feedback_latency,
+    "cycle_len_clocks": cycle_len_clocks,
+    "WAVEFORM_TRY_LEN": WAVEFORM_TRY_LEN,
+    "section_len": section_len,
+}
+seqc_program_shfsg.constants = constants
+
+seqc_program_shfsg.waveforms = Waveforms()
+seqc_program_shfsg.waveforms[0] = Wave(1.0 * np.ones(WAVEFORM_TRY_LEN), name="w_try")
+seqc_program_shfsg.waveforms[1] = Wave(
+    0.5 * np.ones(WAVEFORM_TRY_LEN * 2), name="w_success"
+)
+
+seqc_program_shfsg.code = textwrap.dedent(
+    """\
+    var failure;
+    var feedback_time = feedback_latency;
+
+    var cnt_failures = 0;                                                   // Counter for number of failures
+    var cnt_try = 0;                                                        // Counter for total number of "try"
+
+    waitZSyncTrigger();
+
+    do {
+        playWave(w_try);                                                    // Play "try" pulse
+        playZero(section_len);                                              // Define next section length
+    
+        failure = getFeedback(ZSYNC_DATA_PQSC_DECODER, feedback_time);      // Acquire feedback value from PQSC
+        feedback_time += cycle_len_clocks;                              // Update feedback latency for following cycle
+
+        cnt_failures += failure;                                            // Update counters
+        cnt_try += 1;
+    } while (failure);
+
+    // Success pulse
+    playWave(w_success);
+
+    setUserReg(0, cnt_failures);                                            // Save counters to user register to check them later
+    setUserReg(1, cnt_try);
+"""
+)
+shfsg.sgchannels[SG_CHANNEL].awg.load_sequencer_program(seqc_program_shfsg)
+shfsg.sgchannels[SG_CHANNEL].awg.write_to_waveform_memory(seqc_program_shfsg.waveforms)
+```
+
+The PQSC sends up to four qubit states at the same time. Configure the SHFSG to look only at the one interesting for us, i.e. the least significant one.
+
+```python
+with shfsg.set_transaction():
+    shfsg.sgchannels[SG_CHANNEL].awg.zsync.decoder.shift(0)
+    shfsg.sgchannels[SG_CHANNEL].awg.zsync.decoder.mask(0b1)
+    shfsg.sgchannels[SG_CHANNEL].awg.zsync.decoder.offset(0)
+```
+
+## Run the experiment
+
+
+We can finally put all the pieces together and run the experiment: enable the readout, the SHFSG awg sequencer, the SHFQA readout pulse generator and finally send the start triggers with the PQSC.
+
+```python
+import rtlogger_helpers
+
+rtlogger_helpers.reset_and_enable_rtlogger(shfsg.sgchannels[SG_CHANNEL].awg.rtlogger)
+
+shfqa.qachannels[QA_CHANNEL].readout.result.enable(True)
+shfsg.sgchannels[SG_CHANNEL].awg.enable_sequencer(single=True)
+shfqa.qachannels[QA_CHANNEL].generator.enable(True, deep=True)
+
+pqsc.arm_and_run(repetitions=1, holdoff=100e-3)
+```
+
+To check that everything was correct we print the values of `cnt_failures` and `cnt_try` previously saved in the SHFSG user register. We also print the data collected by the RT Logger, which is a tool for logging data received over ZSync. Data with timestamp 0 correspond to start trigger events; the column "decoder data" shows the data coming from the Decoder Unit of the PQSC.
+
+```python
+print(
+    "Accumulated data: ",
+    shfsg.sgchannels[SG_CHANNEL].awg.userregs[0](deep=True)[1],
+    " - Expected accumulated data: ",
+    SIMULATED_FAILURES,
+)
+print(
+    "Counter executions: ",
+    shfsg.sgchannels[SG_CHANNEL].awg.userregs[1](deep=True)[1],
+    " - Expected counter executions: ",
+    SIMULATED_FAILURES + 1,
+)
+```
+
+```python
+rtlogger_helpers.print_rtlogger_data(session, shfsg.sgchannels[SG_CHANNEL].awg)
+```

--- a/examples/rtlogger_helpers.py
+++ b/examples/rtlogger_helpers.py
@@ -1,0 +1,106 @@
+from zhinst.toolkit import Session
+from zhinst.toolkit.nodetree import Node
+from zhinst.toolkit.driver.nodes.awg import AWG
+from zhinst.core.errors import CoreError
+
+
+def reset_and_enable_rtlogger(rtlogger: Node) -> None:
+    """Reset and start a given RT Logger.
+
+    Args:
+        rtlogger: RT Logger node.
+
+    """
+    rtlogger.clear(True)
+    rtlogger.mode(0)  # Start with first trigger
+    try:
+        rtlogger.input(
+            0
+        )  # Zsync input selected by diozsyncswitch node, set here to DIO
+    except CoreError:
+        pass  # Absent on HDAWG
+    rtlogger.enable(True, deep=True)
+
+
+def _get_trigdelay(session: Session, awg: AWG) -> int:
+    """Get the ZSync trigger delay.
+
+    Note: this function makes use of a raw node; raw nodes are usually meant for
+    internal purposes only, they are not documented and their existence is not
+    guaranteed in future releases. This function is intended for illustrative
+    purposes only and raw nodes should not be used by customers.
+
+    Args:
+        session: Toolkit session to a data server.
+        awg: AWG node.
+
+    Returns:
+        The delay of the ZSync trigger, in clock cycles.
+
+    """
+    awg_split = str(awg).split("/")  # Split into list
+    awg_split.insert(2, "raw")
+    awg_split.append("zsync")
+    awg_split.append("trigdelay")
+    trigdelay_node = "/".join(awg_split)  # Join again into node path
+    return session.daq_server.getInt(trigdelay_node)
+
+
+def print_rtlogger_data(
+    session: Session,
+    awg: AWG,
+    compensate_start_trigger: bool = True,
+    max_lines: int = None,
+) -> None:
+    """Print the data collected by the RT Logger.
+
+    Args:
+        session: Toolkit session to a data server.
+        awg: AWG node
+        compensate_start_trigger: True if the start trigger delay should
+            be compensated for.
+        max_lines: Maximum number of lines to be printed.
+
+    """
+    rtlogger = awg.rtlogger
+    rtdata = rtlogger.data()
+    timebase = rtlogger.timebase()
+
+    reg_shift = awg.zsync.register.shift()
+    reg_mask = awg.zsync.register.mask()
+    reg_offset = awg.zsync.register.offset()
+
+    dec_shift = awg.zsync.decoder.shift()
+    dec_mask = awg.zsync.decoder.mask()
+    dec_offset = awg.zsync.decoder.offset()
+
+    trig_delay = _get_trigdelay(session, awg)
+    base_ts = 0
+
+    max_lines = len(rtdata) // 2 if max_lines is None else max_lines
+
+    print("t[clk]\tt[us]\tdata\tdata binary\t\tregister data\tdecoder data")
+    for i in range(max_lines):
+
+        # raw data
+        data = rtdata[2 * i + 1]
+
+        if compensate_start_trigger:
+            # start trigger, reset timestamp
+            if data == 0xFFFF:
+                base_ts = rtdata[2 * i]
+                ts = 0
+            else:
+                ts = int(rtdata[2 * i] - base_ts - trig_delay)
+        else:
+            ts = rtdata[2 * i]
+
+        # calculate data after transformation
+        reg_data_raw = (int(data) >> 8) & 0xF
+        register_data = ((reg_data_raw >> reg_shift) & reg_mask) + reg_offset
+        dec_data_raw = int(data) & 0xFF
+        decoder_data = ((dec_data_raw >> dec_shift) & dec_mask) + dec_offset
+
+        print(
+            f"{ts:<7d}\t{ts*timebase*1e6:.3f}\t{data:<5d}\t0b{data:016b}\t{register_data:<5d}\t\t{decoder_data:<5d}"
+        )

--- a/examples/test.spec.yml
+++ b/examples/test.spec.yml
@@ -1,5 +1,11 @@
+active_qubit_reset:
+  skip: True
+
 awg:
   device_type: "HDAWG8"
+
+bell_state_stabilization:
+  skip: True
 
 daq_module:
   device_type: ["MFLI", "UHFLI"]
@@ -24,6 +30,9 @@ nodetree:
 
 pid_advisor_module:
   device_type: ["MFLI"]
+
+repeat_until_success:
+  skip: True
 
 scope_module:
   device_type: ["MFLI", "UHFLI"]

--- a/tests/test_example_config.py
+++ b/tests/test_example_config.py
@@ -26,6 +26,10 @@ def test_example_config():
             example_name in test_spec
         ), f'Example "{example_name}" was not included in the configuration file.'
 
+        # If test has to be skipped, return
+        if "skip" in test_spec[example_name] and test_spec[example_name]["skip"]:
+            return
+
         # Check that it has the device id specified
         assert (
             "device_type" in test_spec[example_name]

--- a/tests/test_examples_regex_match.py
+++ b/tests/test_examples_regex_match.py
@@ -1,6 +1,7 @@
 import pathlib
 import re
 import pytest
+import yaml
 
 
 EXAMPLES_PATH = pathlib.Path("examples")
@@ -31,10 +32,15 @@ def get_markdown_files() -> pathlib.Path:
         The path to a markdown file.
 
     """
+    with open(EXAMPLES_PATH / "test.spec.yml", "rb") as f:
+        test_spec = yaml.load(f, Loader=yaml.Loader)
+
     md_list = EXAMPLES_PATH.glob("*.md")
     for md_file in md_list:
         # README.md should not be checked
         if md_file.stem == "README":
+            continue
+        elif "skip" in test_spec[md_file.stem] and test_spec[md_file.stem]["skip"]:
             continue
         else:
             yield md_file


### PR DESCRIPTION
Add the following examples about feedback experiments using PQSC, SHFQA and SHFSG:
- active qubit reset
- repeat until success
- bell state stabilization

For the moment we can't test these notebooks in regression, so we adapt the test.spec file with an optional field "skip" that tells to skip regression tests for some notebooks.