### PR TITLE
Improved verbosity of the CommandTable header and table invalid attribute exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # zhinst-toolkit Changelog
 
+## Version 0.5.2
+
+Unreleased
+
+* Improved verbosity of the error message when invalid attributes of `CommandTable.header` and `CommandTable.table` are used.
+
 ## Version 0.5.1
 * Added full support for the following LabOne modules (no need to fallback to zhinst.core):
   * Impedance Module

--- a/src/zhinst/toolkit/command_table.py
+++ b/src/zhinst/toolkit/command_table.py
@@ -144,7 +144,9 @@ class ParentEntry(ParentNode):
                 return self._childs[name]
             if name in self._attributes:
                 return self._properties.get(name, None)
-        raise AttributeError(name)
+        raise AttributeError(
+            f"{name}. Available entries: {self._available_attributes()}"
+        )
 
     def __setattr__(self, name: str, value: t.Any):
         if name.startswith("_"):
@@ -160,7 +162,15 @@ class ParentEntry(ParentNode):
         elif value is None and name in self._childs:
             self._childs.pop(name)
         else:
-            raise AttributeError(name)
+            raise AttributeError(
+                f"{name}. Available entries: {self._available_attributes()}"
+            )
+
+    def _available_attributes(self) -> t.List[str]:
+        """Available property attributes for the instance."""
+        return list(
+            self._attributes.keys() if self._attributes else self._child_props.keys()
+        )
 
     def as_dict(self) -> dict:
         """Return a dictionary presentation of the table node.

--- a/tests/command_table/test_command_table.py
+++ b/tests/command_table/test_command_table.py
@@ -94,9 +94,20 @@ def test_parent_entry_properties(command_table_schema):
             assert hasattr(ct.table[0], property_) is True
 
 
-def test_property_not_existing(command_table):
-    with pytest.raises(AttributeError):
-        getattr(command_table.table[0], "this_property_cannot_exists")
+def test_property_get_not_existing(command_table):
+    properties = (
+        f'{list(command_table._ct_schema["definitions"]["entry"]["properties"].keys())}'
+    )
+    with pytest.raises(AttributeError, match=properties):
+        command_table.table[0].this_property_cannot_exists
+
+
+def test_property_set_not_existing(command_table):
+    properties = (
+        f'{list(command_table._ct_schema["definitions"]["entry"]["properties"].keys())}'
+    )
+    with pytest.raises(AttributeError, match=properties):
+        command_table.table[0].this_property_cannot_exists = 123
 
 
 def test_parent_entry_header(command_table_schema):


### PR DESCRIPTION
Description:

Improved verbosity of the CommandTable header and table invalid attribute exception

The exception now shows available attributes if invalid attribute is used.

Fixes issue: #

Checklist:

- [x] Add tests for the change to show correct behavior.
- [x] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
