### PR TITLE
Guard against a possibly empty node returned by the DAQ module read() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # zhinst-toolkit Changelog
 
+## Version 1.3.2
+* Guard against accessing a possibly empty node returned by the DAQ Module read() method
+
 ## Version 1.3.1
 * Expose finish and finished methods for the Sweeper and PIDAdvisor modules
 

--- a/src/zhinst/toolkit/driver/modules/daq_module.py
+++ b/src/zhinst/toolkit/driver/modules/daq_module.py
@@ -109,7 +109,7 @@ class DAQModule(BaseModule):
         Returns:
                 Processed and formatted node data.
         """
-        if isinstance(data[0], dict):
+        if data and isinstance(data[0], dict):
             return [DAQModule._process_burst(node, burst, clk_rate) for burst in data]
         return data
 

--- a/tests/test_daq_module.py
+++ b/tests/test_daq_module.py
@@ -144,6 +144,14 @@ def test_read(daq_module, mock_connection, session):
     assert result1[0].shape == (1, 5)
 
 
+def test_read_empty_node(daq_module, mock_connection, session):
+    module_mock = mock_connection.return_value.dataAcquisitionModule.return_value
+    empty_node = {"/dev1234/demods/0/sample.r": []}
+    module_mock.read.return_value = empty_node
+    result = daq_module.read()
+    assert result == empty_node
+
+
 def test_subscribe(daq_module, mock_connection):
     module_mock = mock_connection.return_value.dataAcquisitionModule.return_value
     daq_module.subscribe(daq_module.test.sample.x.avg)


### PR DESCRIPTION
Description:
Due to its asynchronous nature, the DAQ module can return empty nodes when calling the read() method. This pull request guards against accessing such empty nodes.

Fixes issue: #

Checklist:

- [x] Add tests for the change to show correct behavior.
- [x] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
