### PR TITLE
Changed SHFQA qachannels/*/oscs/0/freq out-of-range value rounding to match LabOne API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Unreleased
    * Changed some `RuntimeError` exceptions to `ToolkitError`.
 * Added `find_zsync_worker_port()` to `PQSC` device class.
   The function can be used to find the ID of the PQSC ZSync port connected to a given device.
+* Changed SHFQA node `qachannels/*/oscs/0/freq` value range from (-500e6 Hz, 500e6 Hz) to (-1e9 Hz, 1e9 Hz). Out-of-range values now rounds
+  to (-1e9 Hz, 1e9 Hz). The functionality is changed to be consistent with LabOne UI.
 
 ## Version 0.5.1
 * Added full support for the following LabOne modules (no need to fallback to zhinst.core):

--- a/src/zhinst/toolkit/driver/parsers.py
+++ b/src/zhinst/toolkit/driver/parsers.py
@@ -207,12 +207,6 @@ node_parser = {
                 lambda v: Parse.greater_equal(v, 0.0),
             ],
         },
-        "qachannels/*/oscs/0/freq": {
-            "SetParser": [
-                lambda v: Parse.smaller_equal(v, 500e6),
-                lambda v: Parse.greater_equal(v, -500e6),
-            ],
-        },
         "qachannels/*/spectroscopy/length": {
             "SetParser": [
                 lambda v: Parse.greater_equal(v, 4),


### PR DESCRIPTION
Changed SHFQA qachannels/*/oscs/0/freq out-of-range value rounding to match LabOne API

Description:

Remove custom limits for the node, let LabOne API to handle rounding and limiting.

Fixes issue: #

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [x] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
