### PR TITLE
Adapt scope example to address the change in scope module averager

### DIFF
--- a/examples/scope_module.md
+++ b/examples/scope_module.md
@@ -98,7 +98,6 @@ MIN_NUMBER_OF_RECORDS = 20
 
 scope_module = session.modules.scope
 scope_module.mode(1)
-scope_module.averager.weight(1)
 scope_module.historylength(MIN_NUMBER_OF_RECORDS)
 scope_module.fft.window(0)
 ```


### PR DESCRIPTION
Description:
Removed the setting of averaging weight as it is no longer necessary for LabOne 24.07 and later. The consequence for LabOne 24.04 and before is that the user will see averaged results with an averaging weight of 10.

Fixes issue: #

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [ ] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
