### PR TITLE
Announce zhinst-toolkit 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 Despite the major version bump, **this new version does not introduce any breaking change** with respect to 0.7. The interface is the same.
 
 Even if we haven't changed the public interface, there are some differences you should be aware of:
-
-* `zhinst-toolkit` 1.0 requires `zhinst-core` 25.04.
+* The minimum required version of zhinst.core is bumped from 23.06 to 25.04.
 * Set operations always block until the value has been set on the device, regardless of the value of the `deep` flag. The `deep` flag is still available and can be useful if you want to get back the node value after the setting has been applied.
 
 ## Version 0.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # zhinst-toolkit Changelog
 
+## Version 1.0
+`zhinst-toolkit` has been stable since version 0.3 and we intend to keep that stability going forward. This is way we have decided to promote the library to version 1.0. 
+
+Despite the major version bump, **this new version does not introduce any breaking change** with respect to 0.7. The interface is the same.
+
+Even if we haven't changed the public interface, there are some differences you should be aware of:
+
+* `zhinst-toolkit` 1.0 requires `zhinst-core` 25.04.
+* Set operations always block until the value has been set on the device, regardless of the value of the `deep` flag. The `deep` flag is still available and can be useful if you want to get back the node value after the setting has been applied.
+
 ## Version 0.7.1
 * The constructor of `Session` fails when attempting to connect to a data-server on a different LabOne version. This behavior can be overridden by setting the newly added allow_version_mismatch keyword argument to True. When allow_version_mismatch=True is passed to the `Session` constructor the connection to the data-server succeeds even if the version doesn't match.
 

--- a/examples/nodetree.md
+++ b/examples/nodetree.md
@@ -107,31 +107,36 @@ The call operator support the following Flags:
 
 ### deep
 
-Flag if the set operation should be blocking until the data has been processed by the
-device, respectively if the get operation should return the value from the device or
-the cached value on the data server (if there is any). This flag is reset by
-default because the operation can take significantly longer.
-
-In addition to the value, a deep get operation will return the timestamp from the device
-(The timestamp can be None, e.g. deep gets on LabOne modules).
-
+The deep flag changes the return value of get/set operations and is `False` by default.
+- A set operation with `deep=False` returns `None`.
+```python
+device.demods[0].rate(1000)
+```
+- A set operation with `deep=True` returns the value of the node after the setting has been applied. This may differ from the input value, e.g. due to rounding or clamping.
+```python
+device.demods[0].rate(1000, deep=True)
+```
+- A get operation with `deep=False` simply returns the node value.
+```python
+device.demods[0].freq()
+```
+- A get operation with `deep=True` returns a (timestamp, value) tuple. The timestamp can be `None`, e.g. when using deep gets on LabOne modules.
 ```python
 device.demods[0].freq(deep=True)
 ```
 
-For a deep set the call operator will return the value acknowledged
-by the device. e.g. important for floating point values with a
-limited resolution.
+> Note:
+>
+> Up until version 0.7, a set with `deep=False` would return before the value was
+> actually set on the device. Since version 1.0, this is not the case anymore.
+> A set will always return only once the value has actually been set on the device,
+> regardless of the deep flag.
 
 > Warning:
 >
 > Does not work for wildcard nodes or non leaf nodes since they represent multiple
 > nodes that are set in a transactional set which does not report the acknowledged
 > values.
-
-```python
-device.demods[0].rate(1000, deep=True)
-```
 
 ### enum
 
@@ -179,8 +184,7 @@ device.demods[0].enable(parse= False)
 
 ## Transactions
 
-Setting up an experiment normal requires setting a couple of nodes to the correct
-value. Since every call operation triggers an individual message to the data
+Setting up an experiment normally requires setting multiple nodes. Since every call operation triggers an individual message to the data
 server, this can take a noticeable amount of time. To avoid this LabOne® offers
 an API functionality called transactional set. This functionality enables the user
 to bundle multiple set commands into a single command/message. In zhinst.toolkit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   "numpy>=1.13",
-  "zhinst-core>=23.06",
+  "zhinst-core>=25.04",
   "zhinst-utils>=0.4.0",
   "jsonschema>=3.2.0",
   "jsonref>=0.2",
@@ -180,4 +180,3 @@ disable_error_code = [
   "union-attr",
   "index",
 ]
-

--- a/src/zhinst/toolkit/session.py
+++ b/src/zhinst/toolkit/session.py
@@ -852,7 +852,7 @@ class Session(Node):
                     dev_info = json.loads(self.daq_server.getString("/zi/devices"))[
                         serial.upper()
                     ]
-                    interface = t.cast(str, dev_info["INTERFACE"])
+                    interface = t.cast("str", dev_info["INTERFACE"])
                     undefined_interfaces = ("none", "", "unknown")
                     if interface.lower() in undefined_interfaces:
                         interface = (


### PR DESCRIPTION
Description:
`zhinst-toolkit` has been stable since version 0.3 and we intend to keep that stability going forward. This is way we have decided to promote the library to version 1.0. 

Despite the major version bump, **this new version does not introduce any breaking change** with respect to 0.7. The interface is the same.

Even if we haven't changed the public interface, there are some differences you should be aware of:
* The minimum required version of zhinst.core is bumped from 23.06 to 25.04.
* Set operations always block until the value has been set on the device, regardless of the value of the `deep` flag. The `deep` flag is still available and can be useful if you want to get back the node value after the setting has been applied.

This PR also changes the documentation to better reflect the actual behavior of the `deep` flag.

Fixes issue: #

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [ ] Update CHANGELOG.rst with relevant information and add the issue number.
- [ ] Add .. versionchanged:: where necessary.
