### PR TITLE
Remove ct validation when active validation is disabled (#269)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   to 1 (gen1) when the HDAWG is operated with PQSC together with UHFQA instruments.
 * Improved `CommandTable` performance when `CommandTable.active_validation` is disabled.
 * Added `CommandTable.is_valid()` method to check validity of the command table.
+* Added `py.typed` type information marker file.
 
 ## Version 0.6.1
 * Deep gets on nodes with keywords returns an enum like the regular get.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * The function `enable_qccs_mode` of the HDAWG driver now accept an optional argument to select the QCCS generation.
   It's advised to set it to 2 (gen2) when the HDAWG is operated with PQSC together with SHF instruments, and set it
   to 1 (gen1) when the HDAWG is operated with PQSC together with UHFQA instruments.
+* Improved `CommandTable` performance when `CommandTable.active_validation` is disabled.
+* Added `CommandTable.is_valid()` method to check validity of the command table.
 
 ## Version 0.6.1
 * Deep gets on nodes with keywords returns an enum like the regular get.
@@ -19,7 +21,7 @@
   This means only `*` symbols are supported. A `*` in the middle of the path matches
   everything instead of a `/`. A `*` at the end of the path matches everything.
 * Fix problem of garbage collection daq sessions. The problem was caused due to using
-  lru caches for instance methods. The usage of lru cache has now been bypassed or 
+  lru caches for instance methods. The usage of lru cache has now been bypassed or
   replaced with the `functools.cached_property` decorator (which is currently copied
   to ensure support for python 3.7).
 * `device.factory_reset` now raises an exception if the factory reset was not successful (`#243`).

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include src/ *.json
+include src/zhinst/toolkit/py.typed

--- a/src/zhinst/toolkit/command_table.py
+++ b/src/zhinst/toolkit/command_table.py
@@ -466,6 +466,11 @@ class CommandTable:
             :class:`~zhinst.toolkit.exceptions.ValidateError`: The command table
                 does not correspond to the given JSON schema.
 
+        .. versionchanged:: 0.6.2
+
+            Removed validation when `active_validation` is set to `False`.
+                This improves performance when validation is not needed.
+
         .. versionchanged:: 0.4.2
 
             Removed `$schema` key from resulting dictionary.
@@ -474,7 +479,8 @@ class CommandTable:
             "header": self._header.as_dict(),
             "table": self._table.as_list(),
         }
-        _validate_instance(result, self._ct_schema)
+        if self.active_validation:
+            _validate_instance(result, self._ct_schema)
         return result
 
     def update(self, command_table: t.Union[str, dict]) -> None:
@@ -493,7 +499,8 @@ class CommandTable:
             return json_  # type: ignore[return-value]
 
         command_table = json_to_dict(copy.deepcopy(command_table))
-        _validate_instance(command_table, self._ct_schema)
+        if self._active_validation:
+            _validate_instance(command_table, self._ct_schema)
 
         def build_nodes(path: t.Optional[ParentEntry], index: int, obj: dict):
             for k, v in obj.items():

--- a/tests/command_table/test_command_table.py
+++ b/tests/command_table/test_command_table.py
@@ -161,6 +161,8 @@ def test_command_table_active_validation_table(command_table_schema):
         ct.table[999999]
     ct = CommandTable(command_table_schema, active_validation=False)
     ct.table[999999].amplitude00.value = 1
+    ct.as_dict()
+    ct.active_validation = True
     with pytest.raises(ValidationError):
         ct.as_dict()
 


### PR DESCRIPTION
Description:

To improve `CommandTable` creation and usage, do not validate it during `as_dict()`.

Introduces `is_valid()` method compensate for optional validation.

Removed unnecessary `deepcopy` of schemas for speed improvement

The following script is 10x faster than with copying:

```
for i in range(100):
      ct.table[i].waveform.index = I
```

Fixes issue: #269 

Checklist:

- [x] Add tests for the change to show correct behavior.
- [x] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
- [x] Add .. versionchanged:: where necessary.
