### PR TITLE
Check that factory reset is correctly completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # zhinst-toolkit Changelog
 
+## Version 0.5.4
+* `device.factory_reset` now raises an exception if the factory reset was not successful (`#243`).
+
 ## Version 0.5.3
 * Add internal trigger to SHFQA sweeper class.
 


### PR DESCRIPTION
Description:
The function factory_reset is used to reset a device to its initial state. However it didn't check the successful completion of the operation and instead immediately returned to the user

Fixes issue: #

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [ ] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
