### PR TITLE
Add internal trigger to QA sweeper class

### DIFF
--- a/src/zhinst/toolkit/resources/shfqa_sweeper_nodes.json
+++ b/src/zhinst/toolkit/resources/shfqa_sweeper_nodes.json
@@ -150,7 +150,8 @@
             "10": "\"channel1_sequencer_trigger0\": Channel 1 sequencer trigger 0.",
             "11": "\"channel2_sequencer_trigger0\": Channel 2 sequencer trigger 0.",
             "12": "\"channel3_sequencer_trigger0\": Channel 3 sequencer trigger 0.",
-            "13": "\"software_trigger0\": Software trigger 0."
+            "13": "\"software_trigger0\": Software trigger 0.",
+            "14": "\"internal_trigger\": Internal trigger."
         }
     },
     "/trigger/level": {


### PR DESCRIPTION
Description:
Adds the internal trigger feature, which was added to the SHFQA channels in LabOne 23.02, as a valid trigger source in the SHFQA sweeper nodes.

Fixes issue: #

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [ ] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
