### PR TITLE
Fix stale docs.zhinst.com/zhinst-toolkit links and drop dead doc-build instructions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -7,8 +7,8 @@ Ways to contribute
 * By contributing code; bug fixes, new features and so on.
 
 .. _Issues: https://github.com/zhinst/zhinst-toolkit/issues
-.. _documentation: https://docs.zhinst.com/zhinst-toolkit/en/latest/
-.. _examples: https://docs.zhinst.com/zhinst-toolkit/en/latest/examples/index.html
+.. _documentation: https://docs.zhinst.com/labone_api_user_manual/reference/toolkit/
+.. _examples: https://github.com/zhinst/zhinst-toolkit/tree/main/examples
 
 Code contributions
 ==================
@@ -98,38 +98,16 @@ The examples are stored as Markdown files. If you wish to turn the local
 
     .. code-block:: sh
 
-        $ python scripts/generate_notebooks.py local
+        $ python scripts/generate_notebooks.py
 
 Building the documentation
 --------------------------
 
-Zhinst-toolkit uses `Sphinx <https://pypi.org/project/Sphinx/>`_ to build the package documentation.
+zhinst-toolkit no longer builds its own documentation here; the API
+reference is now part of the `LabOne API User Manual`_, built from the
+``labone/labone`` repository.
 
-- Install the package in editable mode
-
-    .. code-block:: sh
-
-        $ pip install -e .
-
-Change to docs directory
-
-    .. code-block:: sh
-
-        $ cd docs
-
-- Install the docs dependencies
-
-    .. code-block:: sh
-
-        $ pip install -r docs/requirements.txt
-
-- Build the HTML documentation along with examples with Sphinx
-
-    .. code-block:: sh
-
-        $ make html [local | remote]
-
-The generated documentation can be seen in your browser by opening `docs/html/index.html`.
+.. _LabOne API User Manual: https://docs.zhinst.com/labone_api_user_manual/reference/toolkit/
 
 Pull requests
 --------------

--- a/scripts/generate_notebooks.py
+++ b/scripts/generate_notebooks.py
@@ -1,48 +1,11 @@
-"""A script to generate Notebooks for documentation."""
+"""A script to sync the example Notebooks with their Markdown sources."""
 
-import argparse
-import fnmatch
-import os
 import typing as t
 from pathlib import Path
 
-import requests
 from jupytext import cli as jupytext_cli
 
-BASE_EXAMPLE_URL = "https://docs.zhinst.com/zhinst-toolkit/notebooks/"
 EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
-EXAMPLES_ONLY_SYNC = ["nodetree.md"]
-EXCLUDED_FILES = ["README.md"]
-
-
-def download_example_file(filename: str) -> bytes:
-    """Download example file.
-
-    Args:
-        filename: notebook filename.
-
-    Returns:
-        Notebook contents
-    """
-    url = f"{BASE_EXAMPLE_URL}/{filename}"
-    response = requests.get(url)
-    try:
-        response.raise_for_status()
-    except requests.exceptions.RequestException:
-        return None
-    return response.content
-
-
-def get_notebook_examples() -> None:
-    """Get notebook examples."""
-    for example_file in fnmatch.filter(os.listdir(EXAMPLES_DIR), "*.md"):
-        if example_file in EXAMPLES_ONLY_SYNC or example_file in EXCLUDED_FILES:
-            continue
-        example_file = example_file.replace(".md", ".ipynb")
-        contents = download_example_file(example_file)
-        if contents:
-            with open(f"{EXAMPLES_DIR / example_file}", "wb") as f:
-                f.write(contents)
 
 
 def generate_and_sync_example_notebooks(src: t.List[Path]) -> None:
@@ -55,18 +18,5 @@ def generate_and_sync_example_notebooks(src: t.List[Path]) -> None:
     jupytext_cli.jupytext(["--sync", *str_path])
 
 
-def generate_notebooks(args: argparse.Namespace) -> None:
-    """Generate notebooks either from local or remote.
-
-    Args:
-        args: Namespace arguments
-    """
-    generate_and_sync_example_notebooks([EXAMPLES_DIR / "*.md"])
-    if args.src != "local":
-        get_notebook_examples()
-
-
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Generate Notebooks.")
-    parser.add_argument("src", help="Source of Notebooks", choices=["local", "remote"])
-    generate_notebooks(parser.parse_args())
+    generate_and_sync_example_notebooks([EXAMPLES_DIR / "*.md"])


### PR DESCRIPTION
## Summary
- The Sphinx docs this repo used to build were removed over a year ago (43a337c, "Remove project documentation in favor of api-documentation", Feb 2025) in favor of the mkdocs-zhinst-based LabOne API User Manual at `docs.zhinst.com/labone_api_user_manual/reference/toolkit/`.
- `CONTRIBUTING.rst` still pointed `documentation`/`examples` links at the dead `docs.zhinst.com/zhinst-toolkit/en/latest/` path, and documented a `make html [local | remote]` build against a `docs/Makefile` that no longer exists.
- `scripts/generate_notebooks.py`'s `remote` mode downloaded pre-rendered notebook outputs from `docs.zhinst.com/zhinst-toolkit/notebooks/`, which has been 404ing since the same removal, and isn't called from any CI workflow anymore — dropped the dead code path, kept the still-used local jupytext sync.
- Let me know if we should update the remote location instead of removing the remote logic, but I didn't see a current deployment.

## Test plan
- [x] Ran `python scripts/generate_notebooks.py` (no args now) locally, confirmed it still syncs all `examples/*.md` ↔ `.ipynb` correctly.
- [x] `black --check` / `isort --check-only` pass on the modified script.