### PR TITLE
Ensure no validation when active_validation is False

### DIFF
--- a/docs/source/first_steps/installation.rst
+++ b/docs/source/first_steps/installation.rst
@@ -15,7 +15,7 @@ These distributions will be installed automatically when installing zhinst-toolk
 * `numpy <https://pypi.org/project/numpy/>`_ adds support for large, multi-dimensional
   arrays and matrices, along with a large collection of high-level mathematical
   functions to operate on these arrays.
-* `jsonschema <https://pypi.org/project/jsonschema/>`_ is an implementation of the JSON
+* `fastjsonschema <https://pypi.org/project/fastjsonschema/>`_ is an implementation of the JSON
   Schema specification for Python.
 * `zhinst-core <https://pypi.org/project/zhinst-core/>`_ is the low level python API for Zurich
   Instruments devices.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy
 jsonschema
 jsonref
 pyelftools
-
+fastjsonschema==2.16.1
 # Tests
 pytest
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,9 @@ install_requires =
     numpy>=1.13
     zhinst-core>=23.06
     zhinst-utils>=0.3.1
-    jsonschema>=3.2.0
     jsonref>=0.2
     typing_extensions>=4.1.1
+    fastjsonschema==2.16.1
     pyelftools>=0.29
 
 include_package_data = True

--- a/src/zhinst/toolkit/driver/nodes/command_table_node.py
+++ b/src/zhinst/toolkit/driver/nodes/command_table_node.py
@@ -106,6 +106,8 @@ class CommandTableNode(Node):
             `check_status` is only called when not in a ongoing transaction.
         """
         try:
+            if validate:
+                ct.is_valid(raise_for_invalid=True)  # type: ignore
             self.data(json.dumps(ct.as_dict()))  # type: ignore
         except AttributeError:
             if validate:

--- a/tests/command_table/conftest.py
+++ b/tests/command_table/conftest.py
@@ -1,9 +1,9 @@
 import json
-import pytest
 from pathlib import Path
 
-from zhinst.toolkit.command_table import CommandTable
+import pytest
 
+from zhinst.toolkit.command_table import CommandTable
 
 CT_SCHEMA_22_02 = Path(__file__).parent / "data/command_table_schema_22_02.json"
 CT_SCHEMA_22_08 = Path(__file__).parent / "data/command_table_schema_22_08.json"


### PR DESCRIPTION
Description:

This PR addresses performance issues in #269

JSON schema validation decreases the performance of the function and should be bypassed if
the user does not want the validation and requires performance.

Changed to `fastjsonschema` which is much faster.


---

I ran the example in the issue #269 locally and results are for `active_validation=True`:

Before:

- with JSON Schema validation: ~10 ms
- without validation: 0.01 - 0.04 ms

After:

- with JSON Schema validation: ~0.01 - 0.04 ms
- without validation: 0.01 - 0.04 ms

Fixes issue: #269 

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [ ] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
