### PR TITLE
Update lint settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 dependencies = [
   "black>=24.8.0",
   "mypy>=1.11.2",
-  "ruff>=0.6.4",
+  "ruff>=0.11",
   "numpy>=1.20",
   "zhinst-comms~=3.0",
 ]
@@ -128,6 +128,8 @@ ignore = [
   "FBT003",
   # TODO fix
   "B005",
+  # TODO fix: checks for use of typing.Optional
+  "UP045",
   "ANN001",
   "UP007",
   "ISC003",


### PR DESCRIPTION
Description:

This MR ignores the newly enforced `UP045` `ruff` rule to fail for the use of `Optional[T]`.

Fixes issue: #

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [ ] Update CHANGELOG.rst with relevant information and add the issue number.
