### PR TITLE
Update scipy gaussian import to avoid deprecation warnings

### DIFF
--- a/examples/shfqa_qubit_readout_measurement.md
+++ b/examples/shfqa_qubit_readout_measurement.md
@@ -51,7 +51,7 @@ device.qachannels[CHANNEL_INDEX].output.on(1)
 In this example the envelope of the readout pulses is a gaussian with a flat top. For each qubit, the envelope is then modulated at the qubit frequency. For illustrative purposes we assume that the frequencies of the qubits are equally spaced in the range [32 MHz, 230 MHz] relative to the center frequency of 5 GHz specified above.
 
 ```python
-from scipy.signal import gaussian
+from scipy.signal.windows import gaussian
 import numpy as np
 
 # Define the parameters for the readout pulses

--- a/examples/shfqa_qubit_readout_weights.md
+++ b/examples/shfqa_qubit_readout_weights.md
@@ -73,7 +73,7 @@ Generate the readout pulses with a flat top gaussian envelope. For each qubit th
 
 ```python
 
-from scipy.signal import gaussian
+from scipy.signal.windows import gaussian
 import numpy as np
 
 # Define the parameters for the readout pulses

--- a/examples/shfqa_shfqc_power_spectral_density.md
+++ b/examples/shfqa_shfqc_power_spectral_density.md
@@ -170,7 +170,7 @@ else:
 # Generate an interesting test waveform
 from zhinst.toolkit import Waveforms
 import numpy as np
-from scipy import signal
+from scipy.signal.windows import gaussian
 from zhinst.utils.shfqa import SHFQA_SAMPLING_FREQUENCY
 
 # Modulate a Gaussian with complex sinusoidal
@@ -180,7 +180,7 @@ modulation_freq = 100e6
 waveform_length = np.min(128, int(sweeper.average.integration_time() / SHFQA_SAMPLING_FREQUENCY))
 time_axis = np.arange(waveform_length) / SHFQA_SAMPLING_FREQUENCY
 test_signal = np.exp(1j * 2 * np.pi * modulation_freq * time_axis)
-test_signal *= signal.gaussian(waveform_length, std=waveform_length/8)
+test_signal *= gaussian(waveform_length, std=waveform_length/8)
 
 # Upload waveform to the device
 waveforms = Waveforms()

--- a/examples/shfqa_sweeper.md
+++ b/examples/shfqa_sweeper.md
@@ -117,7 +117,7 @@ In pulsed spectroscopy the resonator is probed with a signal consisting of an en
 ### Create the envelope
 
 ```python
-from scipy.signal import gaussian
+from scipy.signal.windows import gaussian
 import numpy as np
 
 SHFQA_SAMPLING_FREQUENCY = 2e9

--- a/examples/shfqc_helper.py
+++ b/examples/shfqc_helper.py
@@ -45,7 +45,7 @@ def generate_flat_top_gaussian(
                 unit circle."
         )
 
-    from scipy.signal import gaussian
+    from scipy.signal.windows import gaussian
 
     rise_fall_len = int(rise_fall_time * sampling_rate)
     pulse_len = int(pulse_duration * sampling_rate)


### PR DESCRIPTION
Description:

When running the example `shfqa_qubit_readout_measurement.md`, I've encountered the following deprecation warning from the SciPy library for the `gaussian` function:

```
DeprecationWarning: Importing gaussian from 'scipy.signal' is deprecated and will raise an error in SciPy 1.13.0. Please use 'scipy.signal.windows.gaussian' or the convenience function 'scipy.signal.get_window' instead.
  gauss = gaussian(2 * rise_fall_len, std_dev)
```

Therefore, this PR updates the import statements for this library function.

Fixes issue: #

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [ ] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
