### PR TITLE
Fix required LabOne version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The zhinst-toolkit is well tested and considered stable enough for general usage
 The interfaces may have some incompatible changes between releases.
 Please check the changelog if you are upgrading.
 ## LabOne software
-As prerequisite, the LabOne software version 22.02 or later must be installed.
+As prerequisite, the LabOne software version 25.04 or later must be installed.
 It can be downloaded for free at
 [https://www.zhinst.com/labone](https://www.zhinst.com/labone). Follow the
 installation instructions specific to your platform. Verify that you can


### PR DESCRIPTION
Since version 1.0 of toolkit, LabOne 25.04 is recommended.

Description:


Fixes issue: #

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [ ] Update CHANGELOG.rst with relevant information and add the issue number.
