### PR TITLE
Update shfqc_propagation_delay.md

### DIFF
--- a/examples/shfqc_propagation_delay.md
+++ b/examples/shfqc_propagation_delay.md
@@ -34,7 +34,7 @@ device = session.connect_device("DEVXXXX")
 ### Parameter
 
 ```python
-qachannel_center_frequency = 4.1e9
+qachannel_center_frequency = 4.0e9
 qachannel_power_in = 5
 qachannel_power_out = 0
 


### PR DESCRIPTION
changed qachannel_center_frequency from 4.1e9 to 4.0e9

Description:


Fixes issue: #

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [ ] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
