### PR TITLE
Fix wait_for_state_change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Deep gets on nodes with keywords returns an enum like the regular get.
 * Fix rare failures of `wait_for_state_change` function that resulted in early timeouts.
 * All keywords on nodes are correctly supported, and not only the first one for each option.
+* Function `wait_for_state_change` now supports strings and enums for keywords nodes.
 
 ## Version 0.6.0
 * Revert full support of `fnmatch` wildcards and instead use the LabOne wildcard support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # zhinst-toolkit Changelog
 
+## Version 0.6.1
+* Deep gets on nodes with keywords returns an enum like the regular get.
+
 ## Version 0.6.0
 * Revert full support of `fnmatch` wildcards and instead use the LabOne wildcard support.
   This means only `*` symbols are supported. A `*` in the middle of the path matches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 0.6.1
 * Deep gets on nodes with keywords returns an enum like the regular get.
 * Fix rare failures of `wait_for_state_change` function that resulted in early timeouts.
+* All keywords on nodes are correctly supported, and not only the first one for each option.
 
 ## Version 0.6.0
 * Revert full support of `fnmatch` wildcards and instead use the LabOne wildcard support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.6.1
 * Deep gets on nodes with keywords returns an enum like the regular get.
+* Fix rare failures of `wait_for_state_change` function that resulted in early timeouts.
 
 ## Version 0.6.0
 * Revert full support of `fnmatch` wildcards and instead use the LabOne wildcard support.

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -137,3 +137,4 @@ labone
 LabOne
 lru
 func
+enums

--- a/src/zhinst/toolkit/nodetree/node.py
+++ b/src/zhinst/toolkit/nodetree/node.py
@@ -316,16 +316,21 @@ class NodeInfo:
     @lazy_property
     def enum(self) -> t.Optional[NodeEnum]:
         """Enum of the node options."""
-        try:
-            options_reversed = {value.enum: key for key, value in self.options.items()}
-            return (
-                NodeEnum(self.path, options_reversed, module=__name__)
-                if options_reversed
-                else None
-            )
-        except ValueError:
+        options_reversed = {}
+        for int_key, value in self._info.get("Options", {}).items():
+            # Find all the keywords associated to a integer key
+            enum_re = re.finditer(r'"(?P<keyword>\w+)"', value)
+            for m in enum_re:
+                keyword = m.group("keyword")
+                options_reversed[keyword] = int_key
+
+        return (
+            NodeEnum(self.path, options_reversed, module=__name__)
+            if options_reversed
             # Nameless options do not have a enum.
-            return None
+            else None
+        )
+
 
 
 class Node:

--- a/src/zhinst/toolkit/nodetree/node.py
+++ b/src/zhinst/toolkit/nodetree/node.py
@@ -9,6 +9,7 @@ import typing as t
 from collections import namedtuple
 from collections.abc import Sequence
 from enum import IntEnum
