### PR TITLE
make utils functions available in transactions

### DIFF
--- a/src/zhinst/toolkit/driver/nodes/shfqa_scope.py
+++ b/src/zhinst/toolkit/driver/nodes/shfqa_scope.py
@@ -6,6 +6,7 @@ import zhinst.utils.shfqa as utils
 from zhinst.core import ziDAQServer
 
 from zhinst.toolkit.nodetree import Node, NodeTree
+from zhinst.toolkit.nodetree.helper import not_callable_in_transactions
 
 logger = logging.getLogger(__name__)
 
@@ -132,8 +133,7 @@ class SHFScope(Node):
             trigger_delay: delay in samples specifying the time between the
                 start of data acquisition and reception of a trigger.
         """
-        utils.configure_scope(
-            self._daq_server,
+        settings = utils.get_scope_settings(
             self._serial,
             input_select=input_select,
             num_samples=num_samples,
@@ -142,7 +142,9 @@ class SHFScope(Node):
             num_averages=num_averages,
             trigger_delay=trigger_delay,
         )
+        self._send_set_list(settings)
 
+    @not_callable_in_transactions
     def read(
         self,
         *,

--- a/src/zhinst/toolkit/driver/nodes/spectroscopy.py
+++ b/src/zhinst/toolkit/driver/nodes/spectroscopy.py
@@ -6,6 +6,7 @@ import zhinst.utils.shfqa as utils
 
 from zhinst.toolkit.interface import AveragingMode
 from zhinst.toolkit.nodetree import Node, NodeTree
+from zhinst.toolkit.nodetree.helper import not_callable_in_transactions
 
 logger = logging.getLogger(__name__)
 
@@ -49,15 +50,16 @@ class Spectroscopy(Node):
             num_averages: Number of averages, will be rounded to 2^n.
             averaging_mode: Averaging order of the result.
         """
