### PR TITLE
Add missing methods for the creating Timeline Module in session.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 1.4.0
 * Add support for Timeline Module
+* Add missing unit test for creation of Data Streaming Module
 
 ## Version 1.3.2
 * Guard against accessing a possibly empty node returned by the DAQ Module read() method

--- a/src/zhinst/toolkit/session.py
+++ b/src/zhinst/toolkit/session.py
@@ -256,7 +256,7 @@ class ModuleHandler:
         zhinst.core Module can be accessed through the `raw_module`
         property.
 
-        The new instance establishes a new session to the DataServer.
+        The new instance establishes a new session with the DataServer.
         New instances should therefore be created carefully since they consume
         resources.
 
@@ -278,7 +278,7 @@ class ModuleHandler:
         zhinst.core Module can be accessed through the `raw_module`
         property.
 
-        The new instance establishes a new session to the DataServer.
+        The new instance establishes a new session with the DataServer.
         New instances should therefore be created carefully since they consume
         resources.
 
@@ -300,7 +300,7 @@ class ModuleHandler:
         zhinst.core Module can be accessed through the `raw_module`
         property.
 
-        The new instance establishes a new session to the DataServer.
+        The new instance establishes a new session with the DataServer.
         New instances should therefore be created carefully since they consume
         resources.
 
@@ -322,7 +322,7 @@ class ModuleHandler:
         zhinst.core Module can be accessed through the `raw_module`
         property.
 
-        The new instance establishes a new session to the DataServer.
+        The new instance establishes a new session with the DataServer.
         New instances should therefore be created carefully since they consume
         resources.
 
@@ -344,7 +344,7 @@ class ModuleHandler:
         zhinst.core Module can be accessed through the `raw_module`
         property.
 
-        The new instance establishes a new session to the DataServer.
+        The new instance establishes a new session with the DataServer.
         New instances should therefore be created carefully since they consume
         resources.
 
@@ -366,7 +366,7 @@ class ModuleHandler:
         zhinst.core Module can be accessed through the `raw_module`
         property.
 
-        The new instance establishes a new session to the DataServer.
+        The new instance establishes a new session with the DataServer.
         New instances should therefore be created carefully since they consume
         resources.
 
@@ -388,7 +388,7 @@ class ModuleHandler:
         zhinst.core Module can be accessed through the `raw_module`
         property.
 
-        The new instance establishes a new session to the DataServer.
+        The new instance establishes a new session with the DataServer.
         New instances should therefore be created carefully since they consume
         resources.
 
@@ -411,7 +411,7 @@ class ModuleHandler:
         In contrast to core.ziDAQServer.precompensationAdvisor() a nodetree property
         is added.
 
-        The new instance establishes a new session to the DataServer.
+        The new instance establishes a new session with the DataServer.
         New instances should therefore be created carefully since they consume
         resources.
 
@@ -433,7 +433,7 @@ class ModuleHandler:
         zhinst.core Module can be accessed through the `raw_module`
         property.
 
-        The new instance establishes a new session to the DataServer.
+        The new instance establishes a new session with the DataServer.
         New instances should therefore be created carefully since they consume
         resources.
 
@@ -455,7 +455,7 @@ class ModuleHandler:
         zhinst.core Module can be accessed through the `raw_module`
         property.
 
-        The new instance establishes a new session to the DataServer.
+        The new instance establishes a new session with the DataServer.
         New instances should therefore be created carefully since they consume
         resources.
 
@@ -477,7 +477,7 @@ class ModuleHandler:
         zhinst.core Module can be accessed through the `raw_module`
         property.
 
-        The new instance establishes a new session to the DataServer.
+        The new instance establishes a new session with the DataServer.
         New instances should therefore be created carefully since they consume
         resources.
 
@@ -509,6 +509,28 @@ class ModuleHandler:
             Created object
         """
         return tk_modules.SHFQASweeper(self._session)
+
+    def create_timeline_module(self) -> tk_modules.TimelineModule:
+        """Create an instance of the TimelineModule.
+
+        The resulting Module will have the nodetree accessible. The underlying
+        zhinst.core Module can be accessed through the `raw_module`
+        property.
+
+        The new instance establishes a new session with the DataServer.
+        New instances should therefore be created carefully since they consume
+        resources.
+
+        The new module is not managed by toolkit. A managed instance is provided
+        by the property `timeline`.
+
+        Returns:
+            Created module
+        """
+        return tk_modules.TimelineModule(
+            self._session.daq_server.timelineModule(),
+            self._session,
+        )
 
     @cached_property
     def awg(self) -> tk_modules.BaseModule:
@@ -683,6 +705,21 @@ class ModuleHandler:
             Managed instance of the shfqa sweeper implementation
         """
         return self.create_shfqa_sweeper()
