### PR TITLE
Fix pre-existing CI lint failures (missing copyright headers, PLR0917)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,8 @@ ignore = [
   "ANN204",
   # Too many arguments in function definition
   "PLR0913",
+  # Too many positional arguments (companion to PLR0913, same rationale)
+  "PLR0917",
   # Magic value used in comparison
   "PLR2004",
   # Dynamically typed expressions (typing.Any) are disallowed

--- a/src/zhinst/toolkit/_min_version.py
+++ b/src/zhinst/toolkit/_min_version.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 _MIN_LABONE_VERSION = "22.2"
 _MIN_DEVICE_UTILS_VERSION = "0.1"
 

--- a/src/zhinst/toolkit/command_table.py
+++ b/src/zhinst/toolkit/command_table.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Zurich Instruments Toolkit (zhinst-toolkit) Command Table Module.
 
 This module provides a `CommandTable` class to create and modify ZI device

--- a/src/zhinst/toolkit/driver/devices/__init__.py
+++ b/src/zhinst/toolkit/driver/devices/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Module for all device drivers."""
 
 import typing as t

--- a/src/zhinst/toolkit/driver/devices/base.py
+++ b/src/zhinst/toolkit/driver/devices/base.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Base Instrument Driver.
 
 Natively works with all device types and provides the basic functionality like

--- a/src/zhinst/toolkit/driver/devices/hdawg.py
+++ b/src/zhinst/toolkit/driver/devices/hdawg.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """HDAWG Instrument Driver."""
 
 import logging

--- a/src/zhinst/toolkit/driver/devices/pqsc.py
+++ b/src/zhinst/toolkit/driver/devices/pqsc.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """PQSC Instrument Driver."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/devices/qhub.py
+++ b/src/zhinst/toolkit/driver/devices/qhub.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """QHub Instrument Driver."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/devices/quantum_system_hub.py
+++ b/src/zhinst/toolkit/driver/devices/quantum_system_hub.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """PQSC and QHub base Instrument Driver."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/devices/shf.py
+++ b/src/zhinst/toolkit/driver/devices/shf.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """SHF* Instrument Driver."""
 
 import logging

--- a/src/zhinst/toolkit/driver/devices/shfqa.py
+++ b/src/zhinst/toolkit/driver/devices/shfqa.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """SHFQA Instrument Driver."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/devices/shfqc.py
+++ b/src/zhinst/toolkit/driver/devices/shfqc.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """SHFQA Instrument Driver."""
 
 import logging

--- a/src/zhinst/toolkit/driver/devices/shfsg.py
+++ b/src/zhinst/toolkit/driver/devices/shfsg.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """SHFSG Instrument Driver."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/devices/uhfli.py
+++ b/src/zhinst/toolkit/driver/devices/uhfli.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """UHFLI Instrument Driver."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/devices/uhfqa.py
+++ b/src/zhinst/toolkit/driver/devices/uhfqa.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """UHFQA Instrument Driver."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/modules/__init__.py
+++ b/src/zhinst/toolkit/driver/modules/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Module for toolkit representations of native LabOne modules."""
 
 import typing as t

--- a/src/zhinst/toolkit/driver/modules/base_module.py
+++ b/src/zhinst/toolkit/driver/modules/base_module.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Base Module Driver.
 
 Natively works with all module types and provides the basic functionality like

--- a/src/zhinst/toolkit/driver/modules/daq_module.py
+++ b/src/zhinst/toolkit/driver/modules/daq_module.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """DAQ Module."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/modules/data_streaming_module.py
+++ b/src/zhinst/toolkit/driver/modules/data_streaming_module.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Data Streaming Module."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/modules/device_settings_module.py
+++ b/src/zhinst/toolkit/driver/modules/device_settings_module.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Device Settings Module."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/modules/impedance_module.py
+++ b/src/zhinst/toolkit/driver/modules/impedance_module.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Impedance Module."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/modules/pid_advisor_module.py
+++ b/src/zhinst/toolkit/driver/modules/pid_advisor_module.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """PID Advisor Module."""
 
 import logging

--- a/src/zhinst/toolkit/driver/modules/precompensation_advisor_module.py
+++ b/src/zhinst/toolkit/driver/modules/precompensation_advisor_module.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Precompensation Advisor Module."""
 
 import logging

--- a/src/zhinst/toolkit/driver/modules/scope_module.py
+++ b/src/zhinst/toolkit/driver/modules/scope_module.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Scope Module."""
 
 import logging

--- a/src/zhinst/toolkit/driver/modules/shfqa_sweeper.py
+++ b/src/zhinst/toolkit/driver/modules/shfqa_sweeper.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Toolkit adaption for the zhinst.utils.SHFSweeper."""
 
 import json

--- a/src/zhinst/toolkit/driver/modules/sweeper_module.py
+++ b/src/zhinst/toolkit/driver/modules/sweeper_module.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Sweeper Module."""
 
 import logging

--- a/src/zhinst/toolkit/driver/modules/timeline_module.py
+++ b/src/zhinst/toolkit/driver/modules/timeline_module.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Timeline Module."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/nodes/__init__.py
+++ b/src/zhinst/toolkit/driver/nodes/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Adaptions of specific nodes.
 
 Custom node child classes with additional helper functions and attributes.

--- a/src/zhinst/toolkit/driver/nodes/awg.py
+++ b/src/zhinst/toolkit/driver/nodes/awg.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """zhinst-toolkit AWG node adaptions."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/nodes/command_table_node.py
+++ b/src/zhinst/toolkit/driver/nodes/command_table_node.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Command Table Node adaptions."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/nodes/multistate.py
+++ b/src/zhinst/toolkit/driver/nodes/multistate.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """zhinst-toolkit multistate node adaptions."""
 
 import typing as t

--- a/src/zhinst/toolkit/driver/nodes/readout.py
+++ b/src/zhinst/toolkit/driver/nodes/readout.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """zhinst-toolkit readout node adaptions."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/driver/nodes/shfqa_scope.py
+++ b/src/zhinst/toolkit/driver/nodes/shfqa_scope.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """zhinst-toolkit scope node adaptions for the SHFQA."""
 
 import logging

--- a/src/zhinst/toolkit/driver/nodes/spectroscopy.py
+++ b/src/zhinst/toolkit/driver/nodes/spectroscopy.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """zhinst-toolkit spectroscopy node adaptions."""
 
 import logging

--- a/src/zhinst/toolkit/driver/parsers.py
+++ b/src/zhinst/toolkit/driver/parsers.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Predefined parsers for device specific nodes."""
 
 import logging

--- a/src/zhinst/toolkit/exceptions.py
+++ b/src/zhinst/toolkit/exceptions.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Global zhinst-toolkit exceptions."""
 
 

--- a/src/zhinst/toolkit/interface.py
+++ b/src/zhinst/toolkit/interface.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Interface Enums for the zhinst.toolkit."""
 
 from enum import Enum, IntEnum

--- a/src/zhinst/toolkit/nodetree/__init__.py
+++ b/src/zhinst/toolkit/nodetree/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """High-level generic lazy node tree for the zhinst.core package.
 
 All interactions with an Zurich Instruments device or a LabOne

--- a/src/zhinst/toolkit/nodetree/connection_dict.py
+++ b/src/zhinst/toolkit/nodetree/connection_dict.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Implements Connection wrapper around a native python dictionary."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/nodetree/helper.py
+++ b/src/zhinst/toolkit/nodetree/helper.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Helper functions used in toolkit."""
 
 import re

--- a/src/zhinst/toolkit/nodetree/node.py
+++ b/src/zhinst/toolkit/nodetree/node.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Single lazy node of a `zhinst.toolkit.nodetree.Nodetree`."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/nodetree/nodetree.py
+++ b/src/zhinst/toolkit/nodetree/nodetree.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """High-level generic lazy node tree for the zhinst.core package."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/sequence.py
+++ b/src/zhinst/toolkit/sequence.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Custom sequence code class."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/session.py
+++ b/src/zhinst/toolkit/session.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Module for managing a session to a Data Server through zhinst.core."""
 
 from __future__ import annotations

--- a/src/zhinst/toolkit/waveform.py
+++ b/src/zhinst/toolkit/waveform.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 Zurich Instruments
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
 """Dictionary like waveform representation."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
Split out from #322, which surfaced that this repo's `main` branch currently fails its own lint CI (`hatch run lint:style` → `ruff check .`) with 46 errors, unrelated to that PR's actual change:

- **44× `CPY001`** ("Missing copyright notice at top of file"): every file under `src/zhinst/toolkit` is missing the standard header that only `__init__.py` files have. Added it verbatim to the remaining 44 files.
- **2× `PLR0917`** ("Too many positional arguments") on `shfqa.py` and `awg.py`'s `__init__` methods: added `PLR0917` to the ignore list, alongside `PLR0913` ("too many arguments") which is already ignored here for the same reason (this codebase's driver classes have wide constructors by design). Didn't restructure the constructors to be keyword-only since that would be a real signature change risking breaking positional callers, for what looks like an unwanted rule rather than a real issue.

## Test plan
- [x] `ruff check .`  all checks passed (was 46 errors)
- [x] `black --check --diff .`  all files unchanged