-        utils.configure_result_logger_for_spectroscopy(
-            self._daq_server,
+        settings = utils.get_result_logger_for_spectroscopy_settings(
             self._serial,
             self._index,
             result_length=result_length,
             num_averages=num_averages,
             averaging_mode=int(averaging_mode),
         )
+        self._send_set_list(settings)
 
+    @not_callable_in_transactions
     def run(self) -> None:
         """Resets and enables the spectroscopy result logger."""
         utils.enable_result_logger(
@@ -115,6 +117,7 @@ class Spectroscopy(Node):
                 f"within the specified timeout ({timeout}s)."
             ) from error
 
+    @not_callable_in_transactions
     def read(
         self,
         *,

--- a/src/zhinst/toolkit/nodetree/node.py
+++ b/src/zhinst/toolkit/nodetree/node.py
@@ -1119,6 +1119,21 @@ class Node:
             self._is_valid = len(keys) > 0
         return self._is_valid
 
+    def _send_set_list(self, settings: t.List[t.Tuple[str, t.Any]]) -> None:
+        """Applies settings and takes care of a possibly ongoing transaction.
+
+        In case of an active transaction, the settings will be put into it,
+        rather than being applied immediately.
+
+        Args:
+            settings: List of node-string, value pairs which list the settings to
+            be changed
+        """
+        if self.root.transaction.in_progress():
+            self.root.transaction.add_raw_list(settings)
+        else:
+            self.root.connection.set(settings)
+
     @property
     def node_info(self) -> NodeInfo:
         """Additional information about the node."""

--- a/src/zhinst/toolkit/nodetree/nodetree.py
+++ b/src/zhinst/toolkit/nodetree/nodetree.py
@@ -121,6 +121,25 @@ class Transaction:
         except AttributeError as exception:
             raise AttributeError("No set transaction is in progress.") from exception
 
+    def add_raw_list(self, node_value_pairs: t.List[t.Tuple[str, t.Any]]) -> None:
+        """Adds multiple set commands at a time.
+
+        Args:
+            node_value_pairs: List of settings in the form of (node_string, value)
+            the node_strings are assumed to be valid and of the form /dev1234/.../attr1
+
+        Raises:
+            TookitError: if this function is called outside a transaction. It is
+                exclusively designed to be used within transactions.
+
+        Note: settings can only take strings which to
+                describe a node, but no node objects
+        """
+        try:
+            self._queue += node_value_pairs  # type: ignore[operator]  # caught
+        except TypeError as exception:
+            raise ToolkitError("No set transaction is in progress.") from exception
+
     def in_progress(self) -> bool:
         """Flag if the transaction is in progress."""
         return self._queue is not None

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -203,8 +203,7 @@ def test_configure_sequencer_triggering(generator, mock_connection):
         generator.configure_sequencer_triggering(
             aux_trigger="fobarob", play_pulse_delay=0.0001
         )
-        utils.configure_sequencer_triggering.assert_called_with(
-            mock_connection.return_value,
+        utils.get_sequencer_triggering_settings.assert_called_with(
             "DEV1234",
             0,
             aux_trigger="fobarob",

--- a/tests/test_readout.py
+++ b/tests/test_readout.py
@@ -14,8 +14,7 @@ def readout(shfqa):
 def test_configure_result_logger(mock_connection, readout):
     with patch("zhinst.toolkit.driver.nodes.readout.utils", autospec=True) as utils:
         readout.configure_result_logger(result_source="test", result_length=10)
-        utils.configure_result_logger_for_readout.assert_called_with(
-            mock_connection.return_value,
+        utils.get_result_logger_for_readout_settings.assert_called_with(
             "DEV1234",
             0,
             result_source="test",
@@ -26,8 +25,7 @@ def test_configure_result_logger(mock_connection, readout):
         readout.configure_result_logger(
             result_source="test2", result_length=0, num_averages=2, averaging_mode=1
         )
-        utils.configure_result_logger_for_readout.assert_called_with(
-            mock_connection.return_value,
+        utils.get_result_logger_for_readout_settings.assert_called_with(
             "DEV1234",
             0,
             result_source="test2",

--- a/tests/test_shfqa.py
+++ b/tests/test_shfqa.py
@@ -44,8 +44,7 @@ def test_qa_configure_channel(mock_connection, shfqa):
             center_frequency=30.0,
             mode=SHFQAChannelMode.READOUT,
         )
-        utils.configure_channel.assert_called_once_with(
-            mock_connection.return_value,
+        utils.get_channel_settings.assert_called_once_with(
             "DEV1234",
             0,
             input_range=10,

--- a/tests/test_shfqa_scope.py
+++ b/tests/test_shfqa_scope.py
@@ -71,8 +71,7 @@ def test_configure(mock_connection, scope):
             num_samples=10,
             trigger_input=scope.available_trigger_inputs[0],
         )
-        utils.configure_scope.assert_called_with(
-            mock_connection.return_value,
+        utils.get_scope_settings.assert_called_with(
             "DEV1234",
             input_select=scope.available_inputs[0],
             num_samples=10,
@@ -89,8 +88,7 @@ def test_configure(mock_connection, scope):
             num_averages=10,
             trigger_delay=33,
         )
-        utils.configure_scope.assert_called_with(
-            mock_connection.return_value,
+        utils.get_scope_settings.assert_called_with(
             "DEV1234",
             input_select=scope.available_inputs[0],
             num_samples=10,

--- a/tests/test_shfqc.py
+++ b/tests/test_shfqc.py
@@ -45,8 +45,7 @@ def test_qa_configure_channel(mock_connection, shfqc):
             center_frequency=30.0,
             mode=SHFQAChannelMode.READOUT,
         )
-        utils.configure_channel.assert_called_once_with(
-            mock_connection.return_value,
+        utils.get_channel_settings.assert_called_once_with(
             "DEV1234",
             0,
             input_range=10,
@@ -142,8 +141,7 @@ def test_awg_configure_marker_and_trigger(data_dir, mock_connection, shfqc):
             trigger_in_slope="test2",
             marker_out_source="test3",
         )
-        utils.configure_marker_and_trigger.assert_called_once_with(
-            mock_connection.return_value,
+        utils.get_marker_and_trigger_settings.assert_called_once_with(
             "DEV1234",
             0,
             trigger_in_source="test1",
@@ -219,8 +217,7 @@ def test_configure_pulse_modulation(mock_connection, shfqc):
             gains=(3.0, -1.0, 5.0, 1.0),
             sine_generator_index=8,
         )
-        utils.configure_pulse_modulation.assert_called_once_with(
-            mock_connection.return_value,
+        utils.get_pulse_modulation_settings.assert_called_once_with(
             "DEV1234",
             0,
             enable=1,
@@ -243,8 +240,7 @@ def test_configure_sine_generation(mock_connection, shfqc):
             gains=(3.0, -1.0, 5.0, 1.0),
             sine_generator_index=8,
         )
-        utils.configure_sine_generation.assert_called_once_with(
-            mock_connection.return_value,
+        utils.get_sine_generation_settings.assert_called_once_with(
             "DEV1234",
             0,
             enable=1,

--- a/tests/test_shfsg.py
+++ b/tests/test_shfsg.py
@@ -63,8 +63,7 @@ def test_awg_configure_marker_and_trigger(data_dir, mock_connection, shfsg):
             trigger_in_slope="test2",
             marker_out_source="test3",
         )
-        utils.configure_marker_and_trigger.assert_called_once_with(
-            mock_connection.return_value,
+        utils.get_marker_and_trigger_settings.assert_called_once_with(
             "DEV1234",
             0,
             trigger_in_source="test1",
@@ -139,8 +138,7 @@ def test_configure_pulse_modulation(mock_connection, shfsg):
             gains=(3.0, -1.0, 5.0, 1.0),
             sine_generator_index=8,
         )
-        utils.configure_pulse_modulation.assert_called_once_with(
-            mock_connection.return_value,
+        utils.get_pulse_modulation_settings.assert_called_once_with(
             "DEV1234",
             0,
             enable=1,
@@ -163,8 +161,7 @@ def test_configure_sine_generation(mock_connection, shfsg):
             gains=(3.0, -1.0, 5.0, 1.0),
             sine_generator_index=8,
         )
-        utils.configure_sine_generation.assert_called_once_with(
-            mock_connection.return_value,
+        utils.get_sine_generation_settings.assert_called_once_with(
             "DEV1234",
             0,
             enable=1,

--- a/tests/test_spectroscopy.py
+++ b/tests/test_spectroscopy.py
@@ -18,8 +18,7 @@ def m_utils():
 
 def test_configure_result_logger(mock_connection, spectroscopy, m_utils):
     spectroscopy.configure_result_logger(result_length=10)
-    m_utils.configure_result_logger_for_spectroscopy.assert_called_with(
-        mock_connection.return_value,
+    m_utils.get_result_logger_for_spectroscopy_settings.assert_called_with(
         "DEV1234",
         0,
         result_length=10,
@@ -29,8 +28,7 @@ def test_configure_result_logger(mock_connection, spectroscopy, m_utils):
     spectroscopy.configure_result_logger(
         result_length=0, num_averages=2, averaging_mode=1
     )
-    m_utils.configure_result_logger_for_spectroscopy.assert_called_with(
-        mock_connection.return_value,
+    m_utils.get_result_logger_for_spectroscopy_settings.assert_called_with(
         "DEV1234",
         0,
         result_length=0,


### PR DESCRIPTION
Description: Utils that were previously ported to toolkit used to bypass the toolkit's transaction logic and execute immediately. These modifications ensure proper behavior by either delaying execution to comply with the transaction scheme or by preventing the functions from being used within transactions.



Fixes issue: #L1-1889

Checklist:

- [x] Add tests for the change to show correct behavior.
- [x] Add or update relevant docs, code and examples.
- [ ] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
