### PR TITLE
Enable support for Python 3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # zhinst-toolkit Changelog
 
+## Version 1.1.2
+* Update to Python 3.14
+
 ## Version 1.1.1
 * Use device base-type for instrument model lookup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
@@ -51,7 +52,7 @@ packages = ["src/zhinst"]
 only-include = ["src/zhinst/toolkit"]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [tool.hatch.envs.test]
 dependencies = ["coverage[toml]>=6.5", "hypothesis", "pytest", "pytest-asyncio"]
@@ -77,7 +78,7 @@ build = ["mkdocs-zhinst build"]
 serve = ["mkdocs-zhinst serve"]
 
 [[tool.hatch.envs.lint.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [tool.hatch.envs.lint]
 dependencies = [


### PR DESCRIPTION
Description:
Update pyproject.toml to enable support for Python 3.14

Fixes issue: #308

Checklist:

- [ ] Add tests for the change to show correct behavior.
- [ ] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
