### PR TITLE
Extend device interface autodetection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.6.4
 * Function `wait_for_state_change` now works with zero timeout; the node value is always checked at least once.
+* Improved the stability of device interface auto-detection when it is not supplied while connecting to a device.
 
 ## Version 0.6.3
 * Adapt `write_integration_weights` function in the readout module to be callable within transactions.

--- a/src/zhinst/toolkit/session.py
+++ b/src/zhinst/toolkit/session.py
@@ -781,11 +781,12 @@ class Session(Node):
                     dev_info = json.loads(self.daq_server.getString("/zi/devices"))[
                         serial.upper()
                     ]
-                    interface = dev_info["INTERFACE"]
-                    if interface == "none":
+                    interface = t.cast(str, dev_info["INTERFACE"])
+                    undefined_interfaces = ("none", "", "unknown")
+                    if interface.lower() in undefined_interfaces:
                         interface = (
                             "1GbE"
-                            if "1GbE" in dev_info["INTERFACES"]
+                            if "1gbe" in dev_info["INTERFACES"].lower()
                             else dev_info["INTERFACES"].split(",")[0]
                         )
             self._daq_server.connectDevice(serial, interface)

--- a/tests/test_data_server_session.py
+++ b/tests/test_data_server_session.py
@@ -172,21 +172,23 @@ def test_connect_device_autodetection(
     connected_devices = ""
     selected_interface = ""
 
-    zi_devices = json.loads(zi_devices_json)
-    zi_devices["DEV1234"]["INTERFACE"] = "none"
-    zi_devices_json = json.dumps(zi_devices)
+    for none_interface in ("none", "", "unknown"):
+        zi_devices = json.loads(zi_devices_json)
+        zi_devices["DEV1234"]["INTERFACE"] = none_interface
+        zi_devices_json = json.dumps(zi_devices)
 
-    session.connect_device("dev1234")
-    assert selected_interface == "1GbE"
+        session.connect_device("dev1234")
+        assert selected_interface == "1GbE"
     connected_devices = ""
     selected_interface = ""
 
-    zi_devices = json.loads(zi_devices_json)
-    zi_devices["DEV1234"]["INTERFACES"] = "1GbE,USB"
-    zi_devices_json = json.dumps(zi_devices)
+    for gbe_interface in ("1GBE", "1GbE"):
+        zi_devices = json.loads(zi_devices_json)
+        zi_devices["DEV1234"]["INTERFACES"] = f"{gbe_interface},USB"
+        zi_devices_json = json.dumps(zi_devices)
 
-    session.connect_device("dev1234")
-    assert selected_interface == "1GbE"
+        session.connect_device("dev1234")
+        assert selected_interface == "1GbE"
     connected_devices = ""
     selected_interface = ""
 


### PR DESCRIPTION
Description:

Extend device interface autodetection from `"none"` to `"", "none", "unknown".

Fixes issue: #

Checklist:

- [x] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