+
+    @cached_property
+    def timeline(self) -> tk_modules.timelineModule:
+        """Managed instance of the Timeline module.
+
+        Managed means that only one instance is created
+        and is held inside the connection Manager. This makes it easier to access
+        the modules from within toolkit, since creating a module requires
+        resources. (``use create_timeline_module`` to create an unmanaged
+        instance)
+
+        Returns:
+            Managed instance of the timeline module
+        """
+        return self.create_timeline_module()
 
 
 class PollFlags(IntFlag):

--- a/tests/data/nodedoc_data_streaming_test.json
+++ b/tests/data/nodedoc_data_streaming_test.json
@@ -1,0 +1,72 @@
+{
+    "/duration": {
+        "Node": "/duration",
+        "Description": "The recording length of the data to be captured. A value of zero means endless capture, in which case the module has to be stopped by calling the finish() method. The value may be adjusted upwards by the module to match its internal sampling grid.",
+        "Properties": "Read, Write",
+        "Unit": "Seconds",
+        "Type": "Double"
+    },
+    "/save/csvlocale": {
+        "Node": "/save/csvlocale",
+        "Description": "The locale to use for the decimal point character and digit grouping character for numerical values in CSV files: \"C\": Dot for the decimal point and no digit grouping (default); \"\" (empty string): Use the symbols set in the language and region settings of the computer.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "String"
+    },
+    "/save/csvseparator": {
+        "Node": "/save/csvseparator",
+        "Description": "The character to use as CSV separator when saving files in this format.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "String"
+    },
+    "/save/directory": {
+        "Node": "/save/directory",
+        "Description": "The base directory where files are saved.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "String"
+    },
+    "/save/fileformat": {
+        "Node": "/save/fileformat",
+        "Description": "The format of the file for saving data.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "Integer (enumerated)",
+        "Options": {
+            "0": "\"mat\": MATLAB",
+            "1": "\"csv\": CSV",
+            "2": "\"zview\": ZView (Impedance data only)",
+            "3": "\"sxm\": SXM (Image format)",
+            "4": "\"hdf5\": HDF5"
+        }
+    },
+    "/save/filename": {
+        "Node": "/save/filename",
+        "Description": "Defines the sub-directory where files are saved. The actual sub-directory has this name with a sequence count (per save) appended, e.g. daq_000.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "String"
+    },
+    "/save/save": {
+        "Node": "/save/save",
+        "Description": "Initiate the saving of data to file. The saving is done in the background. When the save has finished, the module resets this parameter to 0.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "Integer (64 bit)"
+    },
+    "/save/saveonly": {
+        "Node": "/save/saveonly",
+        "Description": "Set to 1 to enable automatic saving of the streaming data to file, in the selected file format (HDF5, CSV or MATLAB), without the need to call the read command. When enabled, the read command has no effect.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "Integer (64 bit)"
+    },
+    "/save/saveonread": {
+        "Node": "/save/saveonread",
+        "Description": "Automatically save the data to file immediately before reading out the data from the module using the read() command. Set this parameter to 1 if you want to save data to file when running the module continuously and performing intermediate reads.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "Integer (64 bit)"
+    }
+}

