### PR TITLE
Add support for allow_version_mismatch (L1-2516)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # zhinst-toolkit Changelog
 
+## Version 0.7.1
+* Added support for the `allow_version_mismatch` in the `Session` constructor. When set to False, an exception will be raised when attempting to connect to a data-server on a different version than that of the zhinst.core library.
+
 ## Version 0.7.0
 * Add QHub driver
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # zhinst-toolkit Changelog
 
-## Version 0.7.1
-* Added support for the `allow_version_mismatch` in the `Session` constructor. When set to False, an exception will be raised when attempting to connect to a data-server on a different version than that of the zhinst.core library.
+## Version 0.8.0
+* The constructor of `Session` fails when attempting to connect to a data-server on a different LabOne version. This behavior can be overridden by setting the newly added allow_version_mismatch keyword argument to True. When allow_version_mismatch=True is passed to the `Session` constructor the connection to the data-server succeeds even if the version doesn't match.
 
 ## Version 0.7.0
 * Add QHub driver

--- a/src/zhinst/toolkit/driver/modules/shfqa_sweeper.py
+++ b/src/zhinst/toolkit/driver/modules/shfqa_sweeper.py
@@ -10,7 +10,6 @@ from enum import IntEnum
 from pathlib import Path
 
 import numpy as np
-from zhinst.core import ziDAQServer
 from zhinst.utils.shf_sweeper import AvgConfig, EnvelopeConfig, RfConfig
 from zhinst.utils.shf_sweeper import ShfSweeper as CoreSweeper
 from zhinst.utils.shf_sweeper import SweepConfig, TriggerConfig
@@ -71,11 +70,7 @@ class SHFQASweeper(Node):
             "force_sw_trigger": "sw_trigger_mode",
         }
         super().__init__(self._create_nodetree(), tuple())
-        self._daq_server = ziDAQServer(
-            session.daq_server.host,
-            session.daq_server.port,
-            6,
-        )
+        self._daq_server = session.clone_underlying_session()
         self._raw_module = CoreSweeper(self._daq_server, "")
         self._session = session
         self.root.update_nodes(

--- a/src/zhinst/toolkit/session.py
+++ b/src/zhinst/toolkit/session.py
@@ -655,11 +655,12 @@ class Session(Node):
         connection: Existing DAQ server object. If specified the session will
             not create a new session to the data server but reuse the passed
             one. (default = None)
-        allow_version_mismatch: When set to False, an exception will be raised
-            when attempting to connect to a data-server on a different version
-            than that of the zhinst.core library. (default = True)
+        allow_version_mismatch: if set to True, the connection to the data-server
+            will succeed even if the data-server is on a different version of LabOne.
+            If False, an exception will be raised if the data-server is on a
+            different version. (default = False)
 
-    .. versionchanged:: 0.7.1
+    .. versionchanged:: 0.8.0
         Added `allow_version_mismatch` argument.
     """
 
@@ -670,7 +671,7 @@ class Session(Node):
         *,
         hf2: t.Optional[bool] = None,
         connection: t.Optional[core.ziDAQServer] = None,
-        allow_version_mismatch: bool = True,
+        allow_version_mismatch: bool = False,
     ):
         self._is_hf2_server = bool(hf2)
         if connection is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,6 @@ def hf2_session(mock_connection):
 
 @pytest.fixture()
 def shfqa(data_dir, mock_connection, session):
-
     json_path = data_dir / "nodedoc_dev1234_shfqa.json"
     with json_path.open("r", encoding="UTF-8") as file:
         nodes_json = file.read()
@@ -62,7 +61,6 @@ def shfqa(data_dir, mock_connection, session):
 
 @pytest.fixture()
 def shfsg(data_dir, mock_connection, session):
-
     json_path = data_dir / "nodedoc_dev1234_shfsg.json"
     with json_path.open("r", encoding="UTF-8") as file:
         nodes_json = file.read()
@@ -74,7 +72,6 @@ def shfsg(data_dir, mock_connection, session):
 
 @pytest.fixture()
 def shfqc(data_dir, mock_connection, session):
-
     json_path = data_dir / "nodedoc_dev1234_shfqc.json"
     with json_path.open("r", encoding="UTF-8") as file:
         nodes_json = file.read()
@@ -96,11 +93,3 @@ def nodedoc_dev1234_json(data_dir):
     json_path = data_dir / "nodedoc_dev1234.json"
     with json_path.open("r", encoding="UTF-8") as file:
         return file.read()
-
-
-@pytest.fixture()
-def mock_sweeper_daq():
-    with patch(
-        "zhinst.toolkit.driver.modules.shfqa_sweeper.ziDAQServer", autospec=True
-    ) as connection:
-        yield connection

--- a/tests/test_data_server_session.py
+++ b/tests/test_data_server_session.py
@@ -10,7 +10,7 @@ from zhinst.toolkit.nodetree import Node
 
 def test_setup(mock_connection, session):
     mock_connection.assert_called_once_with(
-        "localhost", 8004, 6, allow_version_mismatch=True
+        "localhost", 8004, 6, allow_version_mismatch=False
     )
     mock_connection.return_value.listNodesJSON.assert_called_once_with("/zi/*")
     assert repr(session) == "DataServerSession(localhost:8004)"
@@ -21,7 +21,7 @@ def test_setup(mock_connection, session):
 
 def test_setup_hf2(mock_connection, hf2_session):
     mock_connection.assert_called_once_with(
-        "localhost", 8005, 1, allow_version_mismatch=True
+        "localhost", 8005, 1, allow_version_mismatch=False
     )
     mock_connection.return_value.listNodesJSON.assert_not_called()
     assert repr(hf2_session) == "HF2DataServerSession(localhost:8005)"
@@ -39,7 +39,7 @@ def test_allow_mismatch_not_supported(mock_connection, nodedoc_zi_json):
 
     mock_connection.side_effect = create_daq
     Session("localhost", 8004)
-    mock_connection.assert_any_call("localhost", 8004, 6, allow_version_mismatch=True)
+    mock_connection.assert_any_call("localhost", 8004, 6, allow_version_mismatch=False)
     mock_connection.assert_called_with("localhost", 8004, 6)
 
 
@@ -70,7 +70,7 @@ def test_allow_mismatch_default(mock_connection, nodedoc_zi_json):
     mock_connection.side_effect = create_daq
     Session("localhost", 8004)
     mock_connection.assert_called_once_with(
-        "localhost", 8004, 6, allow_version_mismatch=True
+        "localhost", 8004, 6, allow_version_mismatch=False
     )
 
 


### PR DESCRIPTION
Expose the flag so that once it's changed to False by default, it can be overridden.

Description:


Fixes issue: #

Checklist:

- [x] Add tests for the change to show correct behavior.
- [x] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
- [x] Add .. versionchanged:: where necessary.
