### PR TITLE
Update doc requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,4 @@ jupytext==1.13.7
 ipython
 requests
 sphinxcontrib-spelling
+lxml[html_clean]


### PR DESCRIPTION
Description:

* `lxml[html_clean]` is now a separate package

Failing CI workflow: https://github.com/zhinst/zhinst-toolkit/actions/runs/8736609866/job/23971816939?pr=277



Fixes issue: #

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [ ] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