--- a/tests/data/nodedoc_timeline_test.json
+++ b/tests/data/nodedoc_timeline_test.json
@@ -1,0 +1,128 @@
+{
+    "/clearhistory": {
+        "Node": "/clearhistory",
+        "Description": "[empty]",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "Integer (64 bit)"
+    },
+    "/daq/fft/absolute": {
+        "Node": "/daq/fft/absolute",
+        "Description": "[empty]",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "Integer (64 bit)"
+    },
+    "/daq/fft/powercompensation": {
+        "Node": "/daq/fft/powercompensation",
+        "Description": "[empty]",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "Integer (64 bit)"
+    },
+    "/daq/fft/window": {
+        "Node": "/daq/fft/window",
+        "Description": "[empty]",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "Integer (64 bit)"
+    },
+    "/device": {
+        "Node": "/device",
+        "Description": "[empty]",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "String"
+    },
+    "/errortext": {
+        "Node": "/errortext",
+        "Description": "[empty]",
+        "Properties": "Read",
+        "Unit": "None",
+        "Type": "String"
+    },
+    "/historylength": {
+        "Node": "/historylength",
+        "Description": "[empty]",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "Integer (64 bit)"
+    },
+    "/mode": {
+        "Node": "/mode",
+        "Description": "[empty]",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "Integer (64 bit)"
+    },
+    "/save/csvlocale": {
+        "Node": "/save/csvlocale",
+        "Description": "The locale to use for the decimal point character and digit grouping character for numerical values in CSV files: \"C\": Dot for the decimal point and no digit grouping (default); \"\" (empty string): Use the symbols set in the language and region settings of the computer.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "String"
+    },
+    "/save/csvseparator": {
+        "Node": "/save/csvseparator",
+        "Description": "The character to use as CSV separator when saving files in this format.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "String"
+    },
+    "/save/directory": {
+        "Node": "/save/directory",
+        "Description": "The base directory where files are saved.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "String"
+    },
+    "/save/fileformat": {
+        "Node": "/save/fileformat",
+        "Description": "The format of the file for saving data.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "Integer (enumerated)",
+        "Options": {
+            "0": "\"mat\": MATLAB",
+            "1": "\"csv\": CSV",
+            "2": "\"zview\": ZView (Impedance data only)",
+            "3": "\"sxm\": SXM (Image format)",
+            "4": "\"hdf5\": HDF5"
+        }
+    },
+    "/save/filename": {
+        "Node": "/save/filename",
+        "Description": "Defines the sub-directory where files are saved. The actual sub-directory has this name with a sequence count (per save) appended, e.g. daq_000.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "String"
+    },
+    "/save/save": {
+        "Node": "/save/save",
+        "Description": "Initiate the saving of data to file. The saving is done in the background. When the save has finished, the module resets this parameter to 0.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "Integer (64 bit)"
+    },
+    "/save/saveonread": {
+        "Node": "/save/saveonread",
+        "Description": "Automatically save the data to file immediately before reading out the data from the module using the read() command. Set this parameter to 1 if you want to save data to file when running the module continuously and performing intermediate reads.",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "Integer (64 bit)"
+    },
+    "/sequence/sourcestring": {
+        "Node": "/sequence/sourcestring",
+        "Description": "[empty]",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "String"
+    },
+    "/throwonerror": {
+        "Node": "/throwonerror",
+        "Description": "[empty]",
+        "Properties": "Read, Write",
+        "Unit": "None",
+        "Type": "Integer (64 bit)"
+    }
+}

--- a/tests/test_data_server_session.py
+++ b/tests/test_data_server_session.py
@@ -548,6 +548,34 @@ def test_shfqa_sweeper(session):
     assert isinstance(sweeper, tk_modules.SHFQASweeper)
 
 
+def test_data_streaming_module(data_dir, mock_connection, session):
+    json_path = data_dir / "nodedoc_data_streaming_test.json"
+    with json_path.open("r", encoding="UTF-8") as file:
+        nodes_json = file.read()
+    mock_connection.return_value.dataStreamingModule.return_value.listNodesJSON.return_value = (
+        nodes_json
+    )
+    data_streaming_module = session.modules.data_streaming
+    assert data_streaming_module == session.modules.data_streaming
+    mock_connection.return_value.dataStreamingModule.assert_called_once()
+    assert isinstance(data_streaming_module, tk_modules.DataStreamingModule)
+    assert isinstance(data_streaming_module.device, Node)
+
+
+def test_timeline_module(data_dir, mock_connection, session):
+    json_path = data_dir / "nodedoc_timeline_test.json"
+    with json_path.open("r", encoding="UTF-8") as file:
+        nodes_json = file.read()
+    mock_connection.return_value.timelineModule.return_value.listNodesJSON.return_value = (
+        nodes_json
+    )
+    timeline_module = session.modules.timeline
+    assert timeline_module == session.modules.timeline
+    mock_connection.return_value.timelineModule.assert_called_once()
+    assert isinstance(timeline_module, tk_modules.TimelineModule)
+    assert isinstance(timeline_module.device, Node)
+
+
 def test_session_wide_transaction(
     mock_connection,
     nodedoc_dev1234_json,


### PR DESCRIPTION
Description:
The methods for creating the Timeline module were missing from session.py. This pull request fixes that.
Also added unit tests for creating the Data Streaming Module.


Fixes issue: #

Checklist:

- [x] Add tests for the change to show correct behavior.
- [x] Add or update relevant docs, code and examples.
- [x] Update CHANGELOG.rst with relevant information and add the issue number.
