### PR TITLE
Make the function `wait_for_state_change` work with zero timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # zhinst-toolkit Changelog
 
+## Version 0.6.4
+* Function `wait_for_state_change` now works with zero timeout; the node value is always checked at least once.
+
 ## Version 0.6.3
 * Adapt `write_integration_weights` function in the readout module to be callable within transactions.
 

--- a/src/zhinst/toolkit/nodetree/node.py
+++ b/src/zhinst/toolkit/nodetree/node.py
@@ -925,7 +925,7 @@ class Node:
         value: t.Union[int, str, NodeEnum],
         *,
         invert: bool = False,
-        timeout: float = 2,
+        timeout: float = 2.0,
         sleep_time: float = 0.005,
     ) -> None:
         """Waits until the node has the expected state/value.
@@ -944,6 +944,9 @@ class Node:
 
                 Useful when waiting for value to change from existing one.
             timeout: Maximum wait time in seconds. (default = 2)
+
+            .. versionchanged:: 0.6.4 A zero seconds timeout is accepted.
+
             sleep_time: Sleep interval in seconds. (default = 0.005)
 
         Raises:
@@ -975,14 +978,17 @@ class Node:
 
             # Performs a deep get to avoid waiting on stale values from cache
             # In the loop we can use a shallow get
-            # Since deep get
             curr_value = self._get(deep=True)[1]
 
-            while start_time + timeout >= time.time():
+            while True:
                 # Verify if we get to the correct value.
                 # If yes, exit the function.
                 if (curr_value == parsed_value) != invert:
                     return
+
+                # Timeout check
+                if time.time() > start_time + timeout:
+                    break
 
                 time.sleep(sleep_time)
                 curr_value = self._get(deep=False)

--- a/tests/test_nodetree.py
+++ b/tests/test_nodetree.py
@@ -1081,6 +1081,13 @@ def test_wait_for_state_change(connection):
     with pytest.raises(StopIteration):
         next(sequence)
 
+    # Test with zero timeout
+    connection.getInt.side_effect = lambda node: 2
+    connection.get.side_effect = lambda node, **kwargs: {
+        node: {"timestamp": [0], "value": [2]}
+    }
+    tree.demods[0].trigger.wait_for_state_change(2, timeout=0.0)
+
 
 def test_nodetree_iterator(connection):
     tree = NodeTree(connection, "DEV1234")


### PR DESCRIPTION
Now the check is executed at least once, even if the timeout is zero.

Description:


Fixes issue: #

Checklist:

- [x] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
- [x] Add .. versionchanged:: where necessary.
