### PR TITLE
Fix version in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # zhinst-toolkit Changelog
 
-## Version 0.8.0
+## Version 0.7.1
 * The constructor of `Session` fails when attempting to connect to a data-server on a different LabOne version. This behavior can be overridden by setting the newly added allow_version_mismatch keyword argument to True. When allow_version_mismatch=True is passed to the `Session` constructor the connection to the data-server succeeds even if the version doesn't match.
 
 ## Version 0.7.0


### PR DESCRIPTION
Description:

The changelog mentions that the allow_version_mismatch is added in version 0.8.0, when actually it has been added in version 0.7.1.

Fixes issue: #291 

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [ ] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