+import numpy as np
 
 from zhinst.toolkit.nodetree.helper import (
     NodeDict,
@@ -525,6 +526,9 @@ class Node:
 
             .. versionchanged:: 0.5.0 Returns NodeDict instead of WildcardResult
 
+            .. versionchanged:: 0.6.1 Returns an enum on keywords nodes also
+                for deep gets.
+
         Raises:
             AttributeError: If the connection does not support the necessary
                 function to get/set the value.
@@ -579,7 +583,7 @@ class Node:
         Returns:
             Parsed value
         """
-        if enum and isinstance(value, int):
+        if enum and isinstance(value, (int, np.integer)):
             try:
                 value = self.node_info.enum(value) if self.node_info.enum else value
             except ValueError:

--- a/src/zhinst/toolkit/nodetree/node.py
+++ b/src/zhinst/toolkit/nodetree/node.py
@@ -299,10 +299,18 @@ class NodeInfo:
         """Options of the node."""
         option_map = {}
         for key, value in self._info.get("Options", {}).items():
-            node_options = re.findall(r'("(.+?)"[,:]+)? ?(.*)', value)
-            option_map[int(key)] = self._option_info(
-                node_options[0][1], node_options[0][2]
-            )
+            # Find all the keywords. We use only the first one
+            # since it should be unambiguous
+            enum_re = re.findall(r'"(\w+)"', value)
+            enum = enum_re[0] if enum_re else ""
+
+            # The description is either what comes after
+            # the colon and space, or the whole string.
+            # This is the case for nameless options, when the
+            # key is an integer (for example demods/x/order)
+            desc = re.findall(r'(?:.+":\s)?(.+)$', value)[0]
+
+            option_map[int(key)] = self._option_info(enum, desc)
         return option_map
 
     @lazy_property

--- a/tests/test_awg.py
+++ b/tests/test_awg.py
@@ -48,13 +48,17 @@ def test_wait_done(mock_connection, shfsg):
     single = 0
     enable = iter([])
 
-    def get_int_side_effect(node):
-        if node.upper() == "/DEV1234/SGCHANNELS/0/AWG/SINGLE":
-            return single
-        if node.upper() == "/DEV1234/SGCHANNELS/0/AWG/ENABLE":
-            return next(enable)
+    def get_side_effect(node, **kwargs):
+        if node.lower() == "/dev1234/sgchannels/0/awg/single":
+            return {node: {"timestamp": [0], "value": [single]}}
+        if node.lower() == "/dev1234/sgchannels/0/awg/enable":
+            return {node: {"timestamp": [0], "value": [next(enable)]}}
         raise RuntimeError("Node not found")
 
+    def get_int_side_effect(node):
+        return get_side_effect(node)[node]["value"][0]
+
+    mock_connection.return_value.get.side_effect = get_side_effect
     mock_connection.return_value.getInt.side_effect = get_int_side_effect
 
     # if not single mode this function throws a RuntimeError

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -65,7 +65,12 @@ def test_factory_reset_ok(base_instrument, mock_connection):
 
 
 def test_factory_reset_timeout(base_instrument, mock_connection):
+    dev_id = base_instrument.serial.lower()
     mock_connection.return_value.getInt.return_value = 1
+    mock_connection.return_value.get.return_value = {
+        f"/{dev_id}/system/preset/busy": {"timestamp": [0], "value": [1]}
+    }
+
     with pytest.raises(TimeoutError):
         base_instrument.factory_reset(timeout=0.00001)
 

--- a/tests/test_device_settings_module.py
+++ b/tests/test_device_settings_module.py
@@ -23,6 +23,10 @@ def test_repr(device_settings_module):
 
 def test_load_from_file(device_settings_module):
     device_settings_module.raw_module.getInt.return_value = 1
+    device_settings_module.raw_module.get.return_value = {
+        "/finished": {"timestamp": [0], "value": [1]}
+    }
+
     device_settings_module.load_from_file(Path("/path/to/file.json"), "dev1234")
     device_settings_module.raw_module.set.assert_any_call("/device", "dev1234")
     device_settings_module.raw_module.set.assert_any_call("/filename", "file")
@@ -33,6 +37,10 @@ def test_load_from_file(device_settings_module):
 
 def test_load_from_file_timeout(device_settings_module):
     device_settings_module.raw_module.getInt.return_value = 0
+    device_settings_module.raw_module.get.return_value = {
+        "/finished": {"timestamp": [0], "value": [0]}
+    }
+
     with pytest.raises(TimeoutError):
         device_settings_module.load_from_file(
             Path("/path/to/file.json"), "dev1234", timeout=0.01
@@ -41,6 +49,10 @@ def test_load_from_file_timeout(device_settings_module):
 
 def test_save_to_file(device_settings_module):
     device_settings_module.raw_module.getInt.return_value = 1
+    device_settings_module.raw_module.get.return_value = {
+        "/finished": {"timestamp": [0], "value": [1]}
+    }
+
     device_settings_module.save_to_file(Path("/path/to/file.json"), "dev1234")
     device_settings_module.raw_module.set.assert_any_call("/device", "dev1234")
     device_settings_module.raw_module.set.assert_any_call("/filename", "file")
@@ -51,6 +63,10 @@ def test_save_to_file(device_settings_module):
 
 def test_save_to_file_timeout(device_settings_module):
     device_settings_module.raw_module.getInt.return_value = 0
+    device_settings_module.raw_module.get.return_value = {
+        "/finished": {"timestamp": [0], "value": [0]}
+    }
+
     with pytest.raises(TimeoutError):
         device_settings_module.save_to_file(
             Path("/path/to/file.json"), "dev1234", timeout=0.01

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -34,13 +34,17 @@ def test_wait_done(mock_connection, shfqa, generator):
     single = 0
     enable = iter([])
 
-    def get_int_side_effect(node):
-        if node.upper() == "/DEV1234/QACHANNELS/0/GENERATOR/SINGLE":
-            return single
-        if node.upper() == "/DEV1234/QACHANNELS/0/GENERATOR/ENABLE":
-            return next(enable)
+    def get_side_effect(node, **kwargs):
+        if node.lower() == "/dev1234/qachannels/0/generator/single":
+            return {node: {"timestamp": [0], "value": [single]}}
+        if node.lower() == "/dev1234/qachannels/0/generator/enable":
+            return {node: {"timestamp": [0], "value": [next(enable)]}}
         raise RuntimeError("Node not found")
 
+    def get_int_side_effect(node):
+        return get_side_effect(node)[node]["value"][0]
+
+    mock_connection.return_value.get.side_effect = get_side_effect
     mock_connection.return_value.getInt.side_effect = get_int_side_effect
 
     # if not single mode this function throws a RuntimeError

--- a/tests/test_nodetree.py
+++ b/tests/test_nodetree.py
@@ -700,6 +700,13 @@ def test_nameless_options(connection):
 
     assert tree.demods[0].order.node_info.enum is None
 
+def test_multiple_options(connection):
+    tree = NodeTree(connection, "DEV1234")
+
+    options = tree.demods[0].adcselect.node_info.options
+
+    assert options[0].enum == "sigin0"
+    assert options[0].description == "Sig In 1"
 
 def test_parser(connection):
     tree = NodeTree(connection, "DEV1234")

--- a/tests/test_nodetree.py
+++ b/tests/test_nodetree.py
@@ -700,6 +700,7 @@ def test_nameless_options(connection):
 
     assert tree.demods[0].order.node_info.enum is None
 
+
 def test_multiple_options(connection):
     tree = NodeTree(connection, "DEV1234")
 
@@ -707,6 +708,13 @@ def test_multiple_options(connection):
 
     assert options[0].enum == "sigin0"
     assert options[0].description == "Sig In 1"
+
+    assert tree.demods[0].adcselect.node_info.enum.sigin0 == 0
+    assert tree.demods[0].adcselect.node_info.enum.signal_input0 == 0
+
+    assert tree.demods[0].adcselect.node_info.enum.currin0 == 1
+    assert tree.demods[0].adcselect.node_info.enum.current_input0 == 1
+
 
 def test_parser(connection):
     tree = NodeTree(connection, "DEV1234")

--- a/tests/test_readout.py
+++ b/tests/test_readout.py
@@ -49,24 +49,38 @@ def test_run(mock_connection, readout):
 
 
 def test_stop(mock_connection, readout):
+    node = "/dev1234/qachannels/0/readout/result/enable"
+
     # already disabled
     mock_connection.return_value.getInt.return_value = 0
+    mock_connection.return_value.get.return_value = {
+        node: {"timestamp": [0], "value": [0]}
+    }
     readout.stop()
-    mock_connection.return_value.set.assert_called_with(
-        "/dev1234/qachannels/0/readout/result/enable", False
-    )
+    mock_connection.return_value.set.assert_called_with(node, False)
     # never disabled
     mock_connection.return_value.getInt.return_value = 1
+    mock_connection.return_value.get.return_value = {
+        node: {"timestamp": [0], "value": [1]}
+    }
     with pytest.raises(TimeoutError) as e_info:
         readout.stop(timeout=0.5)
 
 
 def test_wait_done(mock_connection, readout):
+    node = "/dev1234/qachannels/0/readout/result/enable"
+
     # already disabled
     mock_connection.return_value.getInt.return_value = 0
+    mock_connection.return_value.get.return_value = {
+        node: {"timestamp": [0], "value": [0]}
+    }
     readout.wait_done()
     # never disabled
     mock_connection.return_value.getInt.return_value = 1
+    mock_connection.return_value.get.return_value = {
+        node: {"timestamp": [0], "value": [1]}
+    }
     with pytest.raises(TimeoutError) as e_info:
         readout.wait_done(timeout=0.5)
 

--- a/tests/test_shfqa_scope.py
+++ b/tests/test_shfqa_scope.py
@@ -9,37 +9,57 @@ def scope(shfqa):
 
 
 def test_run(mock_connection, scope):
+    node = "/dev1234/scopes/0/enable"
+
     # already enabled
     mock_connection.return_value.getInt.return_value = 1
+    mock_connection.return_value.get.return_value = {
+        node: {"timestamp": [0], "value": [1]}
+    }
     scope.run()
-    mock_connection.return_value.set.assert_called_with(
-        "/dev1234/scopes/0/enable", True
-    )
+    mock_connection.return_value.set.assert_called_with(node, True)
     # never disabled
     mock_connection.return_value.getInt.return_value = 0
+    mock_connection.return_value.get.return_value = {
+        node: {"timestamp": [0], "value": [0]}
+    }
     with pytest.raises(TimeoutError) as e_info:
         scope.run(timeout=0.5)
 
 
 def test_stop(mock_connection, scope):
+    node = "/dev1234/scopes/0/enable"
+
     # already disabled
     mock_connection.return_value.getInt.return_value = 0
+    mock_connection.return_value.get.return_value = {
+        node: {"timestamp": [0], "value": [0]}
+    }
     scope.stop()
-    mock_connection.return_value.set.assert_called_with(
-        "/dev1234/scopes/0/enable", False
-    )
+    mock_connection.return_value.set.assert_called_with(node, False)
     # never disabled
     mock_connection.return_value.getInt.return_value = 1
+    mock_connection.return_value.get.return_value = {
+        node: {"timestamp": [0], "value": [1]}
+    }
     with pytest.raises(TimeoutError) as e_info:
         scope.stop(timeout=0.5)
 
 
 def test_wait_done(mock_connection, scope):
+    node = "/dev1234/scopes/0/enable"
+
     # already disabled
     mock_connection.return_value.getInt.return_value = 0
+    mock_connection.return_value.get.return_value = {
+        node: {"timestamp": [0], "value": [0]}
+    }
     scope.wait_done()
     # never disabled
     mock_connection.return_value.getInt.return_value = 1
+    mock_connection.return_value.get.return_value = {
+        node: {"timestamp": [0], "value": [1]}
+    }
     with pytest.raises(TimeoutError) as e_info:
         scope.wait_done(timeout=0.5)
 

--- a/tests/test_spectroscopy.py
+++ b/tests/test_spectroscopy.py
@@ -50,24 +50,38 @@ def test_run(mock_connection, spectroscopy, m_utils):
 
 
 def test_stop(mock_connection, spectroscopy):
+    node = "/dev1234/qachannels/0/spectroscopy/result/enable"
+
     # already disabled
     mock_connection.return_value.getInt.return_value = 0
+    mock_connection.return_value.get.return_value = {
+        node: {"timestamp": [0], "value": [0]}
+    }
     spectroscopy.stop()
-    mock_connection.return_value.set.assert_called_with(
-        "/dev1234/qachannels/0/spectroscopy/result/enable", False
-    )
+    mock_connection.return_value.set.assert_called_with(node, False)
     # never disabled
     mock_connection.return_value.getInt.return_value = 1
+    mock_connection.return_value.get.return_value = {
+        node: {"timestamp": [0], "value": [1]}
+    }
     with pytest.raises(TimeoutError) as e_info:
         spectroscopy.stop(timeout=0.5)
 
 
 def test_wait_done(mock_connection, spectroscopy):
+    node = "/dev1234/qachannels/0/spectroscopy/result/enable"
+
     # already disabled
     mock_connection.return_value.getInt.return_value = 0
+    mock_connection.return_value.get.return_value = {
+        node: {"timestamp": [0], "value": [0]}
+    }
     spectroscopy.wait_done()
     # never disabled
     mock_connection.return_value.getInt.return_value = 1
+    mock_connection.return_value.get.return_value = {
+        node: {"timestamp": [0], "value": [1]}
+    }
     with pytest.raises(TimeoutError) as e_info:
         spectroscopy.wait_done(timeout=0.5)
 


### PR DESCRIPTION
Description:
In some rare cases, the function wait_for_state_change exited
early with a timeout error. That happened when a stale cached
value trigger an early detection of the state change. To avoid that,
a deep get is perfomed at the beginning and the logic is simplified.

Tests have been adapted to work with deep gets.

In addition, a deep get to a keyword node now is correctly resolved to
an enum, instead of returning an integer.

Fixes issue: #

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
